### PR TITLE
fix(client): Merge default contexts without scope

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,16 @@ backtrace = { version = "0.3.8", optional = true }
 url = { version = "1.7.0", optional = true }
 failure = { version = "0.1.1", optional = true }
 log = { version = "0.4.1", optional = true }
-serde = "1.0.64"
+serde = "1.0.66"
 serde_json = "1.0.19"
-sentry-types = "0.5.2"
+sentry-types = "0.5.3"
 reqwest = { version = "0.8.6", optional = true }
 uuid = { version = "0.6.5", features = ["v4"] }
 lazy_static = "1.0.1"
 regex = { version = "1.0.0", optional = true }
 error-chain = { version = "0.11.0", optional = true }
 im = { version = "10.2.0", optional = true }
-libc = { version = "0.2.41", optional = true }
+libc = { version = "0.2.42", optional = true }
 hostname = { version = "0.1.5", optional = true }
 findshlibs = { version = "0.4.0", optional = true }
 


### PR DESCRIPTION
Allows default contexts to be merged into an event even when the _scope_ parameter is set to `None`. Also, the `CONTEXT_DEFAULTS` object is now accessed more lazily (only when the entry is really vacant).

Note that this required an update to `sentry-types 0.5.3` for the `protocol::map::Entry` import.