### PR TITLE
feat: Added debug logs and must use flag for init

### DIFF
--- a/examples/before-send.rs
+++ b/examples/before-send.rs
@@ -15,6 +15,7 @@ fn main() {
             });
             Some(event)
         }))),
+        debug: true,
         ..Default::default()
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! The `sentry::init` function returns a guard that when dropped will flush
 //! Events that were not yet sent to the sentry service.  It has a two second
 //! deadline for this so shutdown of applications might slightly delay as a result
-//! of this.
+//! of this.  Keep the guard around or sending events will not work.
 //!
 //! ```
 //! extern crate sentry;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,6 +37,20 @@ macro_rules! with_client_impl {
 }
 
 #[allow(unused_macros)]
+macro_rules! sentry_debug {
+    ($($arg:tt)*) => {
+        with_client_impl! {{
+            $crate::Hub::with(|hub| {
+                if hub.client().map_or(false, |c| c.options().debug) {
+                    eprint!("[sentry] ");
+                    eprintln!($($arg)*);
+                }
+            });
+        }}
+    }
+}
+
+#[allow(unused_macros)]
 macro_rules! minimal_unreachable {
     () => {
         panic!(

--- a/src/scope/real.rs
+++ b/src/scope/real.rs
@@ -299,9 +299,13 @@ impl Scope {
         }
 
         for processor in &self.event_processors {
+            let id = event.id;
             event = match processor(event) {
                 Some(event) => event,
-                None => return None,
+                None => {
+                    sentry_debug!("event processor dropped event {:?}", id);
+                    return None;
+                }
             }
         }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -230,6 +230,7 @@ impl Transport for HttpTransport {
     }
 
     fn shutdown(&self, timeout: Duration) -> bool {
+        sentry_debug!("shutting down http transport");
         let guard = self.queue_size.lock().unwrap();
         if *guard == 0 {
             true
@@ -244,6 +245,7 @@ impl Transport for HttpTransport {
 
 impl Drop for HttpTransport {
     fn drop(&mut self) {
+        sentry_debug!("dropping http transport");
         self.shutdown_immediately.store(true, Ordering::SeqCst);
         if let Ok(sender) = self.sender.lock() {
             sender.send(None).ok();


### PR DESCRIPTION
This solves an issue that mozilla ran into where the guard was dropped too early and the transport closed. That means events are quietly discarded.