### PR TITLE
Exclude the backtrace in a failure::Error from the error typename

### DIFF
--- a/src/backtrace_support.rs
+++ b/src/backtrace_support.rs
@@ -105,6 +105,9 @@ pub fn demangle_symbol(s: &str) -> String {
 #[allow(unused)]
 pub fn error_typename<D: fmt::Debug>(error: D) -> String {
     format!("{:?}", error)
+        .split('\n')
+        .next()
+        .unwrap()
         .split(&['(', '{'][..])
         .next()
         .unwrap()


### PR DESCRIPTION
A failure::Error (and by extension, a failure::Context wrapping a failure::Error and passed around as a failure::Fail) will print its backtrace in the Debug output. To get only the typename from an Error, we need to exclude the backtrace by only using the first line of the Fail's Debug output.

See https://docs.rs/failure/0.1.1/src/failure/error.rs.html#146-154 for where the backtrace is getting included.

Without this fix, this is what the typename shows as when using `.context()` on a Result:

![error backtrace](https://user-images.githubusercontent.com/3230912/42896024-4226fae2-8a81-11e8-80f3-0bbca6fe09f4.png)

After this fix:

![error typename](https://user-images.githubusercontent.com/3230912/42896032-45ad185e-8a81-11e8-98b2-217cfcc6e21a.png)
