### PR TITLE
feat: Add dsn to options and deprecate disabled methods

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ branches:
 environment:
   fast_finish: true
   DIST_DIR: '.'
+  CARGO_HTTP_CHECK_REVOKE: false
 
   matrix:
     - channel: stable

--- a/examples/error-chain-demo.rs
+++ b/examples/error-chain-demo.rs
@@ -19,13 +19,15 @@ fn execute() -> Result<()> {
 }
 
 fn main() {
-    let _sentry = sentry::init((
-        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
-        sentry::ClientOptions {
-            release: sentry_crate_release!(),
-            ..Default::default()
-        },
-    ));
+    let _sentry = sentry::init(sentry::ClientOptions {
+        dsn: Some(
+            "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156"
+                .parse()
+                .unwrap(),
+        ),
+        release: sentry_crate_release!(),
+        ..Default::default()
+    });
 
     if let Err(err) = execute() {
         println!("error: {}", err);

--- a/src/api.rs
+++ b/src/api.rs
@@ -22,7 +22,7 @@ use hub::IntoBreadcrumbs;
 /// from methods on other types.
 pub mod internals {
     #[cfg(feature = "with_client_implementation")]
-    pub use client::{ClientInitGuard, IntoClient};
+    pub use client::{ClientInitGuard, IntoClient, IntoDsn};
     pub use hub::IntoBreadcrumbs;
     pub use scope::ScopeGuard;
     pub use sentry_types::{Auth, DsnParseError, ProjectId, ProjectIdParseError, Scheme};

--- a/src/api.rs
+++ b/src/api.rs
@@ -22,10 +22,11 @@ use hub::IntoBreadcrumbs;
 /// from methods on other types.
 pub mod internals {
     #[cfg(feature = "with_client_implementation")]
-    pub use client::{ClientInitGuard, IntoClient, IntoDsn};
+    pub use client::{ClientInitGuard, IntoDsn};
     pub use hub::IntoBreadcrumbs;
     pub use scope::ScopeGuard;
     pub use sentry_types::{Auth, DsnParseError, ProjectId, ProjectIdParseError, Scheme};
+    pub use transport::{DefaultTransportFactory, HttpTransport, Transport, TransportFactory};
 }
 
 /// Captures an event on the currently active client if any.

--- a/src/api.rs
+++ b/src/api.rs
@@ -26,6 +26,7 @@ pub mod internals {
     pub use hub::IntoBreadcrumbs;
     pub use scope::ScopeGuard;
     pub use sentry_types::{Auth, DsnParseError, ProjectId, ProjectIdParseError, Scheme};
+    #[cfg(feature = "with_client_implementation")]
     pub use transport::{DefaultTransportFactory, HttpTransport, Transport, TransportFactory};
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,6 +41,10 @@ pub struct ClientOptions {
     /// The DSN to use.  If not set the client is effectively disabled.
     pub dsn: Option<Dsn>,
     /// The transport to use.
+    ///
+    /// This is typically either a boxed function taking the client options by
+    /// reference and returning a `Transport`, a boxed `Arc<Transport>` or
+    /// alternatively the `DefaultTransportFactory`.
     pub transport: Box<TransportFactory>,
     /// module prefixes that are always considered in_app
     pub in_app_include: Vec<&'static str>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -305,7 +305,7 @@ impl Client {
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Plase use Client::with_options instead")]
+    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
     pub fn with_dsn(dsn: Dsn) -> Client {
         let mut options = ClientOptions::default();
         options.dsn = Some(dsn);
@@ -326,20 +326,20 @@ impl Client {
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Plase use Client::with_options instead")]
+    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
     pub fn with_dsn_and_options(dsn: Dsn, mut options: ClientOptions) -> Client {
         options.dsn = Some(dsn);
         Client::with_options(options)
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Plase use Client::with_options instead")]
+    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
     pub fn disabled() -> Client {
         Client::with_options(Default::default())
     }
 
     #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Plase use Client::with_options instead")]
+    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
     pub fn disabled_with_options(options: ClientOptions) -> Client {
         Client {
             options,

--- a/src/test.rs
+++ b/src/test.rs
@@ -38,6 +38,7 @@ lazy_static! {
 /// Example usage:
 ///
 /// ```rust
+/// use std::sync::Arc;
 /// use sentry::{Hub, ClientOptions};
 /// use sentry::test::TestTransport;
 ///
@@ -47,7 +48,7 @@ lazy_static! {
 ///     transport: Box::new(transport.clone()),
 ///     ..ClientOptions::default()
 /// };
-/// Hub::current().bind_client(Some(options.into()));
+/// Hub::current().bind_client(Some(Arc::new(options.into())));
 /// ```
 pub struct TestTransport {
     collected: Mutex<Vec<Event<'static>>>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,9 +3,8 @@
 //! **Feature:** `with_test_support` (*disabled by default*)
 //!
 //! If the sentry crate has been compiled with the test support feature this
-//! module becomes available and provides functionality to create a hub that
-//! does not emit to Sentry but instead captures event objects to an internal
-//! buffer.
+//! module becomes available and provides functionality to capture events
+//! in a block.
 //!
 //! # Example usage
 //!
@@ -19,10 +18,13 @@
 //! assert_eq!(events.len(), 1);
 //! assert_eq!(events[0].message.as_ref().unwrap(), "Hello World!");
 //! ```
+use std::mem;
 use std::sync::Arc;
+use std::sync::Mutex;
 
-use client::{Client, ClientOptions};
+use client::ClientOptions;
 use hub::Hub;
+use transport::Transport;
 
 use protocol::Event;
 use Dsn;
@@ -31,76 +33,44 @@ lazy_static! {
     static ref TEST_DSN: Dsn = "https://public@sentry.invalid/1".parse().unwrap();
 }
 
-/// Creates a testable hub.
+/// Collects events instead of sending them.
 ///
-/// A test hub will never send to an upstream Sentry service but instead
-/// uses an internal transport that just locally captures events.  Utilities
-/// from this module can be used to interact with it.  Testable hubs
-/// internally use a different client that does not send events and they
-/// are always wrapped in an `Arc`.  This uses a hardcoded internal test
-/// only DSN.
+/// Example usage:
 ///
-/// To access test specific functionality on hubs you need to bring the
-/// `TestableHubExt` into the scope.
+/// ```rust
+/// use sentry::{Hub, ClientOptions};
+/// use sentry::test::TestTransport;
 ///
-/// # Example
-///
+/// let transport = TestTransport::new();
+/// let options = ClientOptions {
+///     dsn: Some("https://public@example.com/1".parse().unwrap()),
+///     transport: Box::new(transport.clone()),
+///     ..ClientOptions::default()
+/// };
+/// Hub::current().bind_client(Some(options.into()));
 /// ```
-/// use sentry::test::{create_testable_hub, TestableHubExt};
-/// let hub = create_testable_hub(Default::default());
-/// let events = hub.run_and_capture_events(|| {
-///     // in here `sentry::Hub::current()` returns our testable hub.
-///     // any event captured will go to the hub.
-/// });
-/// ```
-pub fn create_testable_hub(options: ClientOptions) -> Arc<Hub> {
-    Arc::new(Hub::new(
-        Some(Arc::new(Client::testable(TEST_DSN.clone(), options))),
-        Arc::new(Default::default()),
-    ))
+pub struct TestTransport {
+    collected: Mutex<Vec<Event<'static>>>,
 }
 
-/// Extensions for working with testable hubs.
-///
-/// Because a testable hub by itself cannot be told from a non testable hub
-/// this trait needs to be used to access extra functionality on a testable
-/// hub such as fetching the buffered events.
-///
-/// For convenience reasons testable hubs are always wrapped in `Arc` wrappers
-/// so that they can directly be bound to the current thread.  This means
-/// this trait is only implemented for `Arc<Hub>` and not for `Hub` directly.
-pub trait TestableHubExt {
-    /// Checks if the hub is a testable hub.
-    fn is_testable(&self) -> bool;
+impl TestTransport {
+    /// Creates a new test transport.
+    pub fn new() -> Arc<TestTransport> {
+        Arc::new(TestTransport {
+            collected: Mutex::new(vec![]),
+        })
+    }
 
-    /// Fetches events from a testable hub.
-    ///
-    /// This removes all the events from the internal buffer and empties it.
-    fn fetch_events(&self) -> Vec<Event<'static>>;
-
-    /// Runs code with the bound hub and fetches the events.
-    fn run_and_capture_events<F: FnOnce()>(&self, f: F) -> Vec<Event<'static>>;
+    /// Fetches and clears the contained events.
+    pub fn fetch_and_clear_events(&self) -> Vec<Event<'static>> {
+        let mut guard = self.collected.lock().unwrap();
+        mem::replace(&mut *guard, vec![])
+    }
 }
 
-impl TestableHubExt for Arc<Hub> {
-    fn is_testable(&self) -> bool {
-        if let Some(client) = self.client() {
-            client.dsn().is_some() && client.transport().is_test()
-        } else {
-            false
-        }
-    }
-
-    fn fetch_events(&self) -> Vec<Event<'static>> {
-        self.client()
-            .expect("need a hub with client")
-            .transport()
-            .fetch_and_clear_events()
-    }
-
-    fn run_and_capture_events<F: FnOnce()>(&self, f: F) -> Vec<Event<'static>> {
-        Hub::run(self.clone(), f);
-        self.fetch_events()
+impl Transport for TestTransport {
+    fn send_event(&self, event: Event<'static>) {
+        self.collected.lock().unwrap().push(event);
     }
 }
 
@@ -109,17 +79,31 @@ impl TestableHubExt for Arc<Hub> {
 /// This is a shortcut for creating a testable hub with default options and
 /// to call `run_and_capture_events` on it.
 pub fn with_captured_events<F: FnOnce()>(f: F) -> Vec<Event<'static>> {
-    with_captured_events_options(f, Default::default())
+    with_captured_events_options(f, ClientOptions::default())
 }
 
-/// Runs some code with the default test hub with the given optoins and
+/// Runs some code with the default test hub with the given options and
 /// returns the captured events.
+///
+/// If not DSN is set on the options a default test DSN is inserted.  The
+/// transport on the options is also overridden with a `TestTransport`.
 ///
 /// This is a shortcut for creating a testable hub with the supplied options
 /// and to call `run_and_capture_events` on it.
-pub fn with_captured_events_options<F: FnOnce()>(
+pub fn with_captured_events_options<F: FnOnce(), O: Into<ClientOptions>>(
     f: F,
-    options: ClientOptions,
+    options: O,
 ) -> Vec<Event<'static>> {
-    create_testable_hub(options).run_and_capture_events(f)
+    let transport = TestTransport::new();
+    let mut options = options.into();
+    options.dsn = Some(options.dsn.unwrap_or_else(|| TEST_DSN.clone()));
+    options.transport = Box::new(transport.clone());
+    Hub::run(
+        Arc::new(Hub::new(
+            Some(Arc::new(options.into())),
+            Arc::new(Default::default()),
+        )),
+        f,
+    );
+    transport.fetch_and_clear_events()
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -50,6 +50,9 @@ impl<T: 'static + TransportFactory + Clone> InternalTransportFactoryClone for T 
 /// Because transports can be wrapped in `Arc`s and those are clonable
 /// any `Arc<Transport>` is also a valid transport factory.  This for
 /// instance lets you put a `Arc<TestTransport>` directly into the options.
+///
+/// This is automatically implemented for all closures optionally taking
+/// options and returning a boxed factory.
 pub trait TransportFactory: Send + Sync + InternalTransportFactoryClone {
     /// Given some options creates a transport.
     fn create_transport(&self, options: &ClientOptions) -> Box<Transport>;

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -2,16 +2,7 @@ extern crate sentry;
 
 #[test]
 fn test_into_client() {
-    let c: sentry::Client = sentry::Client::from_config("https://public@example.com/42").unwrap();
-    {
-        let dsn = c.dsn().unwrap();
-        assert_eq!(dsn.public_key(), "public");
-        assert_eq!(dsn.host(), "example.com");
-        assert_eq!(dsn.scheme(), sentry::internals::Scheme::Https);
-        assert_eq!(dsn.project_id(), 42.into());
-    }
-
-    let c: sentry::Client = sentry::Client::from_config(c).unwrap();
+    let c: sentry::Client = sentry::Client::from_config("https://public@example.com/42");
     {
         let dsn = c.dsn().unwrap();
         assert_eq!(dsn.public_key(), "public");
@@ -26,7 +17,7 @@ fn test_into_client() {
             release: Some("foo@1.0".into()),
             ..Default::default()
         },
-    )).unwrap();
+    ));
     {
         let dsn = c.dsn().unwrap();
         assert_eq!(dsn.public_key(), "public");
@@ -36,6 +27,5 @@ fn test_into_client() {
         assert_eq!(&c.options().release.as_ref().unwrap(), &"foo@1.0");
     }
 
-    assert!(sentry::Client::from_config(()).is_none());
-    assert!(sentry::Client::disabled().dsn().is_none());
+    assert!(sentry::Client::from_config(()).options().dsn.is_none());
 }


### PR DESCRIPTION
This simplifies the API in that one can explicitly set the DSN to `None` now
on the options to get a disabled client.  All that other API surface just
goes away.  As a followup the transport will also move into the options.