### PR TITLE
Fix with_scope

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -171,7 +171,7 @@ where
     C: FnOnce(&mut Scope),
     F: FnOnce() -> R,
 {
-    #[cfg(with_client_impl)]
+    #[cfg(feature = "with_client_implementation")]
     {
         Hub::with(|hub| {
             if hub.is_active_and_usage_safe() {
@@ -181,7 +181,7 @@ where
             }
         })
     }
-    #[cfg(not(with_client_impl))]
+    #[cfg(not(feature = "with_client_implementation"))]
     {
         let _scope_config = scope_config;
         callback()

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -350,13 +350,13 @@ impl Hub {
         C: FnOnce(&mut Scope),
         F: FnOnce() -> R,
     {
-        #[cfg(with_client_impl)]
+        #[cfg(feature = "with_client_implementation")]
         {
             let _guard = self.push_scope();
             self.configure_scope(scope_config);
             callback()
         }
-        #[cfg(not(with_client_impl))]
+        #[cfg(not(feature = "with_client_implementation"))]
         {
             let _scope_config = scope_config;
             callback()


### PR DESCRIPTION
This is just a shot in the dark here, but in a default client usage `with_scope` always takes the second, non-hub code path, so I figure this might be the reason.