### PR TITLE
build: Update most dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
 
     # Minimum Rust
     - env: SUITE=checkfast
-      rust: "1.39.0"
+      rust: "1.40.0"
     - env: SUITE=testfast
-      rust: "1.39.0"
+      rust: "1.40.0"
 
     # Build Docs
     - env: SUITE=travis-push-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
 
     # Minimum Rust
     - env: SUITE=checkfast
-      rust: "1.36.0"
+      rust: "1.39.0"
     - env: SUITE=testfast
-      rust: "1.36.0"
+      rust: "1.39.0"
 
     # Build Docs
     - env: SUITE=travis-push-docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ autoexamples = true
 all-features = true
 
 [features]
-default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_log", "with_env_logger", "with_device_info", "with_rust_info", "with_native_tls"]
+default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure", "with_device_info", "with_rust_info"]
 with_reqwest_transport = ["reqwest", "httpdate", "with_client_implementation"]
 with_curl_transport = ["curl", "httpdate", "serde_json", "with_client_implementation"]
-with_default_transport = ["with_reqwest_transport"]
-with_client_implementation = ["im", "url", "with_backtrace"]
+with_default_transport = ["with_reqwest_transport", "with_native_tls"]
+with_client_implementation = ["im", "url", "with_backtrace", "rand"]
 with_backtrace = ["backtrace", "regex"]
 with_panic = ["with_backtrace"]
 with_failure = ["failure", "with_backtrace"]
@@ -52,7 +52,7 @@ im = { version = "14.2.0", optional = true }
 libc = { version = "0.2.66", optional = true }
 hostname = { version = "0.3.0", optional = true }
 findshlibs = { version = "0.5.0", optional = true }
