### PR TITLE
Updated `failure` integration for new backtrace display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ with_test_support = []
 [dependencies]
 backtrace = { version = "0.3.9", optional = true }
 url = { version = "1.7.1", optional = true }
-failure = { version = "0.1.2", optional = true }
+failure = { version = "0.1.3", optional = true }
 log = { version = "0.4.5", optional = true, features = ["std"] }
 sentry-types = "0.8.1"
 env_logger = { version = "0.5.13", optional = true }
@@ -55,7 +55,7 @@ uname = { version = "0.1.1", optional = true }
 rustc_version = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
-failure_derive = "0.1.2"
+failure_derive = "0.1.3"
 pretty_env_logger = "0.2.4"
 actix-web = { version = "0.7.8", default-features = false }
 


### PR DESCRIPTION
FIX #105 (.1)