### PR TITLE
Updated documentation of default enabled/disabled of integrations

### DIFF
--- a/src/integrations/env_logger.rs
+++ b/src/integrations/env_logger.rs
@@ -1,6 +1,6 @@
 //! Adds support for automatic breadcrumb capturing from logs with `env_logger`.
 //!
-//! **Feature:** `with_env_logger` (*enabled by default*)
+//! **Feature:** `with_env_logger` (*disabled by default*)
 //!
 //! # Configuration
 //!

--- a/src/integrations/log.rs
+++ b/src/integrations/log.rs
@@ -1,6 +1,6 @@
 //! Adds support for automatic breadcrumb capturing from logs.
 //!
-//! **Feature:** `with_log` (*enabled by default*)
+//! **Feature:** `with_log` (*disabled by default*)
 //!
 //! The `log` crate is supported in two ways.  First events can be captured as
 //! breadcrumbs for later, secondly error events can be logged as events to


### PR DESCRIPTION
These now match the default enabled/disabled state defined in `Cargo.toml` and the top level documentation.