### PR TITLE
feat: add support for openssl-less builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ autoexamples = true
 all-features = true
 
 [features]
-default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info", "native-tls"]
+default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info", "with_native_tls"]
 with_reqwest_transport = ["reqwest", "httpdate", "with_client_implementation"]
 with_curl_transport = ["curl", "httpdate", "serde_json", "with_client_implementation"]
 with_default_transport = ["with_reqwest_transport"]
@@ -34,8 +34,8 @@ with_device_info = ["libc", "hostname", "uname", "with_client_implementation"]
 with_rust_info = ["rustc_version", "with_client_implementation"]
 with_debug_meta = ["findshlibs", "goblin", "memmap", "with_client_implementation"]
 with_test_support = []
-rustls = ["reqwest/rustls-tls"]
-native-tls = ["reqwest/default-tls"]
+with_rustls = ["reqwest/rustls-tls"]
+with_native_tls = ["reqwest/default-tls"]
 
 [dependencies]
 backtrace = { version = "0.3.15", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ autoexamples = true
 all-features = true
 
 [features]
-default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info"]
+default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info", "native-tls"]
 with_reqwest_transport = ["reqwest", "httpdate", "with_client_implementation"]
 with_curl_transport = ["curl", "httpdate", "serde_json", "with_client_implementation"]
 with_default_transport = ["with_reqwest_transport"]
@@ -34,6 +34,8 @@ with_device_info = ["libc", "hostname", "uname", "with_client_implementation"]
 with_rust_info = ["rustc_version", "with_client_implementation"]
 with_debug_meta = ["findshlibs", "goblin", "memmap", "with_client_implementation"]
 with_test_support = []
+rustls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/default-tls"]
 
 [dependencies]
 backtrace = { version = "0.3.15", optional = true }
@@ -42,7 +44,7 @@ failure = { version = "0.1.5", optional = true }
 log = { version = "0.4.6", optional = true, features = ["std"] }
 sentry-types = "0.11.0"
 env_logger = { version = "0.6.1", optional = true }
-reqwest = { version = "0.9.15", optional = true }
+reqwest = { version = "0.9.15", optional = true, default-features = false }
 lazy_static = "1.3.0"
 regex = { version = "1.1.6", optional = true }
 error-chain = { version = "0.12.0", optional = true }


### PR DESCRIPTION
This issue is related to #88 and would prevent issues like it when
openssl 1.2 comes out.

Currently, sentry-rust depends on reqwest with default feature flags,
which pulls in `native-tls` and `openssl`.

This causes multiple issues:

1. On systems without openssl header packages installed, openssl-sys
   won't build.
2. If distributions like arch linux update to newer versions of openssl,
   issues like #88 will arise
3. Systems that don't support openssl are not supported (although
   targeting embedded systems with non-unix OSes is probably not a goal
   in this project)

This commit adds support for building reqwest with rustls support, using
the new feature flag ~~`rustls`~~ `with_rustls`.

This fixes #136.