### PR TITLE
ref: Create the sentry-core crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "sentry",
     "sentry-actix",
+    "sentry-core",
 ]

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sentry-core"
+version = "0.1.0"
+authors = ["Sentry <hello@sentry.io>"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/getsentry/sentry-rust"
+homepage = "https://github.com/getsentry/sentry-rust"
+documentation = "https://getsentry.github.io/sentry-rust"
+description = """
+Core sentry library used for instrumentation and integration development.
+"""
+edition = "2018"
+
+[dependencies]
+sentry-types = "0.15.0"

--- a/sentry-core/README.md
+++ b/sentry-core/README.md
@@ -5,21 +5,13 @@
   <br />
 </p>
 
-# Sentry Rust
+# Sentry-Core
 
 [![Build Status](https://travis-ci.com/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.com/getsentry/sentry-rust)
 [![Crates.io](https://img.shields.io/crates/v/sentry.svg?style=flat)](https://crates.io/crates/sentry)
 
-This workspace contains various crates that provide support for logging events
-and errors / panics to the [Sentry](https://sentry.io/) error logging service.
-
-- [sentry](./sentry) The main `sentry` crate aimed at application users that
-  want to log events to sentry.
-- [sentry-actix](./sentry-actix) An integration for the `actix-web (0.7)`
-  framework.
-- [sentry-core](./sentry-core) The core of `sentry`, which can be used to
-  instrument code, and to write integrations that generate events or hook into
-  event processing.
+The core of `sentry`, which can be used to instrument code, and to write
+integrations that generate events or hook into event processing.
 
 **Note**: Until the _1.0_ release, the crates in this repository are considered work in
 progress and do not follow semver semantics. Between minor releases, we might
@@ -36,7 +28,7 @@ Additionally, the lowest Rust version we target is _1.40.0_.
 
 ## Resources
 
-- [crates.io](https://crates.io/crates/sentry)
+- [crates.io](https://crates.io/crates/sentry-core)
 - [Documentation](https://getsentry.github.io/sentry-rust)
 - [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
 - [Discord](https://discord.gg/ez5KZN7) server for project discussions.

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -12,15 +12,15 @@ use crate::{Event, Hub, IntoBreadcrumbs, Level, Scope, Uuid};
 ///
 /// # Example
 ///
-/// ```
-/// use sentry_core::{Event, Level};
+/// ```should_panic
+/// use sentry_core::{Event, Level, Uuid};
 ///
 /// let uuid = Uuid::new_v4();
 /// let event = Event {
 ///     event_id: uuid,
 ///     message: Some("Hello World!".into()),
 ///     level: Level::Info,
-///     ..Default::default(),
+///     ..Default::default()
 /// };
 ///
 /// assert_eq!(sentry_core::capture_event(event.clone()), None);
@@ -59,7 +59,7 @@ pub fn capture_message(msg: &str, level: Level) -> Option<Uuid> {
 ///
 /// # Example
 ///
-/// ```
+/// ```should_panic
 /// use sentry_core::protocol::{Breadcrumb, Map};
 ///
 /// sentry_core::add_breadcrumb(|| Breadcrumb {
@@ -90,7 +90,7 @@ pub fn add_breadcrumb<B: IntoBreadcrumbs>(breadcrumbs: B) {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```compile_fail
 /// sentry_core::configure_scope(|scope| {
 ///     scope.set_user(Some(sentry_core::User {
 ///         username: Some("john_doe".into()),
@@ -127,7 +127,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```compile_fail
 /// use sentry_core::Level;
 ///
 /// sentry_core::with_scope(
@@ -152,8 +152,8 @@ where
 ///
 /// # Example
 ///
-/// ```
-/// assert_eq!(last_event_id(), None);
+/// ```should_panic
+/// assert_eq!(sentry_core::last_event_id(), None);
 ///
 /// // TODO: init, capture and assert the ID
 /// ```

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -1,0 +1,162 @@
+use crate::{Event, Hub, IntoBreadcrumbs, Level, Scope, Uuid};
+
+/// Captures an event on the currently active client if any.
+///
+/// The event must already be assembled. Typically code would instead use
+/// the utility methods like `capture_message` or other integration provided
+/// methods.
+///
+/// The return value is the event ID, or `None` in case there is no active
+/// client, or the event has been discarded due to rate limiting or one of the
+/// event processors.
+///
+/// # Example
+///
+/// ```
+/// use sentry_core::{Event, Level};
+///
+/// let uuid = Uuid::new_v4();
+/// let event = Event {
+///     event_id: uuid,
+///     message: Some("Hello World!".into()),
+///     level: Level::Info,
+///     ..Default::default(),
+/// };
+///
+/// assert_eq!(sentry_core::capture_event(event.clone()), None);
+///
+/// // TODO: init sentry
+///
+/// assert_eq!(sentry_core::capture_event(event), Some(uuid));
+/// ```
+pub fn capture_event(event: Event<'static>) -> Option<Uuid> {
+    Hub::with_active(|hub| hub.capture_event(event))
+}
+
+/// Captures an arbitrary message.
+///
+/// This creates an event from the given message and sends it via
+/// [`capture_event`](fn.capture_event.html).
+pub fn capture_message(msg: &str, level: Level) -> Option<Uuid> {
+    Hub::with_active(|hub| hub.capture_message(msg, level))
+}
+
+/// Records a new breadcrumb.
+///
+/// The total number of breadcrumbs that can be recorded is limited by the
+/// configuration on the client. This function accepts any type that
+/// implements `IntoBreadcrumbs` which is implemented for a varienty of
+/// common types. For efficiency reasons you can also pass a closure returning
+/// a breadcrumb in which case the closure is only called if the client is
+/// enabled.
+///
+/// The most common implementations that can be passed:
+///
+/// * `Breadcrumb`: to directly record a single breadcrumb.
+/// * `Vec<Breadcrumb>`: to record more than one breadcrumb in one go.
+/// * `Option<Breadcrumb>`: to record an optional breadcrumb.
+/// * additionally all of these can also be returned from a `FnOnce()`.
+///
+/// # Example
+///
+/// ```
+/// use sentry_core::protocol::{Breadcrumb, Map};
+///
+/// sentry_core::add_breadcrumb(|| Breadcrumb {
+///     ty: "http".into(),
+///     category: Some("request".into()),
+///     data: {
+///         let mut map = Map::new();
+///         map.insert("method".into(), "GET".into());
+///         map.insert("url".into(), "https://example.com/".into());
+///         map
+///     },
+///     ..Default::default()
+/// });
+///
+/// // TODO: init, capture and assert breadcrumb
+/// ```
+pub fn add_breadcrumb<B: IntoBreadcrumbs>(breadcrumbs: B) {
+    Hub::with_active(|hub| hub.add_breadcrumb(breadcrumbs))
+}
+
+/// Invokes a function that can modify the current scope.
+///
+/// The function is passed a mutable reference to the `Scope` so that
+/// modifications can be performed. Because there might currently not be a
+/// scope or client active it's possible that the callback might not be called
+/// at all. As a result of this, the return value of this closure must have a
+/// default that is returned in such cases.
+///
+/// # Example
+///
+/// ```rust
+/// sentry_core::configure_scope(|scope| {
+///     scope.set_user(Some(sentry_core::User {
+///         username: Some("john_doe".into()),
+///         ..Default::default()
+///     }));
+/// });
+///
+/// // TODO: init, capture and assert user
+/// ```
+///
+/// # Panics
+///
+/// TODO: update the comment
+/// While the scope is being configured accessing scope related functionality is
+/// not permitted. In this case a wide range of panics will be raised. It's
+/// unsafe to call into `sentry::bind_client` or similar functions from within
+/// the callback as a result of this.
+pub fn configure_scope<F, R>(f: F) -> R
+where
+    R: Default,
+    F: FnOnce(&mut Scope) -> R,
+{
+    Hub::with_active(|hub| hub.configure_scope(f))
+}
+
+/// Temporarily pushes a scope for a single call optionally reconfiguring it.
+///
+/// This function takes two arguments: the first is a callback that is passed
+/// a scope and can reconfigure it. The second is a callback that then executes
+/// in the context of that scope.
+///
+/// This is useful when extra data should be send with a single capture call,
+/// for instance a different level or tags:
+///
+/// # Example
+///
+/// ```
+/// use sentry_core::Level;
+///
+/// sentry_core::with_scope(
+///     |scope| scope.set_level(Level::Warning),
+///     || sentry_core::capture_message("Foobar", Level::Info),
+/// );
+///
+/// // TODO: init and assert the level override
+/// ```
+pub fn with_scope<C, F, R>(scope_config: C, callback: F) -> R
+where
+    C: FnOnce(&mut Scope),
+    F: FnOnce() -> R,
+{
+    Hub::with(|hub| hub.with_scope(scope_config, callback))
+}
+
+/// Returns the last event ID captured.
+///
+/// Returns `None` if no even was previously captured, or all captured events
+/// have been discarded.
+///
+/// # Example
+///
+/// ```
+/// assert_eq!(last_event_id(), None);
+///
+/// // TODO: init, capture and assert the ID
+/// ```
+pub fn last_event_id() -> Option<Uuid> {
+    Hub::with(|hub| hub.last_event_id())
+}

--- a/sentry-core/src/breadcrumbs.rs
+++ b/sentry-core/src/breadcrumbs.rs
@@ -1,0 +1,42 @@
+use crate::Breadcrumb;
+
+/// A helper trait that converts self into an Iterator of Breadcrumbs
+pub trait IntoBreadcrumbs {
+    /// The iterator type for the breadcrumbs.
+    type Output: Iterator<Item = Breadcrumb>;
+
+    /// This converts the object into an optional breadcrumb.
+    fn into_breadcrumbs(self) -> Self::Output;
+}
+
+impl IntoBreadcrumbs for Breadcrumb {
+    type Output = std::iter::Once<Breadcrumb>;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        std::iter::once(self)
+    }
+}
+
+impl IntoBreadcrumbs for Vec<Breadcrumb> {
+    type Output = std::vec::IntoIter<Breadcrumb>;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        self.into_iter()
+    }
+}
+
+impl IntoBreadcrumbs for Option<Breadcrumb> {
+    type Output = std::option::IntoIter<Breadcrumb>;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        self.into_iter()
+    }
+}
+
+impl<F: FnOnce() -> I, I: IntoBreadcrumbs> IntoBreadcrumbs for F {
+    type Output = I::Output;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        self().into_breadcrumbs()
+    }
+}

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -1,0 +1,2 @@
+/// TODO
+pub struct Client {}

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -1,0 +1,152 @@
+use crate::{Client, Event, IntoBreadcrumbs, Level, Scope, ScopeGuard, Uuid};
+
+/// The central object that can manages scopes and clients.
+///
+/// This can be used to capture events and manage the scope. This object is
+/// internally synchronized so it can be used from multiple threads if needed.
+/// The default hub that is available automatically is thread local.
+///
+/// See the
+/// [Unified API](https://docs.sentry.io/development/sdk-dev/unified-api/#hub)
+/// documentation for further details.
+///
+/// In most situations developers do not need to interface with the Hub
+/// directly. Instead, toplevel convenience functions are exposed that will
+/// automatically dispatch to the thread local (`Hub::current`) Hub. In some
+/// situations this might not be possible, in which case it might become
+/// necessary to manually work with the Hub. This is for instance the case when
+/// working with async code.
+///
+/// Hubs that are wrapped in `Arc`s can be bound to the current thread with
+/// the `run` static method.
+#[derive(Clone)]
+pub struct Hub {}
+
+impl Hub {
+    /// Creates a new hub from the given client and scope.
+    pub fn new(client: Option<Client>, scope: Scope) -> Hub {
+        todo!()
+    }
+
+    /// Creates a new hub based on the top scope of the given hub.
+    pub fn new_from_top<H: AsRef<Hub>>(other: H) -> Hub {
+        todo!()
+    }
+
+    /// Returns the current thread local hub.
+    pub fn current() -> Hub {
+        Hub::with(Clone::clone)
+    }
+
+    /// Returns the main thread's hub.
+    ///
+    /// This is similar to `current` but instead of picking the current
+    /// thread's hub it returns the main thread's hub instead.
+    pub fn main() -> Hub {
+        todo!()
+    }
+
+    /// Invokes the callback with the current hub.
+    ///
+    /// This is a slightly more efficient version than `Hub::current()`, as it
+    /// avoids a `clone`.
+    pub fn with<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Hub) -> R,
+    {
+        todo!()
+    }
+
+    /// Like `Hub::with` but only calls the function if a client is bound.
+    ///
+    /// This is useful for integrations that want to do efficiently nothing if
+    /// there is no client bound. Additionally this internally ensures that the
+    /// client can be safely synchronized.
+    /// This prevents accidental recursive calls into the client.
+    pub fn with_active<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Hub) -> R,
+        R: Default,
+    {
+        todo!()
+    }
+
+    pub fn run<F: FnOnce() -> R, R>(hub: Hub, f: F) -> R {
+        todo!()
+    }
+
+    /// Sends the event to the current client with the current scope.
+    ///
+    /// See the global [`capture_event`](fn.capture_event.html)
+    /// for more documentation.
+    pub fn capture_event(&self, event: Event<'static>) -> Option<Uuid> {
+        todo!()
+    }
+
+    /// Captures an arbitrary message.
+    ///
+    /// See the global [`capture_message`](fn.capture_message.html)
+    /// for more documentation.
+    pub fn capture_message(&self, msg: &str, level: Level) -> Option<Uuid> {
+        let event = Event {
+            message: Some(msg.to_string()),
+            level,
+            ..Default::default()
+        };
+        self.capture_event(event)
+    }
+
+    /// Invokes a function that can modify the current scope.
+    ///
+    /// See the global [`configure_scope`](fn.configure_scope.html)
+    /// for more documentation.
+    pub fn configure_scope<F, R>(&self, f: F) -> R
+    where
+        R: Default,
+        F: FnOnce(&mut Scope) -> R,
+    {
+        todo!()
+    }
+
+    /// Pushes a new scope.
+    ///
+    /// This returns a guard that when dropped will pop the scope again.
+    pub fn push_scope(&self) -> ScopeGuard {
+        todo!()
+    }
+
+    /// Temporarily pushes a scope for a single call optionally reconfiguring it.
+    ///
+    /// In case no client is bound, the given `callback` is still invoked, but
+    /// `scope_config` is not.
+    pub fn with_scope<C, F, R>(&self, scope_config: C, callback: F) -> R
+    where
+        C: FnOnce(&mut Scope),
+        F: FnOnce() -> R,
+    {
+        todo!()
+    }
+
+    /// Adds a new breadcrumb to the current scope.
+    ///
+    /// See the global [`add_breadcrumb`](fn.add_breadcrumb.html)
+    /// for more documentation.
+    pub fn add_breadcrumb<B: IntoBreadcrumbs>(&self, breadcrumbs: B) {
+        todo!()
+    }
+
+    /// Returns the currently bound client.
+    pub fn client(&self) -> Option<Client> {
+        todo!()
+    }
+
+    /// Binds a new client to the hub.
+    pub fn bind_client(&self, client: Option<Client>) {
+        todo!()
+    }
+
+    /// Returns the last event id.
+    pub fn last_event_id(&self) -> Option<Uuid> {
+        todo!()
+    }
+}

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -25,11 +25,13 @@ pub struct Hub {}
 impl Hub {
     /// Creates a new hub from the given client and scope.
     pub fn new(client: Option<Client>, scope: Scope) -> Hub {
+        let _ = (client, scope);
         todo!()
     }
 
     /// Creates a new hub based on the top scope of the given hub.
     pub fn new_from_top<H: AsRef<Hub>>(other: H) -> Hub {
+        let _ = other;
         todo!()
     }
 
@@ -54,6 +56,7 @@ impl Hub {
     where
         F: FnOnce(&Hub) -> R,
     {
+        let _ = f;
         todo!()
     }
 
@@ -68,10 +71,13 @@ impl Hub {
         F: FnOnce(&Hub) -> R,
         R: Default,
     {
+        let _ = f;
         todo!()
     }
 
-    pub fn run<F: FnOnce() -> R, R>(hub: Hub, f: F) -> R {
+    /// Binds the hub to the current thread for the duration of the callback.
+    pub fn run<F: FnOnce() -> R, R>(&self, f: F) -> R {
+        let _ = f;
         todo!()
     }
 
@@ -80,6 +86,7 @@ impl Hub {
     /// See the global [`capture_event`](fn.capture_event.html)
     /// for more documentation.
     pub fn capture_event(&self, event: Event<'static>) -> Option<Uuid> {
+        let _ = event;
         todo!()
     }
 
@@ -105,6 +112,7 @@ impl Hub {
         R: Default,
         F: FnOnce(&mut Scope) -> R,
     {
+        let _ = f;
         todo!()
     }
 
@@ -124,6 +132,7 @@ impl Hub {
         C: FnOnce(&mut Scope),
         F: FnOnce() -> R,
     {
+        let _ = (scope_config, callback);
         todo!()
     }
 
@@ -132,6 +141,7 @@ impl Hub {
     /// See the global [`add_breadcrumb`](fn.add_breadcrumb.html)
     /// for more documentation.
     pub fn add_breadcrumb<B: IntoBreadcrumbs>(&self, breadcrumbs: B) {
+        let _ = breadcrumbs;
         todo!()
     }
 
@@ -142,6 +152,7 @@ impl Hub {
 
     /// Binds a new client to the hub.
     pub fn bind_client(&self, client: Option<Client>) {
+        let _ = client;
         todo!()
     }
 

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -1,0 +1,14 @@
+//! <p style="margin: -10px 0 0 15px; padding: 0; float: right;">
+//!   <a href="https://sentry.io/"><img
+//!     src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png"
+//!     style="width: 260px"></a>
+//! </p>
+//!
+//! This crate provides support for logging events and errors to the
+//! [Sentry](https://sentry.io/) error logging service.
+//! It represents the core of sentry and provides APIs for instrumenting code,
+//! and to write integrations that can generate events or hook into the event
+//! processing pipeline.
+
+pub use sentry_types::protocol::v7 as protocol;
+pub use sentry_types::protocol::v7::{Breadcrumb, Level, User};

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -10,5 +10,18 @@
 //! and to write integrations that can generate events or hook into the event
 //! processing pipeline.
 
+mod api;
+mod breadcrumbs;
+mod client;
+mod hub;
+mod scope;
+
+pub use api::*;
+pub use breadcrumbs::IntoBreadcrumbs;
+pub use client::Client;
+pub use hub::Hub;
+pub use scope::{Scope, ScopeGuard};
+
 pub use sentry_types::protocol::v7 as protocol;
-pub use sentry_types::protocol::v7::{Breadcrumb, Level, User};
+pub use sentry_types::protocol::v7::{Breadcrumb, Event, Level, User};
+pub use sentry_types::Uuid;

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -10,6 +10,10 @@
 //! and to write integrations that can generate events or hook into the event
 //! processing pipeline.
 
+#![deny(missing_docs)]
+// hm, this lint does not trigger correctly for some reason
+#![warn(missing_doc_code_examples)]
+
 mod api;
 mod breadcrumbs;
 mod client;

--- a/sentry-core/src/scope.rs
+++ b/sentry-core/src/scope.rs
@@ -1,0 +1,5 @@
+/// TODO
+pub struct ScopeGuard {}
+
+/// TODO
+pub struct Scope {}


### PR DESCRIPTION
This is a different try to #192, as this starts with a completely empty implementation, and explores the API more freely.

So far this is just a sketch of the public static and Hub API, with the following changes:
* `Client`/`Hub`/`Scope` are not explicitly wrappen in `Arc`, the plan instead is to use internal refcounting, or ownership transfer in case of `Scope`.
* Made `Uuid` return values consistent.
* `Hub::run` now works on `&self`.