### PR TITLE
Slog integration, synchronization fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ with_backtrace = ["backtrace", "regex"]
 with_panic = ["with_backtrace"]
 with_failure = ["failure", "with_backtrace"]
 with_log = ["log", "with_backtrace"]
+with_slog = ["slog", "with_backtrace"]
 with_debug_to_log = ["log"]
 with_env_logger = ["with_log", "env_logger"]
 with_error_chain = ["error-chain", "with_backtrace"]
@@ -42,6 +43,7 @@ backtrace = { version = "0.3.15", optional = true }
 url = { version = "1.7.2", optional = true }
 failure = { version = "0.1.5", optional = true }
 log = { version = "0.4.6", optional = true, features = ["std"] }
+slog = { version = "2.5.2", optional = true, features = ["std"] }
 sentry-types = "0.11.0"
 env_logger = { version = "0.6.1", optional = true }
 reqwest = { version = "0.9.15", optional = true, default-features = false }

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -10,6 +10,9 @@ pub mod error_chain;
 #[cfg(feature = "with_log")]
 pub mod log;
 
+#[cfg(feature = "with_slog")]
+pub mod slog;
+
 #[cfg(feature = "with_env_logger")]
 pub mod env_logger;
 

--- a/src/integrations/slog.rs
+++ b/src/integrations/slog.rs
@@ -1,0 +1,169 @@
+//! Adds support for automatic breadcrumb capturing from logs
+//! by implementing the `slog::Drain`
+//!
+//! **Feature:** `with_slog`
+use slog::{Drain, Level as SlogLevel, Never, OwnedKVList, Record};
+
+use crate::api::add_breadcrumb;
+use crate::backtrace_support::current_stacktrace;
+use crate::hub::Hub;
+use crate::protocol::{Breadcrumb, Event, Exception, Level};
+
+/// Logger specific options.
+pub struct LoggerOptions {
+    /// The global filter that should be used (also used before dispatching
+    /// to the nested logger).
+    pub global_filter: Option<log::LevelFilter>,
+    /// The sentry specific log level filter (defaults to `Info`)
+    pub filter: log::LevelFilter,
+    /// If set to `true`, breadcrumbs will be emitted. (defaults to `true`)
+    pub emit_breadcrumbs: bool,
+    /// If set to `true` error events will be sent for errors in the log. (defaults to `true`)
+    pub emit_error_events: bool,
+    /// If set to `true` warning events will be sent for warnings in the log. (defaults to `false`)
+    pub emit_warning_events: bool,
+    /// If set to `true` current stacktrace will be resolved and attached
+    /// to each event. (expensive, defaults to `true`)
+    pub attach_stacktraces: bool,
+}
+
+impl Default for LoggerOptions {
+    fn default() -> LoggerOptions {
+        LoggerOptions {
+            global_filter: None,
+            filter: log::LevelFilter::Info,
+            emit_breadcrumbs: true,
+            emit_error_events: true,
+            emit_warning_events: false,
+            attach_stacktraces: true,
+        }
+    }
+}
+
+impl LoggerOptions {
+    /// Checks if an issue should be created.
+    fn create_issue_for_record(&self, record: &log::Record<'_>) -> bool {
+        match record.level() {
+            log::Level::Warn => self.emit_warning_events,
+            log::Level::Error => self.emit_error_events,
+            _ => false,
+        }
+    }
+}
+
+/// Provides a logger that wraps the sentry communication.
+pub struct Logger {
+    options: LoggerOptions,
+}
+
+impl Logger {
+    /// Initializes a new logger.
+    pub fn new(options: LoggerOptions) -> Logger {
+        Logger { options }
+    }
+
+    /// Returns the options of the logger.
+    pub fn options(&self) -> &LoggerOptions {
+        &self.options
+    }
+}
+
+/// Creates a breadcrumb from a given log record.
+pub fn breadcrumb_from_record(record: &log::Record<'_>) -> Breadcrumb {
+    Breadcrumb {
+        ty: "log".into(),
+        level: convert_log_level(record.level()),
+        category: Some(record.target().into()),
+        message: Some(format!("{}", record.args())),
+        ..Default::default()
+    }
+}
+
+/// Creates an event from a given log record.
+///
+/// If `with_stacktrace` is set to `true` then a stacktrace is attached
+/// from the current frame.
+pub fn event_from_record(record: &log::Record<'_>, with_stacktrace: bool) -> Event<'static> {
+    let culprit = format!("{}:{}",
+                          record.file().unwrap_or("<unknown>"),
+                          record.line().unwrap_or(0));
+    Event {
+        logger: Some(record.target().into()),
+        level: convert_log_level(record.level()),
+        exception: vec![Exception {
+            ty: record.target().into(),
+            value: Some(format!("{}", record.args())),
+            stacktrace: if with_stacktrace {
+                current_stacktrace()
+            } else {
+                None
+            },
+            ..Default::default()
+        }]
+            .into(),
+        culprit: Some(culprit),
+        ..Default::default()
+    }
+}
+
+
+fn convert_log_level(level: log::Level) -> Level {
+    match level {
+        log::Level::Error => Level::Error,
+        log::Level::Warn => Level::Warning,
+        log::Level::Info => Level::Info,
+        log::Level::Debug | log::Level::Trace => Level::Debug,
+    }
+}
+
+
+impl Drain for Logger {
+    type Ok = ();
+    type Err = Never;
+
+    fn log(&self, record: &Record, _values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        let level = to_log_level(record.level());
+        let md = log::MetadataBuilder::new().level(level).target(record.tag()).build();
+        let args = record.msg().clone();
+
+        let record = log::RecordBuilder::new()
+            .metadata(md)
+            .args(args)
+            .module_path(Some(record.module()))
+            .line(Some(record.line()))
+            .file(Some(record.file()))
+            .build();
+
+        if self.options.create_issue_for_record(&record) {
+            Hub::with_active(|hub| {
+                hub.capture_event(event_from_record(&record, self.options.attach_stacktraces))
+            });
+        }
+        if self.options.emit_breadcrumbs && record.level() <= self.options.filter {
+            add_breadcrumb(|| breadcrumb_from_record(&record))
+        }
+
+        Ok(())
+    }
+
+    fn is_enabled(&self, level: SlogLevel) -> bool {
+        let level = to_log_level(level);
+        if let Some(global_filter) = self.options.global_filter {
+            if level > global_filter {
+                return false;
+            }
+        }
+        level <= self.options.filter
+    }
+}
+
+
+fn to_log_level(level: SlogLevel) -> log::Level {
+    match level {
+        SlogLevel::Trace => log::Level::Trace,
+        SlogLevel::Debug => log::Level::Debug,
+        SlogLevel::Info => log::Level::Info,
+        SlogLevel::Warning => log::Level::Warn,
+        SlogLevel::Error | SlogLevel::Critical => log::Level::Error,
+    }
+}

--- a/src/integrations/slog.rs
+++ b/src/integrations/slog.rs
@@ -84,9 +84,11 @@ pub fn breadcrumb_from_record(record: &log::Record<'_>) -> Breadcrumb {
 /// If `with_stacktrace` is set to `true` then a stacktrace is attached
 /// from the current frame.
 pub fn event_from_record(record: &log::Record<'_>, with_stacktrace: bool) -> Event<'static> {
-    let culprit = format!("{}:{}",
-                          record.file().unwrap_or("<unknown>"),
-                          record.line().unwrap_or(0));
+    let culprit = format!(
+        "{}:{}",
+        record.file().unwrap_or("<unknown>"),
+        record.line().unwrap_or(0)
+    );
     Event {
         logger: Some(record.target().into()),
         level: convert_log_level(record.level()),
@@ -100,12 +102,11 @@ pub fn event_from_record(record: &log::Record<'_>, with_stacktrace: bool) -> Eve
             },
             ..Default::default()
         }]
-            .into(),
+        .into(),
         culprit: Some(culprit),
         ..Default::default()
     }
 }
-
 
 fn convert_log_level(level: log::Level) -> Level {
     match level {
@@ -116,15 +117,17 @@ fn convert_log_level(level: log::Level) -> Level {
     }
 }
 
-
 impl Drain for Logger {
     type Ok = ();
     type Err = Never;
 
     fn log(&self, record: &Record, _values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
         let level = to_log_level(record.level());
-        let md = log::MetadataBuilder::new().level(level).target(record.tag()).build();
-        let args = record.msg().clone();
+        let md = log::MetadataBuilder::new()
+            .level(level)
+            .target(record.tag())
+            .build();
+        let args = *record.msg();
 
         let record = log::RecordBuilder::new()
             .metadata(md)
@@ -156,7 +159,6 @@ impl Drain for Logger {
         level <= self.options.filter
     }
 }
-
 
 fn to_log_level(level: SlogLevel) -> log::Level {
     match level {


### PR DESCRIPTION
- added `integrations::slog::Logger` which implements `slog::Drain` to easily integrate with the popular [slog library](https://github.com/slog-rs/slog);
- fixed deadlock with shutting down the transport while having non-empty queue to send;
- explicitly join the transport thread after sending the stop signal to it 