### PR TITLE
Combined panic/failure integration

### DIFF
--- a/src/integrations/panic.rs
+++ b/src/integrations/panic.rs
@@ -34,6 +34,18 @@ pub fn message_from_panic_info<'a>(info: &'a panic::PanicInfo) -> &'a str {
 ///
 /// The stacktrace is calculated from the current frame.
 pub fn event_from_panic_info(info: &panic::PanicInfo) -> Event<'static> {
+    if cfg!(feature = "with_failure") {
+        use failure::Error;
+        use crate::integrations::failure::event_from_error;
+
+        if let Some(e) = info.payload().downcast_ref::<Error>() {
+            return Event {
+                level: Level::Fatal,
+                ..event_from_error(e)
+            };
+        }
+    }
+
     let msg = message_from_panic_info(info);
     Event {
         exception: vec![Exception {


### PR DESCRIPTION
It would be useful to have a way to turn a `failure::Error` into a panic without losing the backtrace.

This is very common when you receive an error from further down the call-stack, and you don't have a good way to handle it, but currently you only get a callstack to the panic location, you lose the underlying error's backtrace.

This is just one possible way to implement the functionality.