### PR TITLE
Fix wrong crates.io link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Additionally, the lowest Rust version we target is _1.24.0_.
 
 ## Resources
 
-* [crates.io](https://crates.io/crate/sentry)
+* [crates.io](https://crates.io/crates/sentry)
 * [Documentation](https://docs.rs/sentry)
 * [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
 * [IRC](irc://chat.freenode.net/sentry) (chat.freenode.net, #sentry)


### PR DESCRIPTION
The [current link](https://crates.io/crate/sentry) is broken with the error "Oops, that route doesn't exist!". The correct link uses `crates` instead of `crate` in the path.