### PR TITLE
clippy: Switch to "cognitive_complexity" lint name

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -390,7 +390,7 @@ impl Client {
         }
     }
 
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     fn prepare_event(
         &self,
         mut event: Event<'static>,

--- a/src/scope/real.rs
+++ b/src/scope/real.rs
@@ -221,7 +221,7 @@ impl Scope {
     }
 
     /// Applies the contained scoped data to fill an event.
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     pub fn apply_to_event(&self, mut event: Event<'static>) -> Option<Event<'static>> {
         let mut add_os = true;
         let mut add_rust = true;


### PR DESCRIPTION
This was renamed upstream and the name `cognitive_complexity` can be used instead.  I think this will resolve the build errors that permeate the project at the moment.