### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
 
     # Minimum Rust
     - env: SUITE=checkfast
-      rust: "1.34.0"
+      rust: "1.36.0"
     - env: SUITE=testfast
-      rust: "1.34.0"
+      rust: "1.36.0"
 
     # Build Docs
     - env: SUITE=travis-push-docs

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.34.0_.
+Additionally, the lowest Rust version we target is _1.36.0_.
 
 ## Resources
 

--- a/integrations/sentry-actix/README.md
+++ b/integrations/sentry-actix/README.md
@@ -18,7 +18,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.34.0_.
+Additionally, the lowest Rust version we target is _1.36.0_.
 
 ## Resources
 

--- a/integrations/sentry-actix/src/lib.rs
+++ b/integrations/sentry-actix/src/lib.rs
@@ -8,12 +8,8 @@
 //!
 //! # Example
 //!
-//! ```
-//! extern crate actix_web;
-//! extern crate sentry;
-//! extern crate sentry_actix;
-//!
-//! # fn main() {
+#![allow(clippy::needless_doctest_main)]
+//! ```no_run
 //! use std::env;
 //! use std::io;
 //!
@@ -37,7 +33,6 @@
 //!         .unwrap()
 //!         .run();
 //! }
-//! # }
 //! ```
 //!
 //! # Reusing the Hub

--- a/src/client.rs
+++ b/src/client.rs
@@ -617,19 +617,13 @@ impl Drop for ClientInitGuard {
 /// # Examples
 ///
 /// ```rust
-/// fn main() {
-///     let _sentry = sentry::init("https://key@sentry.io/1234");
-/// }
+/// let _sentry = sentry::init("https://key@sentry.io/1234");
 /// ```
 ///
 /// Or if draining on shutdown should be ignored:
 ///
 /// ```rust
-/// use std::mem;
-///
-/// fn main() {
-///     mem::forget(sentry::init("https://key@sentry.io/1234"));
-/// }
+/// std::mem::forget(sentry::init("https://key@sentry.io/1234"));
 /// ```
 ///
 /// The guard returned can also be inspected to see if a client has been
@@ -638,14 +632,12 @@ impl Drop for ClientInitGuard {
 /// ```rust
 /// use sentry::integrations::panic::register_panic_handler;
 ///
-/// fn main() {
-///     let sentry = sentry::init(sentry::ClientOptions {
-///         release: Some("foo-bar-baz@1.0.0".into()),
-///         ..Default::default()
-///     });
-///     if sentry.is_enabled() {
-///         register_panic_handler();
-///     }
+/// let sentry = sentry::init(sentry::ClientOptions {
+///     release: Some("foo-bar-baz@1.0.0".into()),
+///     ..Default::default()
+/// });
+/// if sentry.is_enabled() {
+///     register_panic_handler();
 /// }
 /// ```
 ///

--- a/src/integrations/error_chain.rs
+++ b/src/integrations/error_chain.rs
@@ -8,7 +8,6 @@
 //! # Example
 //!
 //! ```no_run
-//! # extern crate sentry;
 //! # #[macro_use] extern crate error_chain;
 //! # error_chain! {}
 //! use sentry::integrations::error_chain::capture_error_chain;
@@ -22,7 +21,6 @@
 //!     }
 //! };
 //! # Ok(()) }
-//! # fn main() { test().unwrap() }
 //! ```
 use std::fmt::{Debug, Display};
 

--- a/src/integrations/failure.rs
+++ b/src/integrations/failure.rs
@@ -23,7 +23,6 @@
 //!     }
 //! };
 //! # Ok(()) }
-//! # fn main() { test().unwrap() }
 //! ```
 //!
 //! To capture fails and not errors use `capture_fail`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,10 @@
 //! of this.  Keep the guard around or sending events will not work.
 //!
 //! ```
-//! extern crate sentry;
-//!
-//! fn main() {
-//!     let _guard = sentry::init("https://key@sentry.io/42");
-//!     sentry::capture_message("Hello World!", sentry::Level::Info);
-//!     // when the guard goes out of scope here, the client will wait up to two
-//!     // seconds to send remaining events to the service.
-//! }
+//! let _guard = sentry::init("https://key@sentry.io/42");
+//! sentry::capture_message("Hello World!", sentry::Level::Info);
+//! // when the guard goes out of scope here, the client will wait up to two
+//! // seconds to send remaining events to the service.
 //! ```
 //!
 //! # Integrations

--- a/src/scope/real.rs
+++ b/src/scope/real.rs
@@ -168,7 +168,7 @@ impl Scope {
     /// Sets the fingerprint.
     pub fn set_fingerprint(&mut self, fingerprint: Option<&[&str]>) {
         self.fingerprint =
-            fingerprint.map(|fp| Arc::new(fp.iter().map(|x| Cow::Owned(x.to_string())).collect()))
+            fingerprint.map(|fp| Arc::new(fp.iter().map(|x| Cow::Owned((*x).to_string())).collect()))
     }
 
     /// Sets the transaction.

--- a/src/scope/real.rs
+++ b/src/scope/real.rs
@@ -167,8 +167,8 @@ impl Scope {
 
     /// Sets the fingerprint.
     pub fn set_fingerprint(&mut self, fingerprint: Option<&[&str]>) {
-        self.fingerprint =
-            fingerprint.map(|fp| Arc::new(fp.iter().map(|x| Cow::Owned((*x).to_string())).collect()))
+        self.fingerprint = fingerprint
+            .map(|fp| Arc::new(fp.iter().map(|x| Cow::Owned((*x).to_string())).collect()))
     }
 
     /// Sets the transaction.


### PR DESCRIPTION
Fixes failing clippy lints and bumps Rust version because dependencies are no longer compatible with 1.34.

Prevents unrelated CI failures in #173