### PR TITLE
fix doubly escaped filenames in stacktrace breaking JSON body

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,7 +601,7 @@ impl Sentry {
                     let name = symbol.name()
                         .map_or("unresolved symbol".to_string(), |name| name.to_string());
                     let filename = symbol.filename()
-                        .map_or("".to_string(), |sym| format!("{:?}", sym));
+                        .map_or("".to_string(), |sym| sym.to_string_lossy().into_owned());
                     let lineno = symbol.lineno().unwrap_or(0);
                     frames.push(StackFrame {
                         filename: filename,


### PR DESCRIPTION
Fixes #15.

When I turned logging to the trace level, I saw this:

```
Sentry body {"event_id":"","message":"Panic Handler Testing","timestamp":"2017-06-04T16:51:23","level":"fatal","logger":"panic","platform":"other","sdk": {"name":"rust-sentry","version":"0.1.9"},"device": {"name":"","version":"","build":""},"culprit": "src/lib.rs: 829","server_name":"Server Name","release":"release","environment":"test_env","stacktrace":{"frames":[{"filename":"","function":"_pthread_start","lineno":0},{"filename":"","function":"_pthread_body","lineno":0},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/sys_common/thread.rs"","function":"std::sys::imp::thread::{{impl}}::new::thread_start","lineno":21},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/liballoc/boxed.rs"","function":"alloc::boxed::{{impl}}::call_box<(),closure>","lineno":614},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/thread/mod.rs"","function":"std::thread::{{impl}}::spawn::{{closure}}<closure,()>","lineno":357},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/panic.rs"","function":"std::panic::catch_unwind<std::panic::AssertUnwindSafe<closure>,()>","lineno":361},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/panicking.rs"","function":"std::panicking::try<(),std::panic::AssertUnwindSafe<closure>>","lineno":436},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libpanic_unwind/lib.rs"","function":"__rust_maybe_catch_panic","lineno":98},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/panicking.rs"","function":"std::panicking::try::do_call<std::panic::AssertUnwindSafe<closure>,()>","lineno":460},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/panic.rs"","function":"std::panic::{{impl}}::call_once<(),closure>","lineno":296},{"filename":""/Users/hobofan/stuff/sentry-rust/src/lib.rs"","function":"sentry::tests::it_registrer_panic_handler2::{{closure}}","lineno":829},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/panicking.rs"","function":"std::panicking::begin_panic<&str>","lineno":517},{"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/panicking.rs"","function":"std::panicking::rust_panic_with_hook::h979db19ee91d2a53","lineno":556},{"filename":""/Users/hobofan/stuff/sentry-rust/src/lib.rs"","function":"sentry::{{impl}}::register_panic_handler::{{closure}}<closure>","lineno":607},{"filename":""/Users/hobofan/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.2/src/backtrace/mod.rs"","function":"backtrace::backtrace::trace<closure>","lineno":42}]}}
Sentry Response {"error":"Bad data reconstructing object (JSONDecodeError, Expecting ',' delimiter or '}': line 1 column 479 (char 478))"}
```

The relevant part is this one:
`"filename":""/Users/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-mac/build/src/libstd/sys_common/thread.rs""`

This was caused by double escaping the filename. The first time by printing the `Path` via the `Debug` trait, and the second time when building the JSON by hand.

I tried to write a test for it for some time by separating out the building of the stackframe into a separate function, and then trying to parse the serialized event, but didn't manage to win over the borrow checker :(

------

Semi-related thoughts to the issue:
- I think rejected events sent to Sentry should at least result in a log message with level `warn`. Not sure how this is handled in your other client libraries.
- What was the reasoning behind the choice to hand-role the JSON serialization? I think now with Serde hitting 1.0 and becoming the "blessed" serialization library, a case could be made to port the code to that.