### PR TITLE
Stop using std::sync::ONCE_INIT

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,8 +6,8 @@
 #[cfg(feature = "with_client_implementation")]
 macro_rules! release_name {
     () => {{
-        use std::sync::{Once, ONCE_INIT};
-        static mut INIT: Once = ONCE_INIT;
+        use std::sync::Once;
+        static mut INIT: Once = Once::new();
         static mut RELEASE: Option<String> = None;
         unsafe {
             INIT.call_once(|| {


### PR DESCRIPTION
I've got a couple of projects that require nightly and I've started to get a deprecation warning for `std::sync::ONCE_INIT`. Docs confirm it'll be marked from 1.38 ([link](https://doc.rust-lang.org/nightly/std/sync/constant.ONCE_INIT.html)).

`Once::new()` has been around since 1.20 and since this library claims to require at least 1.31 I figured I'd be safe to switch.