### PR TITLE
fix(client): Parse crate names from impl traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,7 @@ rustc_version = { version = "0.2.2", optional = true }
 [dev-dependencies]
 failure_derive = "0.1.1"
 pretty_env_logger = "0.2.2"
+
+[[example]]
+name = "error-chain-demo"
+required-features = ["with_error_chain"]


### PR DESCRIPTION
This allows to parse the following names:

```
futures::task_impl::std::set
_<futures..task_impl..Spawn<T>>::enter::_{{closure}}
```