-rand = "0.7.3"
+rand = { version = "0.7.3", optional = true }
 httpdate = { version = "0.3.2", optional = true }
 curl = { version = "0.4.25", optional = true }
 serde_json = { version = "1.0.48", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ with_rustls = ["reqwest/rustls-tls"]
 with_native_tls = ["reqwest/default-tls"]
 
 [dependencies]
-backtrace = { version = "0.3.15", optional = true }
+backtrace = { version = "0.3.44", optional = true }
 url = { version = "2.1.1", optional = true }
 failure = { version = "0.1.6", optional = true }
 log = { version = "0.4.8", optional = true, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ failure = { version = "0.1.6", optional = true }
 log = { version = "0.4.8", optional = true, features = ["std"] }
 sentry-types = "0.14.1"
 env_logger = { version = "0.7.1", optional = true }
-reqwest = { version = "0.9.15", optional = true, default-features = false }
+reqwest = { version = "0.10.1", optional = true, features = ["blocking", "json"], default-features = false }
 lazy_static = "1.4.0"
 regex = { version = "1.3.4", optional = true }
 error-chain = { version = "0.12.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,23 +39,23 @@ with_native_tls = ["reqwest/default-tls"]
 
 [dependencies]
 backtrace = { version = "0.3.15", optional = true }
-url = { version = "1.7.2", optional = true }
-failure = { version = "0.1.5", optional = true }
-log = { version = "0.4.6", optional = true, features = ["std"] }
-sentry-types = "0.11.0"
-env_logger = { version = "0.6.1", optional = true }
+url = { version = "2.1.1", optional = true }
+failure = { version = "0.1.6", optional = true }
+log = { version = "0.4.8", optional = true, features = ["std"] }
+sentry-types = "0.14.1"
+env_logger = { version = "0.7.1", optional = true }
 reqwest = { version = "0.9.15", optional = true, default-features = false }
-lazy_static = "1.3.0"
-regex = { version = "1.1.6", optional = true }
-error-chain = { version = "0.12.0", optional = true }
-im = { version = "13.0.0", optional = true }
-libc = { version = "0.2.51", optional = true }
+lazy_static = "1.4.0"
+regex = { version = "1.3.4", optional = true }
+error-chain = { version = "0.12.1", optional = true }
+im = { version = "14.2.0", optional = true }
+libc = { version = "0.2.66", optional = true }
 hostname = { version = "0.3.0", optional = true }
 findshlibs = { version = "0.5.0", optional = true }
 rand = "0.7.3"
 httpdate = { version = "0.3.2", optional = true }
-curl = { version = "0.4.21", optional = true }
-serde_json = { version = "1.0.39", optional = true }
+curl = { version = "0.4.25", optional = true }
+serde_json = { version = "1.0.48", optional = true }
 
 [target."cfg(not(windows))".dependencies]
 uname = { version = "0.1.1", optional = true }
@@ -68,8 +68,8 @@ memmap = { version = "0.7.0", optional = true }
 rustc_version = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
-failure_derive = "0.1.5"
-pretty_env_logger = "0.3.0"
+failure_derive = "0.1.6"
+pretty_env_logger = "0.4.0"
 actix-web = { version = "0.7.19", default-features = false }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ with_env_logger = ["with_log", "env_logger"]
 with_error_chain = ["error-chain", "with_backtrace"]
 with_device_info = ["libc", "hostname", "uname", "with_client_implementation"]
 with_rust_info = ["rustc_version", "with_client_implementation"]
-with_debug_meta = ["findshlibs", "goblin", "memmap", "with_client_implementation"]
+with_debug_meta = ["findshlibs", "with_client_implementation"]
 with_test_support = []
 with_rustls = ["reqwest/rustls-tls"]
 with_native_tls = ["reqwest/default-tls"]
@@ -59,10 +59,6 @@ serde_json = { version = "1.0.48", optional = true }
 
 [target."cfg(not(windows))".dependencies]
 uname = { version = "0.1.1", optional = true }
-
-[target."cfg(unix)".dependencies]
-goblin = { version = "0.0.22", default-features = false, features = ["elf32", "elf64", "endian_fd", "std"], optional = true }
-memmap = { version = "0.7.0", optional = true }
 
 [build-dependencies]
 rustc_version = { version = "0.2.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,5 +72,13 @@ actix-web = { version = "0.7.19", default-features = false }
 name = "error-chain-demo"
 required-features = ["with_error_chain"]
 
+[[example]]
+name = "log-demo"
+required-features = ["with_env_logger"]
+
+[[example]]
+name = "thread-demo"
+required-features = ["with_env_logger"]
+
 [workspace]
 members = [".", "integrations/sentry-actix"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.36.0_.
+Additionally, the lowest Rust version we target is _1.39.0_.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.39.0_.
+Additionally, the lowest Rust version we target is _1.40.0_.
 
 ## Resources
 

--- a/build.rs
+++ b/build.rs
@@ -17,17 +17,22 @@ fn main() {
     #[cfg(feature = "with_rust_info")]
     {
         use rustc_version::{version, version_meta, Channel};
-        write!(
+        writeln!(
             f,
-            "/// The rustc version that was used to compile this crate\n"
+            "/// The rustc version that was used to compile this crate"
         )
         .ok();
         if let Ok(version) = version() {
-            write!(f, "#[allow(dead_code)] pub const RUSTC_VERSION: Option<&'static str> = Some(\"{}\");\n", version).ok();
-        } else {
-            write!(
+            writeln!(
                 f,
-                "#[allow(dead_code)] pub const RUSTC_VERSION: Option<&'static str> = None;\n"
+                "#[allow(dead_code)] pub const RUSTC_VERSION: Option<&'static str> = Some(\"{}\");",
+                version
+            )
+            .ok();
+        } else {
+            writeln!(
+                f,
+                "#[allow(dead_code)] pub const RUSTC_VERSION: Option<&'static str> = None;"
             )
             .ok();
         }
@@ -38,30 +43,35 @@ fn main() {
                 Channel::Beta => "beta",
                 Channel::Stable => "stable",
             };
-            write!(f, "#[allow(dead_code)] pub const RUSTC_CHANNEL: Option<&'static str> = Some(\"{}\");\n", chan).ok();
-        } else {
-            write!(
+            writeln!(
                 f,
-                "#[allow(dead_code)] pub const RUSTC_CHANNEL: Option<&'static str> = None;\n"
+                "#[allow(dead_code)] pub const RUSTC_CHANNEL: Option<&'static str> = Some(\"{}\");",
+                chan
+            )
+            .ok();
+        } else {
+            writeln!(
+                f,
+                "#[allow(dead_code)] pub const RUSTC_CHANNEL: Option<&'static str> = None;"
             )
             .ok();
         }
     }
 
-    write!(f, "/// The platform identifier\n").ok();
-    write!(
+    writeln!(f, "/// The platform identifier").ok();
+    writeln!(
         f,
-        "#[allow(dead_code)] pub const PLATFORM: &str = \"{}\";\n",
+        "#[allow(dead_code)] pub const PLATFORM: &str = \"{}\";",
         platform
     )
     .ok();
-    write!(f, "/// The CPU architecture identifier\n").ok();
-    write!(
+    writeln!(f, "/// The CPU architecture identifier").ok();
+    writeln!(
         f,
-        "#[allow(dead_code)] pub const ARCH: &str = \"{}\";\n",
+        "#[allow(dead_code)] pub const ARCH: &str = \"{}\";",
         arch
     )
     .ok();
-    println!("cargo:rerun-if-changed=build.rs\n");
-    println!("cargo:rerun-if-changed=Cargo.toml\n");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
 }

--- a/integrations/sentry-actix/README.md
+++ b/integrations/sentry-actix/README.md
@@ -18,7 +18,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.39.0_.
+Additionally, the lowest Rust version we target is _1.40.0_.
 
 ## Resources
 

--- a/integrations/sentry-actix/README.md
+++ b/integrations/sentry-actix/README.md
@@ -18,7 +18,7 @@ We currently only verify this crate against a recent version of Sentry hosted on
 [sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.36.0_.
+Additionally, the lowest Rust version we target is _1.39.0_.
 
 ## Resources
 

--- a/integrations/sentry-actix/src/lib.rs
+++ b/integrations/sentry-actix/src/lib.rs
@@ -41,9 +41,6 @@
 //! To get the request specific one you need to use the `ActixWebHubExt` trait:
 //!
 //! ```
-//! # extern crate sentry;
-//! # extern crate sentry_actix;
-//! # extern crate actix_web;
 //! # fn test(req: &actix_web::HttpRequest) {
 //! use sentry::{Hub, Level};
 //! use sentry_actix::ActixWebHubExt;
@@ -56,9 +53,6 @@
 //! The hub can also be made current:
 //!
 //! ```
-//! # extern crate sentry;
-//! # extern crate sentry_actix;
-//! # extern crate actix_web;
 //! # fn test(req: &actix_web::HttpRequest) {
 //! use sentry::{Hub, Level};
 //! use sentry_actix::ActixWebHubExt;

--- a/src/backtrace_support.rs
+++ b/src/backtrace_support.rs
@@ -116,7 +116,7 @@ pub fn demangle_symbol(s: &str) -> String {
 #[allow(unused)]
 pub fn error_typename<D: fmt::Debug>(error: D) -> String {
     format!("{:?}", error)
-        .split(&['(', '{'][..])
+        .split(&[' ', '(', '{', '\r', '\n'][..])
         .next()
         .unwrap()
         .trim()

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use crate::backtrace_support::{function_starts_with, is_sys_function, trim_stacktrace};
 use crate::constants::{SDK_INFO, USER_AGENT};
 use crate::hub::Hub;
-use crate::internals::{Dsn, DsnParseError, Uuid};
+use crate::internals::{Dsn, ParseDsnError, Uuid};
 use crate::protocol::{Breadcrumb, DebugMeta, Event};
 use crate::scope::Scope;
 use crate::transport::{DefaultTransportFactory, Transport, TransportFactory};
@@ -236,7 +236,7 @@ fn parse_crate_name(func_name: &str) -> Option<String> {
 /// null values result in no DSN being parsed.
 pub trait IntoDsn {
     /// Converts the value into a `Result<Option<Dsn>, E>`.
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError>;
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError>;
 }
 
 impl<T: Into<ClientOptions>> From<T> for Client {
@@ -262,7 +262,7 @@ impl<T: IntoDsn> From<T> for ClientOptions {
 }
 
 impl<I: IntoDsn> IntoDsn for Option<I> {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         match self {
             Some(into_dsn) => into_dsn.into_dsn(),
             None => Ok(None),
@@ -271,13 +271,13 @@ impl<I: IntoDsn> IntoDsn for Option<I> {
 }
 
 impl IntoDsn for () {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         Ok(None)
     }
 }
 
 impl<'a> IntoDsn for &'a str {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         if self.is_empty() {
             Ok(None)
         } else {
@@ -287,38 +287,38 @@ impl<'a> IntoDsn for &'a str {
 }
 
 impl<'a> IntoDsn for Cow<'a, str> {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         let x: &str = &self;
         x.into_dsn()
     }
 }
 
 impl<'a> IntoDsn for &'a OsStr {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         self.to_string_lossy().into_dsn()
     }
 }
 
 impl IntoDsn for OsString {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         self.as_os_str().into_dsn()
     }
 }
 
 impl IntoDsn for String {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         self.as_str().into_dsn()
     }
 }
 
 impl<'a> IntoDsn for &'a Dsn {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         Ok(Some(self.clone()))
     }
 }
 
 impl IntoDsn for Dsn {
-    fn into_dsn(self) -> Result<Option<Dsn>, DsnParseError> {
+    fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         Ok(Some(self))
     }
 }

--- a/src/integrations/env_logger.rs
+++ b/src/integrations/env_logger.rs
@@ -8,7 +8,6 @@
 //! from `env_logger` and pass `None` as logger:
 //!
 //! ```no_run
-//! # extern crate sentry;
 //! sentry::integrations::env_logger::init(None, Default::default());
 //! ```
 //!
@@ -17,10 +16,8 @@
 //! accordingly:
 //!
 //! ```no_run
-//! # extern crate sentry;
-//! # extern crate pretty_env_logger;
 //! let mut log_builder = pretty_env_logger::formatted_builder();
-//! log_builder.parse("info,foo=debug");
+//! log_builder.parse_filters("info,foo=debug");
 //! sentry::integrations::env_logger::init(Some(log_builder.build()), Default::default());
 //! ```
 use crate::integrations::log::{self as sentry_log, LoggerOptions};

--- a/src/integrations/failure.rs
+++ b/src/integrations/failure.rs
@@ -132,7 +132,8 @@ pub fn exception_from_single_fail<F: Fail + ?Sized>(
         module,
         value: Some(f.to_string()),
         stacktrace: bt
-            .map(failure::Backtrace::to_string)
+            // format the stack trace with alternate debug to get addresses
+            .map(|bt| format!("{:#?}", bt))
             .and_then(|x| parse_stacktrace(&x)),
         ..Default::default()
     }
@@ -270,5 +271,47 @@ fn test_parse_stacktrace() {
     assert_eq!(
         stacktrace.frames[1].instruction_addr,
         Some(Addr(0x55a1_2174_de62))
+    );
+}
+
+#[test]
+fn test_parse_stacktrace_alternate() {
+    use crate::protocol::Addr;
+
+    let backtrace = r#"
+   1:        0x104f87e23 - backtrace::backtrace::trace::he6b6038e0eef17f8
+                               at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.44/src/backtrace/mod.rs:53
+   2:        0x104f7a6f7 - backtrace::capture::Backtrace::create::h10a127635da03d41
+                               at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.44/src/capture.rs:164
+   3:        0x104fb9f4f - __rust_maybe_catch_panic
+                               at src/libpanic_unwind/lib.rs:78
+   4:        0x104fb784e - std::panicking::try::h989c79f60ffdf02a
+                               at src/libstd/panicking.rs:270
+                           std::panic::catch_unwind::hd3f56528916c87b0
+                               at src/libstd/panic.rs:394
+                           std::rt::lang_start_internal::h3d261fac4b6382f2
+                               at src/libstd/rt.rs:51
+   5:        0x1046a06a2 - std::rt::lang_start::h8baa07060377e0b8
+                               at /rustc/5e1a799842ba6ed4a57e91f7ab9435947482f7d8/src/libstd/rt.rs:67
+   6:        0x10469fb62 - main
+"#;
+
+    let stacktrace = parse_stacktrace(backtrace).expect("stacktrace");
+    assert_eq!(stacktrace.frames.len(), 8);
+
+    assert_eq!(stacktrace.frames[0].function, Some("main".into()));
+    assert_eq!(
+        stacktrace.frames[0].instruction_addr,
+        Some(Addr(0x1_0469_fb62))
+    );
+
+    // Inlined frame, inherits address from parent
+    assert_eq!(
+        stacktrace.frames[3].function,
+        Some("std::panic::catch_unwind".into())
+    );
+    assert_eq!(
+        stacktrace.frames[1].instruction_addr,
+        Some(Addr(0x1_046a_06a2))
     );
 }

--- a/src/integrations/failure.rs
+++ b/src/integrations/failure.rs
@@ -10,8 +10,6 @@
 //! # Example
 //!
 //! ```no_run
-//! # extern crate sentry;
-//! # extern crate failure;
 //! # fn function_that_might_fail() -> Result<(), failure::Error> { Ok(()) }
 //! use sentry::integrations::failure::capture_error;
 //! # fn test() -> Result<(), failure::Error> {

--- a/src/integrations/log.rs
+++ b/src/integrations/log.rs
@@ -14,10 +14,8 @@
 //! env logger crate:
 //!
 //! ```no_run
-//! # extern crate sentry;
-//! # extern crate pretty_env_logger;
 //! let mut log_builder = pretty_env_logger::formatted_builder();
-//! log_builder.parse("info");  // or env::var("RUST_LOG")
+//! log_builder.parse_filters("info");  // or env::var("RUST_LOG")
 //! let logger = log_builder.build();
 //! let options = sentry::integrations::log::LoggerOptions {
 //!     global_filter: Some(logger.filter()),
@@ -225,7 +223,6 @@ fn convert_log_level(level: log::Level) -> Level {
 ///
 /// ```ignore
 /// use sentry::integrations::log;
-/// use env_logger;
 ///
 /// let builder = env_logger::Builder::from_default_env();
 /// let logger = builder.build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,8 @@ pub mod internals {
     };
 
     pub use sentry_types::{
-        Auth, ChronoParseError, DateTime, DebugId, Dsn, DsnParseError, ParseDebugIdError,
-        ProjectId, ProjectIdParseError, Scheme, TimeZone, Utc, Uuid, UuidVariant, UuidVersion,
+        Auth, ChronoParseError, DateTime, DebugId, Dsn, ParseDebugIdError, ParseDsnError,
+        ParseProjectIdError, ProjectId, Scheme, TimeZone, Utc, Uuid, UuidVariant, UuidVersion,
     };
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,7 +11,7 @@ use std::io::Cursor;
 use httpdate::parse_http_date;
 
 #[cfg(feature = "with_reqwest_transport")]
-use reqwest::{header::RETRY_AFTER, Client, Proxy};
+use reqwest::{blocking::Client, header::RETRY_AFTER, Proxy};
 
 #[cfg(feature = "with_curl_transport")]
 use {crate::internals::Scheme, curl, std::io::Read};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -216,7 +216,7 @@ pub fn os_context() -> Option<Context> {
 
 /// Returns the rust info.
 pub fn rust_context() -> Option<Context> {
-    #[cfg(feature = "with_device_info")]
+    #[cfg(feature = "with_rust_info")]
     {
         use crate::constants::{RUSTC_CHANNEL, RUSTC_VERSION};
         let ctx = crate::protocol::RuntimeContext {
@@ -233,7 +233,7 @@ pub fn rust_context() -> Option<Context> {
         .into();
         Some(ctx)
     }
-    #[cfg(not(feature = "with_device_info"))]
+    #[cfg(not(feature = "with_rust_info"))]
     {
         None
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,6 @@ use crate::protocol::{Context, DebugImage, Stacktrace, Thread};
 
 #[cfg(all(feature = "with_device_info", target_os = "macos"))]
 mod model_support {
-    use libc;
     use libc::c_void;
     use regex::Regex;
     use std::ptr;

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "with_test_support")]
 
-extern crate sentry;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -3,8 +3,6 @@
 use std::panic;
 use std::sync::Arc;
 
-extern crate sentry;
-
 #[test]
 fn test_into_client() {
     let c: sentry::Client = sentry::Client::from_config("https://public@example.com/42");
@@ -13,7 +11,7 @@ fn test_into_client() {
         assert_eq!(dsn.public_key(), "public");
         assert_eq!(dsn.host(), "example.com");
         assert_eq!(dsn.scheme(), sentry::internals::Scheme::Https);
-        assert_eq!(dsn.project_id(), 42.into());
+        assert_eq!(dsn.project_id().value(), 42);
     }
 
     let c: sentry::Client = sentry::Client::from_config((
@@ -28,7 +26,7 @@ fn test_into_client() {
         assert_eq!(dsn.public_key(), "public");
         assert_eq!(dsn.host(), "example.com");
         assert_eq!(dsn.scheme(), sentry::internals::Scheme::Https);
-        assert_eq!(dsn.project_id(), 42.into());
+        assert_eq!(dsn.project_id().value(), 42);
         assert_eq!(&c.options().release.as_ref().unwrap(), &"foo@1.0");
     }
 

--- a/tests/test_log.rs
+++ b/tests/test_log.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "with_test_support")]
 
-extern crate log;
-extern crate sentry;
-
 #[test]
 fn test_log() {
     sentry::integrations::log::init(None, Default::default());

--- a/tests/test_log.rs
+++ b/tests/test_log.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "with_test_support")]
+#![cfg(feature = "with_log")]
 
 #[test]
 fn test_log() {

--- a/tests/test_processors.rs
+++ b/tests/test_processors.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "with_test_support")]
 
-extern crate sentry;
-
 use std::sync::Arc;
 
 #[test]


### PR DESCRIPTION
Note that this is a minimal effort to bring `sentry-rust` up to speed. We will be looking into trimming it down and adding more integrations at a later point.

Fixes #156
Fixes #159
Fixes #171
Fixes #182