### PR TITLE
feat: Support for curl and disabled transports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,22 +39,22 @@ failure = { version = "0.1.5", optional = true }
 log = { version = "0.4.6", optional = true, features = ["std"] }
 sentry-types = "0.9.0"
 env_logger = { version = "0.6.0", optional = true }
-reqwest = { version = "0.9.6", optional = true }
+reqwest = { version = "0.9.9", optional = true }
 lazy_static = "1.2.0"
 regex = { version = "1.1.0", optional = true }
 error-chain = { version = "0.12.0", optional = true }
-im = { version = "12.2.0", optional = true }
-libc = { version = "0.2.46", optional = true }
+im = { version = "12.3.0", optional = true }
+libc = { version = "0.2.48", optional = true }
 hostname = { version = "0.1.5", optional = true }
 findshlibs = { version = "0.4.1", optional = true }
-rand = "0.6.4"
+rand = "0.6.5"
 httpdate = "0.3.2"
 
 [target."cfg(not(windows))".dependencies]
 uname = { version = "0.1.1", optional = true }
 
 [target."cfg(unix)".dependencies]
-goblin = { version = "0.0.19", default-features = false, features = ["elf32", "elf64", "endian_fd", "std"], optional = true }
+goblin = { version = "0.0.20", default-features = false, features = ["elf32", "elf64", "endian_fd", "std"], optional = true }
 memmap = { version = "0.7.0", optional = true }
 
 [build-dependencies]
@@ -63,7 +63,7 @@ rustc_version = { version = "0.2.3", optional = true }
 [dev-dependencies]
 failure_derive = "0.1.5"
 pretty_env_logger = "0.3.0"
-actix-web = { version = "0.7.17", default-features = false }
+actix-web = { version = "0.7.18", default-features = false }
 
 [[example]]
 name = "error-chain-demo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ autoexamples = true
 all-features = true
 
 [features]
