### PR TITLE
ci: Compatibility with rust 1.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ script: make $SUITE
 matrix:
   include:
     - os: linux
-      env: SUITE=checkall
-      rust: "1.19.0"
+      env: SUITE=check
+      rust: "1.21.0"
     - os: linux
       env: SUITE=cargotest
-      rust: "1.19.0"
+      rust: "1.21.0"
     - os: linux
       env: SUITE=checkall
     - os: linux
-      env: SUITE=cargotest
+      env: SUITE=cargotestall
     - os: osx
       env: SUITE=checkall
     - os: osx
-      env: SUITE=cargotest
+      env: SUITE=cargotestall
     - os: linux
       env: SUITE=format-check
       install: rustup component add rustfmt-preview

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
   include:
     - os: linux
       env: SUITE=checkall
+      rust: "1.19.0"
+    - os: linux
+      env: SUITE=cargotest
+      rust: "1.19.0"
+    - os: linux
+      env: SUITE=checkall
     - os: linux
       env: SUITE=cargotest
     - os: osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 all-features = true
 
 [features]
-default = ["with_client_implementation", "with_panic", "with_failure", "with_log", "with_device_info", "with_rust_info", "with_debug_meta"]
+default = ["with_client_implementation", "with_panic", "with_failure", "with_log", "with_device_info", "with_rust_info"]
 with_client_implementation = ["reqwest", "im", "url", "with_backtrace"]
 with_backtrace = ["backtrace", "regex"]
 with_panic = ["with_backtrace"]
@@ -35,7 +35,7 @@ failure = { version = "0.1.1", optional = true }
 log = { version = "0.4.1", optional = true }
 serde = "1.0.43"
 serde_json = "1.0.16"
-sentry-types = "0.3.2"
+sentry-types = "0.3.3"
 reqwest = { version = "0.8.5", optional = true }
 uuid = { version = "0.6.3", features = ["v4"] }
 lazy_static = "1.0.0"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 all: test
 .PHONY: all
 
+clean:
+	@cargo clean
+.PHONY: clean
+
 build:
-	@cargo build --all
+	@cargo build
 .PHONY: build
 
 doc:
@@ -49,15 +53,23 @@ check-all-impls:
 	@RUSTFLAGS=-Dwarnings cargo check --no-default-features --features 'with_failure,with_log,with_panic,with_error_chain'
 .PHONY: check-all-impls
 
+check: check-no-default-features check-default-features
+.PHONY: check-all-features
+
 checkall: check-all-features check-no-default-features check-default-features check-failure check-log check-panic check-error-chain check-all-impls
 .PHONY: checkall
 
 cargotest:
 	@echo 'TESTSUITE'
-	@cargo test --all --all-features
+	@cargo test
 .PHONY: cargotest
 
-test: checkall cargotest
+cargotestall:
+	@echo 'TESTSUITE'
+	@cargo test --all-features
+.PHONY: cargotest
+
+test: checkall cargotestall
 .PHONY: test
 
 format-check:

--- a/src/backtrace_support.rs
+++ b/src/backtrace_support.rs
@@ -47,7 +47,7 @@ lazy_static!{
         rv
     };
     pub static ref SECONDARY_BORDER_FRAMES: Vec<(&'static str, &'static str)> = {
-        #[allow(unused_mut)]
+        #![allow(unused_mut)]
         let mut rv = Vec::new();
         #[cfg(feature = "with_error_chain")] {
             rv.push(("error_chain::make_backtrace", "_<T as core..convert..Into<U>>::into"));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,5 @@
 //! Useful utilities for working with events.
-use uuid::Uuid;
-
 use api::protocol::{Context, DebugImage, DeviceContext, OsContext, RuntimeContext};
-use api::protocol::debugid::DebugId;
 
 #[cfg(all(feature = "with_device_info", target_os = "macos"))]
 mod model_support {
@@ -66,8 +63,10 @@ mod model_support {
 mod findshlibs_support {
     use super::*;
     use api::protocol::SymbolicDebugImage;
+    use api::protocol::debugid::DebugId;
     use findshlibs::{Segment, SharedLibrary, SharedLibraryId, TargetSharedLibrary,
                      TARGET_SUPPORTED};
+    use uuid::Uuid;
 
     pub fn find_shlibs() -> Option<Vec<DebugImage>> {
         if !TARGET_SUPPORTED {


### PR DESCRIPTION
- `tokio` requires `crossbeam-deque`, which will only compile on 1.21.0
- `finshlibs` depends on `bindgen` (which it probably shouldn't), which in turn requires `bitflags` and that requires 1.20.0