### PR TITLE
fix(curl): Do not loop the same data when sending with curl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
 
     # Minimum Rust
     - env: SUITE=checkfast
-      rust: "1.31.0"
+      rust: "1.34.0"
     - env: SUITE=testfast
-      rust: "1.31.0"
+      rust: "1.34.0"
 
     # Build Docs
     - env: SUITE=travis-push-docs

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.31.0_.
+Additionally, the lowest Rust version we target is _1.34.0_.
 
 ## Resources
 

--- a/integrations/sentry-actix/README.md
+++ b/integrations/sentry-actix/README.md
@@ -18,7 +18,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.31.0_.
+Additionally, the lowest Rust version we target is _1.34.0_.
 
 ## Resources
 


### PR DESCRIPTION
Good bug.

The curl transport implementation works like this:
 - Serialize the event into an in-memory buffer
 - Determine the length of the buffer and let curl read it
 - In the read function, pass a chunk into the buffer

However, the read function always sliced the beginning of the buffer, rather than reading it chunk by chunk. This is fixed by wrapping the buffer into a cursor, which implements read correctly.