### PR TITLE
Upgrade reqwest to 0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
 
     # Minimum Rust
     - env: SUITE=checkfast
-      rust: "1.36.0"
+      rust: "1.39.0"
     - env: SUITE=testfast
-      rust: "1.36.0"
+      rust: "1.39.0"
 
     # Build Docs
     - env: SUITE=travis-push-docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ failure = { version = "0.1.5", optional = true }
 log = { version = "0.4.6", optional = true, features = ["std"] }
 sentry-types = "0.11.0"
 env_logger = { version = "0.6.1", optional = true }
-reqwest = { version = "0.9.15", optional = true, default-features = false }
+reqwest = { version = "0.10.0-alpha.2", optional = true, default-features = false, features = ["blocking", "json", "rustls-tls"] }
 lazy_static = "1.3.0"
 regex = { version = "1.1.6", optional = true }
 error-chain = { version = "0.12.0", optional = true }
@@ -78,3 +78,8 @@ required-features = ["with_error_chain"]
 
 [workspace]
 members = [".", "integrations/sentry-actix"]
+
+
+
+[patch.crates-io]
+reqwest = { git = "https://github.com/seanmonstar/reqwest.git", rev = "18fd9a6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ failure = { version = "0.1.5", optional = true }
 log = { version = "0.4.6", optional = true, features = ["std"] }
 sentry-types = "0.11.0"
 env_logger = { version = "0.6.1", optional = true }
-reqwest = { version = "0.10.0-alpha.2", optional = true, default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.10.0", optional = true, default-features = false, features = ["blocking", "json", "rustls-tls"] }
 lazy_static = "1.3.0"
 regex = { version = "1.1.6", optional = true }
 error-chain = { version = "0.12.0", optional = true }
@@ -78,8 +78,3 @@ required-features = ["with_error_chain"]
 
 [workspace]
 members = [".", "integrations/sentry-actix"]
-
-
-
-[patch.crates-io]
-reqwest = { git = "https://github.com/seanmonstar/reqwest.git", rev = "18fd9a6" }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 use httpdate::parse_http_date;
 
 #[cfg(feature = "with_reqwest_transport")]
-use reqwest::{header::RETRY_AFTER, Client, Proxy};
+use reqwest::{blocking::Client, header::RETRY_AFTER, Proxy};
 
 #[cfg(feature = "with_curl_transport")]
 use {crate::internals::Scheme, curl, std::io::Read};


### PR DESCRIPTION
This can't be merged yet as it contains a git patch to use latest reqwest for rustls support, but will upgrade this to next reqwest official 0.10.0 release later.