### PR TITLE
fix(backtrace): Support newer backtrace format

### DIFF
--- a/src/backtrace_support.rs
+++ b/src/backtrace_support.rs
@@ -21,9 +21,16 @@ pub static ref WELL_KNOWN_SYS_MODULES: Vec<&'static str> = {
         "sentry_types::",
         // these are not modules but things like __rust_maybe_catch_panic
         "__rust_",
+        "___rust_",
     ];
     #[cfg(feature = "with_failure")] {
         rv.push("failure::");
+    }
+    #[cfg(feature = "with_log")] {
+        rv.push("log::");
+    }
+    #[cfg(feature = "with_error_chain")] {
+        rv.push("error_chain::");
     }
     rv
 };
@@ -32,10 +39,13 @@ pub static ref WELL_KNOWN_BORDER_FRAMES: Vec<&'static str> = {
     #[allow(unused_mut)]
     let mut rv = vec![
         "std::panicking::begin_panic",
+        "core::panicking::panic",
     ];
     #[cfg(feature = "with_failure")] {
         rv.push("failure::error_message::err_msg");
         rv.push("failure::backtrace::Backtrace::new");
+        rv.push("failure::backtrace::internal::InternalBacktrace::new");
+        rv.push("failure::Fail::context");
     }
     #[cfg(feature = "with_log")] {
         rv.push("<sentry::integrations::log::Logger as log::Log>::log");


### PR DESCRIPTION
**TL;DR:** We need to resume the work on exposing `failure::Backtrace` internals.

Backtrace parsing for recent versions of `backtrace-rs` fails to obtain inline frames. The regular expression is now tidied up a little bit and supports both the old and new backtrace format in one go, along with inline frames. 

Additionally, crate name parsing was broken for the new Rust mangling schema, which no longer uses underscores in front of trait implementors and uses `::` instead of `..` for crate separators. 