### PR TITLE
env_logger: 0.5.13 -> 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ url = { version = "1.7.1", optional = true }
 failure = { version = "0.1.2", optional = true }
 log = { version = "0.4.5", optional = true, features = ["std"] }
 sentry-types = "0.8.1"
-env_logger = { version = "0.5.13", optional = true }
+env_logger = { version = "0.6.0", optional = true }
 reqwest = { version = "0.9.2", optional = true }
 lazy_static = "1.1.0"
 regex = { version = "1.0.5", optional = true }


### PR DESCRIPTION
fix #98 

Being on 0.5 prevents the sentry crate to be used with other crate that are using 0.6.0.