-default = ["with_client_implementation", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info"]
-with_client_implementation = ["reqwest", "im", "url", "with_backtrace"]
+default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info"]
+with_reqwest_transport = ["reqwest", "httpdate"]
+with_default_transport = ["with_reqwest_transport"]
+with_client_implementation = ["im", "url", "with_backtrace"]
 with_backtrace = ["backtrace", "regex"]
 with_panic = ["with_backtrace"]
 with_failure = ["failure", "with_backtrace"]
@@ -48,7 +50,7 @@ libc = { version = "0.2.48", optional = true }
 hostname = { version = "0.1.5", optional = true }
 findshlibs = { version = "0.4.1", optional = true }
 rand = "0.6.5"
-httpdate = "0.3.2"
+httpdate = { version = "0.3.2", optional = true }
 
 [target."cfg(not(windows))".dependencies]
 uname = { version = "0.1.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ all-features = true
 
 [features]
 default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info"]
-with_reqwest_transport = ["reqwest", "httpdate"]
+with_reqwest_transport = ["reqwest", "httpdate", "with_client_implementation"]
+with_curl_transport = ["curl", "httpdate", "serde_json", "with_client_implementation"]
 with_default_transport = ["with_reqwest_transport"]
 with_client_implementation = ["im", "url", "with_backtrace"]
 with_backtrace = ["backtrace", "regex"]
@@ -51,6 +52,8 @@ hostname = { version = "0.1.5", optional = true }
 findshlibs = { version = "0.4.1", optional = true }
 rand = "0.6.5"
 httpdate = { version = "0.3.2", optional = true }
+curl = { version = "0.4.19", optional = true }
+serde_json = { version = "1.0.38", optional = true }
 
 [target."cfg(not(windows))".dependencies]
 uname = { version = "0.1.1", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,13 @@ check-all-impls:
 	@RUSTFLAGS=-Dwarnings cargo check --no-default-features --features 'with_failure,with_log,with_panic,with_error_chain'
 .PHONY: check-all-impls
 
+check-curl-transport:
+	@echo 'CURL TRANSPORT'
+	@RUSTFLAGS=-Dwarnings cargo check --features with_curl_transport
+	@echo 'CURL TRANSPORT ONLY'
+	@RUSTFLAGS=-Dwarnings cargo check --no-default-features --features 'with_curl_transport,with_client_implementation,with_panic'
+.PHONY: check-curl-transport
+
 check-actix:
 	@echo 'ACTIX INTEGRATION'
 	@RUSTFLAGS=-Dwarnings cargo check --manifest-path integrations/sentry-actix/Cargo.toml
@@ -61,7 +68,7 @@ check-actix:
 check: check-no-default-features check-default-features
 .PHONY: check-all-features
 
-checkall: check-all-features check-no-default-features check-default-features check-failure check-log check-panic check-error-chain check-all-impls check-actix
+checkall: check-all-features check-no-default-features check-default-features check-failure check-log check-panic check-error-chain check-all-impls check-curl-transport check-actix
 .PHONY: checkall
 
 cargotest:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@
 //! default flags:
 //!
 //! * `with_client_implementation`: turns on the real client implementation.
+//! * `with_default_transport`: compiles in the default HTTP transport.
 //! * `with_backtrace`: enables backtrace support (automatically turned on in a few cases)
 //! * `with_panic`: enables the panic integration
 //! * `with_failure`: enables the `failure` integration
@@ -104,6 +105,8 @@
 //!
 //! * `with_error_chain`: enables the error-chain integration
 //! * `with_test_support`: enables the test support module
+//! * `with_reqwest_transport`: enables the reqwest transport explicitly.  This
+//!   is currently the default transport.
 #![warn(missing_docs)]
 
 #[macro_use]
@@ -142,8 +145,11 @@ pub mod internals {
     #[cfg(feature = "with_client_implementation")]
     pub use crate::{
         client::{ClientInitGuard, IntoDsn},
-        transport::{DefaultTransportFactory, HttpTransport, Transport, TransportFactory},
+        transport::{DefaultTransportFactory, Transport, TransportFactory},
     };
+
+    #[cfg(feature = "with_reqwest_transport")]
+    pub use crate::transport::{HttpTransport, ReqwestHttpTransport};
 
     pub use sentry_types::{
         Auth, ChronoParseError, DateTime, DebugId, Dsn, DsnParseError, ParseDebugIdError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@
 //! * `with_test_support`: enables the test support module
 //! * `with_reqwest_transport`: enables the reqwest transport explicitly.  This
 //!   is currently the default transport.
+//! * `with_curl_transport`: enables the curl transport.
 #![warn(missing_docs)]
 
 #[macro_use]
@@ -145,16 +146,29 @@ pub mod internals {
     #[cfg(feature = "with_client_implementation")]
     pub use crate::{
         client::{ClientInitGuard, IntoDsn},
-        transport::{DefaultTransportFactory, Transport, TransportFactory},
+        transport::{Transport, TransportFactory},
     };
-
-    #[cfg(feature = "with_reqwest_transport")]
-    pub use crate::transport::{HttpTransport, ReqwestHttpTransport};
 
     pub use sentry_types::{
         Auth, ChronoParseError, DateTime, DebugId, Dsn, DsnParseError, ParseDebugIdError,
         ProjectId, ProjectIdParseError, Scheme, TimeZone, Utc, Uuid, UuidVariant, UuidVersion,
     };
+}
+
+/// The provided transports.
+///
+/// This module exposes all transports that are compiled into the sentry
+/// library.  The `with_reqwest_transport` and `with_curl_transport` flags
+/// turn on these transports.
+pub mod transports {
+    #[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+    pub use crate::transport::{DefaultTransportFactory, HttpTransport};
+
+    #[cfg(feature = "with_reqwest_transport")]
+    pub use crate::transport::ReqwestHttpTransport;
+
+    #[cfg(feature = "with_curl_transport")]
+    pub use crate::transport::CurlHttpTransport;
 }
 
 // public api or exports from this crate

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,14 +4,16 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime};
 
+#[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+use httpdate::parse_http_date;
+
 #[cfg(feature = "with_reqwest_transport")]
-use {
-    httpdate::parse_http_date,
-    reqwest::{header::RETRY_AFTER, Client, Proxy},
-};
+use reqwest::{header::RETRY_AFTER, Client, Proxy};
+
+#[cfg(feature = "with_curl_transport")]
+use {crate::internals::Scheme, curl, std::io::Read};
 
 use crate::client::ClientOptions;
-use crate::internals::Dsn;
 use crate::protocol::Event;
 
 /// The trait for transports.
@@ -98,36 +100,18 @@ pub struct DefaultTransportFactory;
 
 impl TransportFactory for DefaultTransportFactory {
     fn create_transport(&self, options: &ClientOptions) -> Box<dyn Transport> {
-        #[cfg(feature = "with_reqwest_transport")]
+        #[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
         {
             Box::new(HttpTransport::new(options))
         }
-        #[cfg(not(feature = "with_reqwest_transport"))]
+        #[cfg(not(any(feature = "with_reqwest_transport", feature = "with_curl_transport")))]
         {
-            panic!(
-                "sentry crate was compiled without transport, enable at \
-                 least with_default_transport for default implementation."
-            )
+            panic!("sentry crate was compiled without transport")
         }
     }
 }
 
-/// A transport can send events via HTTP to sentry via `reqwest`.
-///
-/// When the `with_default_transport` feature is enabled this will currently
-/// be the default transport.
-#[cfg(feature = "with_reqwest_transport")]
-#[derive(Debug)]
-pub struct ReqwestHttpTransport {
-    dsn: Dsn,
-    sender: Mutex<SyncSender<Option<Event<'static>>>>,
-    shutdown_signal: Arc<Condvar>,
-    shutdown_immediately: Arc<AtomicBool>,
-    queue_size: Arc<Mutex<usize>>,
-    _handle: Option<JoinHandle<()>>,
-}
-
-#[cfg(feature = "with_reqwest_transport")]
+#[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
 fn parse_retry_after(s: &str) -> Option<SystemTime> {
     if let Ok(value) = s.parse::<f64>() {
         Some(SystemTime::now() + Duration::from_secs(value.ceil() as u64))
@@ -138,86 +122,105 @@ fn parse_retry_after(s: &str) -> Option<SystemTime> {
     }
 }
 
-#[cfg(feature = "with_reqwest_transport")]
-fn spawn_http_sender(
-    client: Client,
-    receiver: Receiver<Option<Event<'static>>>,
-    dsn: Dsn,
-    signal: Arc<Condvar>,
-    shutdown_immediately: Arc<AtomicBool>,
-    queue_size: Arc<Mutex<usize>>,
-    user_agent: String,
-) -> JoinHandle<()> {
-    let mut disabled = SystemTime::now();
+macro_rules! implement_http_transport {
+    (
+        $(#[$attr:meta])*
+        pub struct $typename:ident;
+        fn spawn($($argname:ident: $argty:ty,)*) $body:block
+    ) => {
+        $(#[$attr])*
+        pub struct $typename {
+            sender: Mutex<SyncSender<Option<Event<'static>>>>,
+            shutdown_signal: Arc<Condvar>,
+            shutdown_immediately: Arc<AtomicBool>,
+            queue_size: Arc<Mutex<usize>>,
+            _handle: Option<JoinHandle<()>>,
+        }
 
-    thread::spawn(move || {
-        let url = dsn.store_api_url().to_string();
+        impl $typename {
+            /// Creates a new transport.
+            pub fn new(options: &ClientOptions) -> $typename {
+                fn spawn($($argname: $argty,)*) -> JoinHandle<()> { $body }
 
-        while let Some(event) = receiver.recv().unwrap_or(None) {
-            // on drop we want to not continue processing the queue.
-            if shutdown_immediately.load(Ordering::SeqCst) {
-                let mut size = queue_size.lock().unwrap();
-                *size = 0;
-                signal.notify_all();
-                break;
-            }
-
-            // while we are disabled due to rate limits, skip
-            let now = SystemTime::now();
-            if let Ok(time_left) = disabled.duration_since(now) {
-                sentry_debug!(
-                    "Skipping event send because we're disabled due to rate limits for {}s",
-                    time_left.as_secs()
-                );
-                continue;
-            }
-
-            match client
-                .post(url.as_str())
-                .json(&event)
-                .header("X-Sentry-Auth", dsn.to_auth(Some(&user_agent)).to_string())
-                .send()
-            {
-                Ok(resp) => {
-                    if resp.status() == 429 {
-                        if let Some(retry_after) = resp
-                            .headers()
-                            .get(RETRY_AFTER)
-                            .and_then(|x| x.to_str().ok())
-                            .and_then(parse_retry_after)
-                        {
-                            disabled = retry_after;
-                        }
-                    }
+                let (sender, receiver) = sync_channel(30);
+                let shutdown_signal = Arc::new(Condvar::new());
+                let shutdown_immediately = Arc::new(AtomicBool::new(false));
+                #[allow(clippy::mutex_atomic)]
+                let queue_size = Arc::new(Mutex::new(0));
+                let _handle = Some(spawn(
+                    options,
+                    receiver,
+                    shutdown_signal.clone(),
+                    shutdown_immediately.clone(),
+                    queue_size.clone(),
+                ));
+                $typename {
+                    sender: Mutex::new(sender),
+                    shutdown_signal,
+                    shutdown_immediately,
+                    queue_size,
+                    _handle,
                 }
-                Err(err) => {
-                    sentry_debug!("Failed to send event: {}", err);
-                }
-            }
-
-            let mut size = queue_size.lock().unwrap();
-            *size -= 1;
-            if *size == 0 {
-                signal.notify_all();
             }
         }
-    })
+
+        impl Transport for $typename {
+            fn send_event(&self, event: Event<'static>) {
+                // we count up before we put the item on the queue and in case the
+                // queue is filled with too many items or we shut down, we decrement
+                // the count again as there is nobody that can pick it up.
+                *self.queue_size.lock().unwrap() += 1;
+                if self.sender.lock().unwrap().try_send(Some(event)).is_err() {
+                    *self.queue_size.lock().unwrap() -= 1;
+                }
+            }
+
+            fn shutdown(&self, timeout: Duration) -> bool {
+                sentry_debug!("shutting down http transport");
+                let guard = self.queue_size.lock().unwrap();
+                if *guard == 0 {
+                    true
+                } else {
+                    if let Ok(sender) = self.sender.lock() {
+                        sender.send(None).ok();
+                    }
+                    self.shutdown_signal.wait_timeout(guard, timeout).is_ok()
+                }
+            }
+        }
+
+        impl Drop for $typename {
+            fn drop(&mut self) {
+                sentry_debug!("dropping http transport");
+                self.shutdown_immediately.store(true, Ordering::SeqCst);
+                if let Ok(sender) = self.sender.lock() {
+                    sender.send(None).ok();
+                }
+            }
+        }
+    }
 }
 
 #[cfg(feature = "with_reqwest_transport")]
-impl ReqwestHttpTransport {
-    /// Creates a new transport.
-    pub fn new(options: &ClientOptions) -> ReqwestHttpTransport {
+implement_http_transport! {
+    /// A transport can send events via HTTP to sentry via `reqwest`.
+    ///
+    /// When the `with_default_transport` feature is enabled this will currently
+    /// be the default transport.  This is separately enabled by the
+    /// `with_reqwest_transport` flag.
+    pub struct ReqwestHttpTransport;
+
+    fn spawn(
+        options: &ClientOptions,
+        receiver: Receiver<Option<Event<'static>>>,
+        signal: Arc<Condvar>,
+        shutdown_immediately: Arc<AtomicBool>,
+        queue_size: Arc<Mutex<usize>>,
+    ) {
         let dsn = options.dsn.clone().unwrap();
         let user_agent = options.user_agent.to_string();
         let http_proxy = options.http_proxy.as_ref().map(|x| x.to_string());
         let https_proxy = options.https_proxy.as_ref().map(|x| x.to_string());
-
-        let (sender, receiver) = sync_channel(30);
-        let shutdown_signal = Arc::new(Condvar::new());
-        let shutdown_immediately = Arc::new(AtomicBool::new(false));
-        #[allow(clippy::mutex_atomic)]
-        let queue_size = Arc::new(Mutex::new(0));
         let mut client = Client::builder();
         if let Some(url) = http_proxy {
             client = client.proxy(Proxy::http(&url).unwrap());
@@ -225,63 +228,197 @@ impl ReqwestHttpTransport {
         if let Some(url) = https_proxy {
             client = client.proxy(Proxy::https(&url).unwrap());
         };
-        let _handle = Some(spawn_http_sender(
-            client.build().unwrap(),
-            receiver,
-            dsn.clone(),
-            shutdown_signal.clone(),
-            shutdown_immediately.clone(),
-            queue_size.clone(),
-            user_agent,
-        ));
-        ReqwestHttpTransport {
-            dsn,
-            sender: Mutex::new(sender),
-            shutdown_signal,
-            shutdown_immediately,
-            queue_size,
-            _handle,
-        }
-    }
-}
+        let client = client.build().unwrap();
 
-#[cfg(feature = "with_reqwest_transport")]
-impl Transport for ReqwestHttpTransport {
-    fn send_event(&self, event: Event<'static>) {
-        // we count up before we put the item on the queue and in case the
-        // queue is filled with too many items or we shut down, we decrement
-        // the count again as there is nobody that can pick it up.
-        *self.queue_size.lock().unwrap() += 1;
-        if self.sender.lock().unwrap().try_send(Some(event)).is_err() {
-            *self.queue_size.lock().unwrap() -= 1;
-        }
-    }
+        let mut disabled = SystemTime::now();
 
-    fn shutdown(&self, timeout: Duration) -> bool {
-        sentry_debug!("shutting down http transport");
-        let guard = self.queue_size.lock().unwrap();
-        if *guard == 0 {
-            true
-        } else {
-            if let Ok(sender) = self.sender.lock() {
-                sender.send(None).ok();
+        thread::spawn(move || {
+            sentry_debug!("spawning reqwest transport");
+            let url = dsn.store_api_url().to_string();
+
+            while let Some(event) = receiver.recv().unwrap_or(None) {
+                // on drop we want to not continue processing the queue.
+                if shutdown_immediately.load(Ordering::SeqCst) {
+                    let mut size = queue_size.lock().unwrap();
+                    *size = 0;
+                    signal.notify_all();
+                    break;
+                }
+
+                // while we are disabled due to rate limits, skip
+                let now = SystemTime::now();
+                if let Ok(time_left) = disabled.duration_since(now) {
+                    sentry_debug!(
+                        "Skipping event send because we're disabled due to rate limits for {}s",
+                        time_left.as_secs()
+                    );
+                    continue;
+                }
+
+                match client
+                    .post(url.as_str())
+                    .json(&event)
+                    .header("X-Sentry-Auth", dsn.to_auth(Some(&user_agent)).to_string())
+                    .send()
+                {
+                    Ok(resp) => {
+                        if resp.status() == 429 {
+                            if let Some(retry_after) = resp
+                                .headers()
+                                .get(RETRY_AFTER)
+                                .and_then(|x| x.to_str().ok())
+                                .and_then(parse_retry_after)
+                            {
+                                disabled = retry_after;
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        sentry_debug!("Failed to send event: {}", err);
+                    }
+                }
+
+                let mut size = queue_size.lock().unwrap();
+                *size -= 1;
+                if *size == 0 {
+                    signal.notify_all();
+                }
             }
-            self.shutdown_signal.wait_timeout(guard, timeout).is_ok()
-        }
+        })
+    }
+}
+
+#[cfg(feature = "with_curl_transport")]
+implement_http_transport! {
+    /// A transport can send events via HTTP to sentry via `curl`.
+    ///
+    /// This is enabled by the `with_curl_transport` flag.
+    pub struct CurlHttpTransport;
+
+    fn spawn(
+        options: &ClientOptions,
+        receiver: Receiver<Option<Event<'static>>>,
+        signal: Arc<Condvar>,
+        shutdown_immediately: Arc<AtomicBool>,
+        queue_size: Arc<Mutex<usize>>,
+    ) {
+        let dsn = options.dsn.clone().unwrap();
+        let user_agent = options.user_agent.to_string();
+        let http_proxy = options.http_proxy.as_ref().map(|x| x.to_string());
+        let https_proxy = options.https_proxy.as_ref().map(|x| x.to_string());
+
+        let mut disabled = SystemTime::now();
+        let mut handle = curl::easy::Easy::new();
+
+        thread::spawn(move || {
+            sentry_debug!("spawning curl transport");
+            let url = dsn.store_api_url().to_string();
+
+            while let Some(event) = receiver.recv().unwrap_or(None) {
+                // on drop we want to not continue processing the queue.
+                if shutdown_immediately.load(Ordering::SeqCst) {
+                    let mut size = queue_size.lock().unwrap();
+                    *size = 0;
+                    signal.notify_all();
+                    break;
+                }
+
+                // while we are disabled due to rate limits, skip
+                let now = SystemTime::now();
+                if let Ok(time_left) = disabled.duration_since(now) {
+                    sentry_debug!(
+                        "Skipping event send because we're disabled due to rate limits for {}s",
+                        time_left.as_secs()
+                    );
+                    continue;
+                }
+
+                handle.reset();
+                handle.url(&url).unwrap();
+                handle.custom_request("POST").unwrap();
+
+                if dsn.scheme() == Scheme::Https {
+                    if let Some(ref proxy) = https_proxy {
+                        handle.proxy(&proxy).unwrap();
+                    }
+                } else {
+                    if let Some(ref proxy) = http_proxy {
+                        handle.proxy(&proxy).unwrap();
+                    }
+                }
+
+                let body = serde_json::to_vec(&event).unwrap();
+                let mut retry_after = None;
+                let mut headers = curl::easy::List::new();
+                headers.append(&format!("X-Sentry-Auth: {}", dsn.to_auth(Some(&user_agent)))).unwrap();
+                headers.append("Expect:").unwrap();
+                headers.append("Content-Type: application/json").unwrap();
+                handle.http_headers(headers).unwrap();
+                handle.upload(true).unwrap();
+                handle.in_filesize(body.len() as u64).unwrap();
+                handle.read_function(move |buf| Ok((&body[..]).read(buf).unwrap_or(0))).unwrap();
+                handle.verbose(true).unwrap();
+                handle.debug_function(move |info, data| {
+                    let prefix = match info {
+                        curl::easy::InfoType::HeaderIn => "< ",
+                        curl::easy::InfoType::HeaderOut => "> ",
+                        curl::easy::InfoType::DataOut => "",
+                        _ => return
+                    };
+                    sentry_debug!("curl: {}{}", prefix, String::from_utf8_lossy(data).trim());
+                }).unwrap();
+
+                {
+                    let mut handle = handle.transfer();
+                    let retry_after_setter = &mut retry_after;
+                    handle.header_function(move |data| {
+                        if let Ok(data) = std::str::from_utf8(data) {
+                            let mut iter = data.split(':');
+                            if let Some(key) = iter.next().map(|x| x.to_lowercase()) {
+                                if key == "retry-after" {
+                                    *retry_after_setter = iter.next().map(|x| x.trim().to_string());
+                                }
+                            }
+                        }
+                        true
+                    }).unwrap();
+                    handle.perform().ok();
+                }
+
+                match handle.response_code() {
+                    Ok(429) => {
+                        if let Some(retry_after) = retry_after
+                            .as_ref()
+                            .map(|x| x.as_str())
+                            .and_then(parse_retry_after)
+                        {
+                            disabled = retry_after;
+                        }
+                    }
+                    Ok(200) | Ok(201) => {}
+                    _ => {
+                        sentry_debug!("Failed to send event");
+                    }
+                }
+
+                let mut size = queue_size.lock().unwrap();
+                *size -= 1;
+                if *size == 0 {
+                    signal.notify_all();
+                }
+            }
+        })
     }
 }
 
 #[cfg(feature = "with_reqwest_transport")]
-impl Drop for ReqwestHttpTransport {
-    fn drop(&mut self) {
-        sentry_debug!("dropping http transport");
-        self.shutdown_immediately.store(true, Ordering::SeqCst);
-        if let Ok(sender) = self.sender.lock() {
-            sender.send(None).ok();
-        }
-    }
-}
+type DefaultTransport = ReqwestHttpTransport;
+
+#[cfg(all(
+    feature = "with_curl_transport",
+    not(feature = "with_reqwest_transport")
+))]
+type DefaultTransport = CurlHttpTransport;
 
 /// The default http transport.
-#[cfg(feature = "with_reqwest_transport")]
-pub type HttpTransport = ReqwestHttpTransport;
+pub type HttpTransport = DefaultTransport;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -337,14 +337,14 @@ implement_http_transport! {
                 handle.url(&url).unwrap();
                 handle.custom_request("POST").unwrap();
 
-                if dsn.scheme() == Scheme::Https {
-                    if let Some(ref proxy) = https_proxy {
+                match (dsn.scheme(), &http_proxy, &https_proxy) {
+                    (Scheme::Https, _, &Some(ref proxy)) => {
                         handle.proxy(&proxy).unwrap();
                     }
-                } else {
-                    if let Some(ref proxy) = http_proxy {
+                    (_, &Some(ref proxy), _) => {
                         handle.proxy(&proxy).unwrap();
                     }
+                    _ => {}
                 }
 
                 let body = serde_json::to_vec(&event).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,7 @@
 //! Useful utilities for working with events.
 use std::thread;
 
-use crate::protocol::{
-    Context, DebugImage, DeviceContext, Map, OsContext, RuntimeContext, Stacktrace, Thread,
-};
+use crate::protocol::{Context, DebugImage, Stacktrace, Thread};
 
 #[cfg(all(feature = "with_device_info", target_os = "macos"))]
 mod model_support {
@@ -230,7 +228,7 @@ pub fn os_context() -> Option<Context> {
         use uname::uname;
         if let Ok(info) = uname() {
             Some(
-                OsContext {
+                crate::protocol::OsContext {
                     name: Some(info.sysname),
                     kernel_version: Some(info.version),
                     version: Some(info.release),
@@ -246,7 +244,7 @@ pub fn os_context() -> Option<Context> {
     {
         use crate::constants::PLATFORM;
         Some(
-            OsContext {
+            crate::protocol::OsContext {
                 name: Some(PLATFORM.into()),
                 ..Default::default()
             }
@@ -264,11 +262,11 @@ pub fn rust_context() -> Option<Context> {
     #[cfg(feature = "with_device_info")]
     {
         use crate::constants::{RUSTC_CHANNEL, RUSTC_VERSION};
-        let ctx = RuntimeContext {
+        let ctx = crate::protocol::RuntimeContext {
             name: Some("rustc".into()),
             version: RUSTC_VERSION.map(|x| x.into()),
             other: {
-                let mut map = Map::default();
+                let mut map = crate::protocol::Map::default();
                 if let Some(channel) = RUSTC_CHANNEL {
                     map.insert("channel".to_string(), channel.into());
                 }
@@ -292,7 +290,7 @@ pub fn device_context() -> Option<Context> {
         let family = device_family();
         let arch = cpu_arch();
         Some(
-            DeviceContext {
+            crate::protocol::DeviceContext {
                 model,
                 family,
                 arch,


### PR DESCRIPTION
This pull request provides two features: disabling all built in transports
and using curl as an optional transport instead of reqwest.

This should cut down on a lot of extra dependencies for users that do not
want to pull in all of tokio.