### PR TITLE
#130 Possibility to share Reqwest client with Sentry through `transport` config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 target
 Cargo.lock
 venv
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 venv
+.idea

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -221,7 +221,7 @@ implement_http_transport! {
         signal: Arc<Condvar>,
         shutdown_immediately: Arc<AtomicBool>,
         queue_size: Arc<Mutex<usize>>,
-        http_client: Arc<Client>,
+        http_client: Client,
     ) {
         let dsn = options.dsn.clone().unwrap();
         let user_agent = options.user_agent.to_string();
@@ -288,7 +288,7 @@ implement_http_transport! {
             }).unwrap()
     }
 
-    fn http_client(options: &ClientOptions, client: Option<Arc<Client>>) -> Arc<Client> {
+    fn http_client(options: &ClientOptions, client: Option<Client>) -> Client {
         if let Some(client) = client {
             client
         } else {
@@ -301,7 +301,7 @@ implement_http_transport! {
             if let Some(url) = https_proxy {
                 client = client.proxy(Proxy::https(&url).unwrap());
             };
-            Arc::new(client.build().unwrap())
+            client.build().unwrap()
         }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -441,7 +441,7 @@ implement_http_transport! {
     }
 
     fn http_client(_options: &ClientOptions, client: Option<curl::easy::Easy>) -> curl::easy::Easy {
-        client.unwrap_or_else(|| curl::easy::Easy::new())
+        client.unwrap_or_else(curl::easy::Easy::new)
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -102,7 +102,7 @@ impl TransportFactory for DefaultTransportFactory {
     fn create_transport(&self, options: &ClientOptions) -> Box<dyn Transport> {
         #[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
         {
-            Box::new(HttpTransport::new(options))
+            Box::new(HttpTransport::new(options, None))
         }
         #[cfg(not(any(feature = "with_reqwest_transport", feature = "with_curl_transport")))]
         {
@@ -127,6 +127,7 @@ macro_rules! implement_http_transport {
         $(#[$attr:meta])*
         pub struct $typename:ident;
         fn spawn($($argname:ident: $argty:ty,)*) $body:block
+        fn http_client($hc_options:ident: &ClientOptions, $hc_client:ident: Option<$hc_client_ty:ty>) -> $hc_ret:ty $hc_body:block
     ) => {
         $(#[$attr])*
         pub struct $typename {
@@ -139,20 +140,24 @@ macro_rules! implement_http_transport {
 
         impl $typename {
             /// Creates a new transport.
-            pub fn new(options: &ClientOptions) -> $typename {
+            pub fn new(options: &ClientOptions, $hc_client: Option<$hc_client_ty>) -> $typename {
                 fn spawn($($argname: $argty,)*) -> JoinHandle<()> { $body }
+
+                fn http_client($hc_options: &ClientOptions, $hc_client: Option<$hc_client_ty>) -> $hc_ret { $hc_body }
 
                 let (sender, receiver) = sync_channel(30);
                 let shutdown_signal = Arc::new(Condvar::new());
                 let shutdown_immediately = Arc::new(AtomicBool::new(false));
                 #[allow(clippy::mutex_atomic)]
                 let queue_size = Arc::new(Mutex::new(0));
+                let http_client = http_client(options, $hc_client);
                 let _handle = Some(spawn(
                     options,
                     receiver,
                     shutdown_signal.clone(),
                     shutdown_immediately.clone(),
                     queue_size.clone(),
+                    http_client,
                 ));
                 $typename {
                     sender: Mutex::new(sender),
@@ -216,19 +221,10 @@ implement_http_transport! {
         signal: Arc<Condvar>,
         shutdown_immediately: Arc<AtomicBool>,
         queue_size: Arc<Mutex<usize>>,
+        http_client: Arc<Client>,
     ) {
         let dsn = options.dsn.clone().unwrap();
         let user_agent = options.user_agent.to_string();
-        let http_proxy = options.http_proxy.as_ref().map(|x| x.to_string());
-        let https_proxy = options.https_proxy.as_ref().map(|x| x.to_string());
-        let mut client = Client::builder();
-        if let Some(url) = http_proxy {
-            client = client.proxy(Proxy::http(&url).unwrap());
-        };
-        if let Some(url) = https_proxy {
-            client = client.proxy(Proxy::https(&url).unwrap());
-        };
-        let client = client.build().unwrap();
 
         let mut disabled = None::<SystemTime>;
 
@@ -260,7 +256,7 @@ implement_http_transport! {
                         }
                     }
 
-                    match client
+                    match http_client
                         .post(url.as_str())
                         .json(&event)
                         .header("X-Sentry-Auth", dsn.to_auth(Some(&user_agent)).to_string())
@@ -291,6 +287,23 @@ implement_http_transport! {
                 }
             }).unwrap()
     }
+
+    fn http_client(options: &ClientOptions, client: Option<Arc<Client>>) -> Arc<Client> {
+        if let Some(client) = client {
+            client
+        } else {
+            let http_proxy = options.http_proxy.as_ref().map(|x| x.to_string());
+            let https_proxy = options.https_proxy.as_ref().map(|x| x.to_string());
+            let mut client = Client::builder();
+            if let Some(url) = http_proxy {
+                client = client.proxy(Proxy::http(&url).unwrap());
+            };
+            if let Some(url) = https_proxy {
+                client = client.proxy(Proxy::https(&url).unwrap());
+            };
+            Arc::new(client.build().unwrap())
+        }
+    }
 }
 
 #[cfg(feature = "with_curl_transport")]
@@ -306,6 +319,7 @@ implement_http_transport! {
         signal: Arc<Condvar>,
         shutdown_immediately: Arc<AtomicBool>,
         queue_size: Arc<Mutex<usize>>,
+        http_client: curl::easy::Easy,
     ) {
         let dsn = options.dsn.clone().unwrap();
         let user_agent = options.user_agent.to_string();
@@ -313,7 +327,7 @@ implement_http_transport! {
         let https_proxy = options.https_proxy.as_ref().map(|x| x.to_string());
 
         let mut disabled = None::<SystemTime>;
-        let mut handle = curl::easy::Easy::new();
+        let mut handle = http_client;
 
         thread::spawn(move || {
             sentry_debug!("spawning curl transport");
@@ -416,6 +430,14 @@ implement_http_transport! {
                 }
             }
         })
+    }
+
+    fn http_client(_options: &ClientOptions, client: Option<curl::easy::Easy>) -> curl::easy::Easy {
+        if let Some(client) = client {
+            client
+        } else {
+            curl::easy::Easy::new()
+        }
     }
 }
 


### PR DESCRIPTION
- Sharing through Arc is implemented only for Reqwest client that can be shared among threads.
- Curl client is not thread safe so it would require a mutex.

```
sentry::ClientOptions {
    transport: Box::new(|options: &sentry::ClientOptions| -> Box<sentry::internals::Transport> {
        Box::new(ReqwestHttpTransport::new(options, Some(http_client)))
    }),

    // ...
}
```