### PR TITLE
update backtrace dependency and add gimli-symbolize feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ with_rustls = ["reqwest/rustls-tls"]
 with_native_tls = ["reqwest/default-tls"]
 
 [dependencies]
-backtrace = { version = "0.3.44", optional = true }
+backtrace = { version = "0.3.46", optional = true, features = ["gimli-symbolize"] }
 url = { version = "2.1.1", optional = true }
 failure = { version = "0.1.6", optional = true }
 log = { version = "0.4.8", optional = true, features = ["std"] }


### PR DESCRIPTION
I have updated the backtrace dependency and add `gimli-symbolize` feature flag.
This feature flag seems to fix the issue https://github.com/getsentry/sentry-rust/issues/188.
I found how to fix it in the issue https://github.com/rust-lang/backtrace-rs/issues/150.