### PR TITLE
Point links to working documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://docs.rs/sentry"
+documentation = "https://getsentry.github.io/sentry-rust"
 description = """
 Sentry (getsentry.com) client for rust ;)
 """

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 ## Resources
 
 - [crates.io](https://crates.io/crates/sentry)
-- [Documentation](https://docs.rs/sentry)
+- [Documentation](https://getsentry.github.io/sentry-rust)
 - [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
 - [IRC](irc://chat.freenode.net/sentry) (chat.freenode.net, #sentry)
 - Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates


### PR DESCRIPTION
According to #92, the docs.rs documentation doesn't work and it is known.

Aim the links users are likely to find to something that works.