### PR TITLE
meta: Import sentry-types into the monorepo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "sentry",
     "sentry-actix",
+    "sentry-types",
 ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ and errors / panics to the [Sentry](https://sentry.io/) error logging service.
   want to log events to sentry.
 - [sentry-actix](./sentry-actix) An integration for the `actix-web (0.7)`
   framework.
+- [sentry-types](./sentry-types) Contains types for the Sentry v7 protocol as
+  well as other common types.
 
 **Note**: Until the _1.0_ release, the crates in this repository are considered work in
 progress and do not follow semver semantics. Between minor releases, we might

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -8,7 +8,7 @@
 # Sentry-Actix
 
 [![Build Status](https://travis-ci.org/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.org/getsentry/sentry-rust)
-[![Crates.io](https://img.shields.io/crates/v/sentry.svg?style=flat)](https://crates.io/crates/sentry)
+[![Crates.io](https://img.shields.io/crates/v/sentry-actix.svg?style=flat)](https://crates.io/crates/sentry-actix)
 
 This is an actix-web integration for the Sentry crate.
 

--- a/sentry-types/CHANGELOG.md
+++ b/sentry-types/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.15.0
+
+- **breaking**: Remove usage of `failure`.
+  `ParseAuthError`, `ParseDsnError`, `ParseProjectIdError`, and
+  `ParseLevelError` now implement `std::error::Error`.
+- **breaking**: Remove deprecated `with_serde` feature.

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.15.0"
 license = "Apache-2.0"
 description = "Common reusable types for implementing the sentry.io protocol."
 homepage = "https://sentry.io/"
-repository = "https://github.com/getsentry/rust-sentry-types"
+repository = "https://github.com/getsentry/sentry-rust"
 documentation = "https://docs.rs/sentry-types"
 keywords = ["sentry", "protocol"]
 readme = "README.md"
@@ -20,7 +20,7 @@ default = ["with_protocol"]
 with_protocol = []
 
 [badges]
-travis-ci = { repository = "getsentry/rust-sentry-types" }
+travis-ci = { repository = "getsentry/sentry-rust" }
 
 [dependencies]
 thiserror = "1.0.15"

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "sentry-types"
+version = "0.15.0"
+license = "Apache-2.0"
+description = "Common reusable types for implementing the sentry.io protocol."
+homepage = "https://sentry.io/"
+repository = "https://github.com/getsentry/rust-sentry-types"
+documentation = "https://docs.rs/sentry-types"
+keywords = ["sentry", "protocol"]
+readme = "README.md"
+authors = ["Sentry <hello@sentry.io>"]
+exclude = [
+    ".vscode/**/*",
+    "scripts/**/*"
+]
+edition = "2018"
+
+[features]
+default = ["with_protocol"]
+with_protocol = []
+
+[badges]
+travis-ci = { repository = "getsentry/rust-sentry-types" }
+
+[dependencies]
+thiserror = "1.0.15"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_json = "1.0.46"
+url = { version = "2.1.1", features = ["serde"] }
+chrono = { version = "0.4.10", features = ["serde"] }
+uuid = { version = "0.8.1", features = ["v4", "serde"] }
+debugid = { version = "0.7.2", features = ["serde"] }

--- a/sentry-types/README.md
+++ b/sentry-types/README.md
@@ -1,14 +1,29 @@
-# Rust Sentry Types
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
 
-<a href="https://travis-ci.org/getsentry/rust-sentry-types"><img src="https://travis-ci.org/getsentry/rust-sentry-types.svg?branch=master" alt=""></a>
-<a href="https://crates.io/crates/sentry-types"><img src="https://img.shields.io/crates/v/sentry-types.svg" alt=""></a>
+# Sentry Types
+
+[![Crates.io](https://img.shields.io/crates/v/sentry-types.svg?style=flat)](https://crates.io/crates/sentry-types)
 
 This library implements Rust types for the Sentry v7 protocol as well as some other
 common types that are useful when working with Sentry (like DSNs and so forth).
 
-This library can be used for implementing Sentry clients and is used by
-[sentry-rust](https://github.com/getsentry/sentry-rust).
+## Requirements
 
-## License
+We currently only verify this crate against a recent version of Sentry hosted on
+[sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
+8.20 and later.
 
-Rust sentry types is licensed under the Apache 2 license.
+Additionally, the lowest Rust version we target is _1.40.0_.
+
+## Resources
+
+- [crates.io](https://crates.io/crates/sentry-actix)
+- [Documentation](https://docs.rs/sentry-actix)
+- [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
+- [Discord](https://discord.gg/ez5KZN7) server for project discussions.
+- Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates

--- a/sentry-types/README.md
+++ b/sentry-types/README.md
@@ -1,0 +1,14 @@
+# Rust Sentry Types
+
+<a href="https://travis-ci.org/getsentry/rust-sentry-types"><img src="https://travis-ci.org/getsentry/rust-sentry-types.svg?branch=master" alt=""></a>
+<a href="https://crates.io/crates/sentry-types"><img src="https://img.shields.io/crates/v/sentry-types.svg" alt=""></a>
+
+This library implements Rust types for the Sentry v7 protocol as well as some other
+common types that are useful when working with Sentry (like DSNs and so forth).
+
+This library can be used for implementing Sentry clients and is used by
+[sentry-rust](https://github.com/getsentry/sentry-rust).
+
+## License
+
+Rust sentry types is licensed under the Apache 2 license.

--- a/sentry-types/src/auth.rs
+++ b/sentry-types/src/auth.rs
@@ -1,0 +1,190 @@
+#[allow(unused_imports, deprecated)]
+use std::ascii::AsciiExt;
+use std::borrow::Cow;
+use std::fmt;
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::form_urlencoded;
+
+use crate::dsn::Dsn;
+use crate::protocol;
+use crate::utils::{datetime_to_timestamp, timestamp_to_datetime};
+
+/// Represents an auth header parsing error.
+#[derive(Debug, Error, Copy, Clone, Eq, PartialEq)]
+pub enum ParseAuthError {
+    /// Raised if the auth header is not indicating sentry auth
+    #[error("non sentry auth")]
+    NonSentryAuth,
+    /// Raised if the version value is invalid
+    #[error("invalid value for version")]
+    InvalidVersion,
+    /// Raised if the public key is missing entirely
+    #[error("missing public key in auth header")]
+    MissingPublicKey,
+}
+
+/// Represents an auth header.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Auth {
+    #[serde(skip)]
+    timestamp: Option<DateTime<Utc>>,
+    #[serde(rename = "sentry_client")]
+    client: Option<String>,
+    #[serde(rename = "sentry_version")]
+    version: u16,
+    #[serde(rename = "sentry_key")]
+    key: String,
+    #[serde(rename = "sentry_secret")]
+    secret: Option<String>,
+}
+
+impl Auth {
+    /// Creates an auth header from key value pairs.
+    pub fn from_pairs<'a, I, K, V>(pairs: I) -> Result<Auth, ParseAuthError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: Into<Cow<'a, str>>,
+    {
+        let mut rv = Auth {
+            timestamp: None,
+            client: None,
+            version: protocol::LATEST,
+            key: "".into(),
+            secret: None,
+        };
+
+        for (key, value) in pairs {
+            let value = value.into();
+            match key.as_ref() {
+                "sentry_timestamp" => {
+                    let timestamp = value
+                        .parse()
+                        .ok()
+                        .and_then(|ts| timestamp_to_datetime(ts).single())
+                        .or_else(|| value.parse().ok());
+
+                    rv.timestamp = timestamp;
+                }
+                "sentry_client" => {
+                    rv.client = Some(value.into());
+                }
+                "sentry_version" => {
+                    rv.version = value
+                        .splitn(2, '.')
+                        .next()
+                        .and_then(|v| v.parse().ok())
+                        .ok_or(ParseAuthError::InvalidVersion)?;
+                }
+                "sentry_key" => {
+                    rv.key = value.into();
+                }
+                "sentry_secret" => {
+                    rv.secret = Some(value.into());
+                }
+                _ => {}
+            }
+        }
+
+        if rv.key.is_empty() {
+            return Err(ParseAuthError::MissingPublicKey);
+        }
+
+        Ok(rv)
+    }
+
+    /// Creates an auth header from a query string.
+    pub fn from_querystring(qs: &[u8]) -> Result<Auth, ParseAuthError> {
+        Auth::from_pairs(form_urlencoded::parse(qs))
+    }
+
+    /// Returns the unix timestamp the client defined
+    pub fn timestamp(&self) -> Option<DateTime<Utc>> {
+        self.timestamp
+    }
+
+    /// Returns the protocol version the client speaks
+    pub fn version(&self) -> u16 {
+        self.version
+    }
+
+    /// Returns the public key
+    pub fn public_key(&self) -> &str {
+        &self.key
+    }
+
+    /// Returns the client's secret if it authenticated with a secret.
+    pub fn secret_key(&self) -> Option<&str> {
+        self.secret.as_deref()
+    }
+
+    /// Returns true if the authentication implies public auth (no secret)
+    pub fn is_public(&self) -> bool {
+        self.secret.is_none()
+    }
+
+    /// Returns the client's agent
+    pub fn client_agent(&self) -> Option<&str> {
+        self.client.as_deref()
+    }
+}
+
+impl fmt::Display for Auth {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Sentry sentry_key={}, sentry_version={}",
+            self.key, self.version
+        )?;
+        if let Some(ts) = self.timestamp {
+            write!(f, ", sentry_timestamp={}", datetime_to_timestamp(&ts))?;
+        }
+        if let Some(ref client) = self.client {
+            write!(f, ", sentry_client={}", client)?;
+        }
+        if let Some(ref secret) = self.secret {
+            write!(f, ", sentry_secret={}", secret)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for Auth {
+    type Err = ParseAuthError;
+
+    fn from_str(s: &str) -> Result<Auth, ParseAuthError> {
+        let mut base_iter = s.splitn(2, ' ');
+
+        let prefix = base_iter.next().unwrap_or("");
+        let items = base_iter.next().unwrap_or("");
+
+        if !prefix.eq_ignore_ascii_case("sentry") {
+            return Err(ParseAuthError::NonSentryAuth);
+        }
+
+        let auth = Self::from_pairs(items.split(',').filter_map(|item| {
+            let mut kviter = item.split('=');
+            Some((kviter.next()?.trim(), kviter.next()?.trim()))
+        }))?;
+
+        if auth.key.is_empty() {
+            return Err(ParseAuthError::MissingPublicKey);
+        }
+
+        Ok(auth)
+    }
+}
+
+pub(crate) fn auth_from_dsn_and_client(dsn: &Dsn, client: Option<&str>) -> Auth {
+    Auth {
+        timestamp: Some(Utc::now()),
+        client: client.map(|x| x.to_string()),
+        version: protocol::LATEST,
+        key: dsn.public_key().to_string(),
+        secret: dsn.secret_key().map(|x| x.to_string()),
+    }
+}

--- a/sentry-types/src/dsn.rs
+++ b/sentry-types/src/dsn.rs
@@ -1,0 +1,314 @@
+use std::fmt;
+use std::str::FromStr;
+
+use thiserror::Error;
+use url::Url;
+
+use crate::auth::{auth_from_dsn_and_client, Auth};
+use crate::project_id::{ParseProjectIdError, ProjectId};
+
+/// Represents a dsn url parsing error.
+#[derive(Debug, Error)]
+pub enum ParseDsnError {
+    /// raised on completely invalid urls
+    #[error("no valid url provided")]
+    InvalidUrl,
+    /// raised the scheme is invalid / unsupported.
+    #[error("no valid scheme")]
+    InvalidScheme,
+    /// raised if the username (public key) portion is missing.
+    #[error("username is empty")]
+    NoUsername,
+    /// raised the project is is missing (first path component)
+    #[error("empty path")]
+    NoProjectId,
+    /// raised the project id is invalid.
+    #[error("invalid project id")]
+    InvalidProjectId(#[from] ParseProjectIdError),
+}
+
+/// Represents the scheme of an url http/https.
+///
+/// This holds schemes that are supported by sentry and relays.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Scheme {
+    /// unencrypted HTTP scheme (should not be used)
+    Http,
+    /// encrypted HTTPS scheme
+    Https,
+}
+
+impl Scheme {
+    /// Returns the default port for this scheme.
+    pub fn default_port(self) -> u16 {
+        match self {
+            Scheme::Http => 80,
+            Scheme::Https => 443,
+        }
+    }
+}
+
+impl fmt::Display for Scheme {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match *self {
+                Scheme::Https => "https",
+                Scheme::Http => "http",
+            }
+        )
+    }
+}
+
+/// Represents a Sentry dsn.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct Dsn {
+    scheme: Scheme,
+    public_key: String,
+    secret_key: Option<String>,
+    host: String,
+    port: Option<u16>,
+    path: String,
+    project_id: ProjectId,
+}
+
+impl Dsn {
+    /// Converts the dsn into an auth object.
+    ///
+    /// This always attaches the latest and greatest protocol
+    /// version to the auth header.
+    pub fn to_auth(&self, client_agent: Option<&str>) -> Auth {
+        auth_from_dsn_and_client(self, client_agent)
+    }
+
+    /// Returns the submission API URL.
+    pub fn store_api_url(&self) -> Url {
+        use std::fmt::Write;
+        let mut buf = format!("{}://{}", self.scheme(), self.host());
+        if self.port() != self.scheme.default_port() {
+            write!(&mut buf, ":{}", self.port()).unwrap();
+        }
+        write!(&mut buf, "{}api/{}/store/", self.path, self.project_id()).unwrap();
+        Url::parse(&buf).unwrap()
+    }
+
+    /// Returns the scheme
+    pub fn scheme(&self) -> Scheme {
+        self.scheme
+    }
+
+    /// Returns the public_key
+    pub fn public_key(&self) -> &str {
+        &self.public_key
+    }
+
+    /// Returns secret_key
+    pub fn secret_key(&self) -> Option<&str> {
+        self.secret_key.as_deref()
+    }
+
+    /// Returns the host
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Returns the port
+    pub fn port(&self) -> u16 {
+        self.port.unwrap_or_else(|| self.scheme.default_port())
+    }
+
+    /// Returns the path
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns the project_id
+    pub fn project_id(&self) -> ProjectId {
+        self.project_id
+    }
+}
+
+impl fmt::Display for Dsn {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}://{}:", self.scheme, self.public_key)?;
+        if let Some(ref secret_key) = self.secret_key {
+            write!(f, "{}", secret_key)?;
+        }
+        write!(f, "@{}", self.host)?;
+        if let Some(ref port) = self.port {
+            write!(f, ":{}", port)?;
+        }
+        write!(f, "{}{}", self.path, self.project_id)?;
+        Ok(())
+    }
+}
+
+impl FromStr for Dsn {
+    type Err = ParseDsnError;
+
+    fn from_str(s: &str) -> Result<Dsn, ParseDsnError> {
+        let url = Url::parse(s).map_err(|_| ParseDsnError::InvalidUrl)?;
+
+        if url.path() == "/" {
+            return Err(ParseDsnError::NoProjectId);
+        }
+
+        let mut path_segments = url.path().trim_matches('/').rsplitn(2, '/');
+
+        let project_id = path_segments
+            .next()
+            .ok_or_else(|| ParseDsnError::NoProjectId)?
+            .parse()
+            .map_err(ParseDsnError::InvalidProjectId)?;
+        let path = match path_segments.next().unwrap_or("") {
+            "" | "/" => "/".into(),
+            other => format!("/{}/", other),
+        };
+
+        let public_key = match url.username() {
+            "" => return Err(ParseDsnError::NoUsername),
+            username => username.to_string(),
+        };
+
+        let scheme = match url.scheme() {
+            "http" => Scheme::Http,
+            "https" => Scheme::Https,
+            _ => return Err(ParseDsnError::InvalidScheme),
+        };
+
+        let secret_key = url.password().map(|s| s.into());
+        let port = url.port();
+        let host = match url.host_str() {
+            Some(host) => host.into(),
+            None => return Err(ParseDsnError::InvalidUrl),
+        };
+
+        Ok(Dsn {
+            scheme,
+            public_key,
+            secret_key,
+            port,
+            host,
+            path,
+            project_id,
+        })
+    }
+}
+
+impl_str_serde!(Dsn);
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_dsn_serialize_deserialize() {
+        let dsn = Dsn::from_str("https://username:@domain/42").unwrap();
+        let serialized = serde_json::to_string(&dsn).unwrap();
+        assert_eq!(serialized, "\"https://username:@domain/42\"");
+        let deserialized: Dsn = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.to_string(), "https://username:@domain/42");
+    }
+
+    #[test]
+    fn test_dsn_parsing() {
+        let url = "https://username:password@domain:8888/23";
+        let dsn = url.parse::<Dsn>().unwrap();
+        assert_eq!(dsn.scheme(), Scheme::Https);
+        assert_eq!(dsn.public_key(), "username");
+        assert_eq!(dsn.secret_key(), Some("password"));
+        assert_eq!(dsn.host(), "domain");
+        assert_eq!(dsn.port(), 8888);
+        assert_eq!(dsn.path(), "/");
+        assert_eq!(dsn.project_id(), ProjectId::new(23));
+        assert_eq!(url, dsn.to_string());
+    }
+
+    #[test]
+    fn test_dsn_no_port() {
+        let url = "https://username:@domain/42";
+        let dsn = Dsn::from_str(url).unwrap();
+        assert_eq!(dsn.port(), 443);
+        assert_eq!(url, dsn.to_string());
+        assert_eq!(
+            dsn.store_api_url().to_string(),
+            "https://domain/api/42/store/"
+        );
+    }
+
+    #[test]
+    fn test_insecure_dsn_no_port() {
+        let url = "http://username:@domain/42";
+        let dsn = Dsn::from_str(url).unwrap();
+        assert_eq!(dsn.port(), 80);
+        assert_eq!(url, dsn.to_string());
+        assert_eq!(
+            dsn.store_api_url().to_string(),
+            "http://domain/api/42/store/"
+        );
+    }
+
+    #[test]
+    fn test_dsn_no_password() {
+        let url = "https://username:@domain:8888/42";
+        let dsn = Dsn::from_str(url).unwrap();
+        assert_eq!(url, dsn.to_string());
+        assert_eq!(
+            dsn.store_api_url().to_string(),
+            "https://domain:8888/api/42/store/"
+        );
+    }
+
+    #[test]
+    fn test_dsn_no_password_colon() {
+        let url = "https://username@domain:8888/42";
+        let dsn = Dsn::from_str(url).unwrap();
+        assert_eq!("https://username:@domain:8888/42", dsn.to_string());
+    }
+
+    #[test]
+    fn test_dsn_http_url() {
+        let url = "http://username:@domain:8888/42";
+        let dsn = Dsn::from_str(url).unwrap();
+        assert_eq!(url, dsn.to_string());
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidProjectId")]
+    fn test_dsn_more_than_one_non_integer_path() {
+        Dsn::from_str("http://username:@domain:8888/path/path2").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "NoUsername")]
+    fn test_dsn_no_username() {
+        Dsn::from_str("https://:password@domain:8888/23").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidUrl")]
+    fn test_dsn_invalid_url() {
+        Dsn::from_str("random string").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidUrl")]
+    fn test_dsn_no_host() {
+        Dsn::from_str("https://username:password@:8888/42").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "NoProjectId")]
+    fn test_dsn_no_project_id() {
+        Dsn::from_str("https://username:password@domain:8888/").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "InvalidScheme")]
+    fn test_dsn_invalid_scheme() {
+        Dsn::from_str("ftp://username:password@domain:8888/1").unwrap();
+    }
+}

--- a/sentry-types/src/lib.rs
+++ b/sentry-types/src/lib.rs
@@ -1,0 +1,52 @@
+//! This crate provides common types for working with the Sentry protocol or the
+//! Sentry server.  It's used by the Sentry Relay infrastructure as well as the
+//! rust Sentry client.
+//!
+//! Most of the types in this crate are serializable in one form or another.
+//! The types in the `protocol` module are generally really only serializable
+//! to JSON as other formats are not supported by Sentry at this date.
+//!
+//! ## Contents
+//!
+//! The crate provides a bunch of common types for working with Sentry as
+//! such (DSN, ProjectIDs, authentication headers) as well as types for
+//! the Sentry event protocol.
+//!
+//! Right now only `v7` of the protocol is implemented but it's versioned
+//! so later versions might be added later.
+//!
+//! ## API Concepts
+//!
+//! Most types are directly serializable or deserializable and try to implement
+//! the `Default` type.  This means that objects can be created conviently
+//! and missing attributes can be filled in:
+//!
+//! ```rust
+//! use sentry_types::protocol::v7;
+//!
+//! let event = v7::Event {
+//!     message: Some("Hello World!".to_string()),
+//!     culprit: Some("foo in bar".to_string()),
+//!     level: v7::Level::Info,
+//!     ..Default::default()
+//! };
+//! ```
+#![warn(missing_docs)]
+
+#[macro_use]
+mod macros;
+
+mod auth;
+mod dsn;
+mod project_id;
+pub mod protocol;
+mod utils;
+
+pub use crate::auth::*;
+pub use crate::dsn::*;
+pub use crate::project_id::*;
+
+// Re-export external types and traits for convenience
+pub use chrono::{DateTime, ParseError as ChronoParseError, TimeZone, Utc};
+pub use debugid::*;
+pub use uuid::{Uuid, Variant as UuidVariant, Version as UuidVersion};

--- a/sentry-types/src/macros.rs
+++ b/sentry-types/src/macros.rs
@@ -1,0 +1,251 @@
+#![cfg_attr(not(feature = "with_protocol"), allow(unused))]
+
+/// Helper macro to implement string based serialization.
+///
+/// If a type implements `Display` then this automatically
+/// implements a serializer for that type that dispatches
+/// appropriately.
+macro_rules! impl_str_ser {
+    ($type:ty) => {
+        impl ::serde::ser::Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::ser::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+    };
+}
+
+/// Helper macro to implement string based deserialization.
+///
+/// If a type implements `FromStr` then this automatically
+/// implements a deserializer for that type that dispatches
+/// appropriately.
+#[allow(unused_macros)]
+macro_rules! impl_str_de {
+    ($type:ty) => {
+        impl<'de> ::serde::de::Deserialize<'de> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: ::serde::de::Deserializer<'de>,
+            {
+                <::std::borrow::Cow<str>>::deserialize(deserializer)?
+                    .parse()
+                    .map_err(::serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+/// Helper macro to implement string based serialization and deserialization.
+///
+/// If a type implements `FromStr` and `Display` then this automatically
+/// implements a serializer/deserializer for that type that dispatches
+/// appropriately.
+#[allow(unused_macros)]
+macro_rules! impl_str_serde {
+    ($type:ty) => {
+        impl_str_ser!($type);
+        impl_str_de!($type);
+    };
+}
+
+#[cfg(test)]
+mod str_tests {
+    use std::fmt;
+    use std::io::Cursor;
+    use std::str::FromStr;
+
+    use serde_json;
+
+    struct Test;
+
+    impl FromStr for Test {
+        type Err = &'static str;
+
+        fn from_str(string: &str) -> Result<Self, Self::Err> {
+            match string {
+                "test" => Ok(Test),
+                _ => Err("failed"),
+            }
+        }
+    }
+
+    impl fmt::Display for Test {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "test")
+        }
+    }
+
+    impl_str_serde!(Test);
+
+    #[test]
+    fn test_serialize_string() {
+        assert_eq!("\"test\"", serde_json::to_string(&Test).unwrap());
+    }
+
+    #[test]
+    fn test_deserialize() {
+        assert!(serde_json::from_str::<Test>("\"test\"").is_ok());
+    }
+
+    #[test]
+    fn test_deserialize_owned() {
+        assert!(serde_json::from_reader::<_, Test>(Cursor::new("\"test\"")).is_ok());
+    }
+}
+
+/// Helper macro to implement serialization into base 16 (hex) string
+/// representation. Implements `Display` and `Serialize`.
+macro_rules! impl_hex_ser {
+    ($type:ident) => {
+        impl ::std::fmt::Display for $type {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, "{:#x}", self.0)
+            }
+        }
+
+        impl ::serde::ser::Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::ser::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+    };
+}
+
+/// Helper macro to implement deserialization from both numeric values or their
+/// base16 (hex) / base10 representations as string. Implements `FromStr` and
+/// `Deserialize`.
+macro_rules! impl_hex_de {
+    ($type:ident, $num:ident) => {
+        impl ::std::str::FromStr for $type {
+            type Err = ::std::num::ParseIntError;
+
+            fn from_str(s: &str) -> Result<$type, ::std::num::ParseIntError> {
+                if s.starts_with("0x") || s.starts_with("0X") {
+                    $num::from_str_radix(&s[2..], 16).map($type)
+                } else {
+                    $num::from_str_radix(&s, 10).map($type)
+                }
+            }
+        }
+
+        impl<'de> ::serde::de::Deserialize<'de> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<$type, D::Error>
+            where
+                D: ::serde::de::Deserializer<'de>,
+            {
+                struct HexVisitor;
+
+                impl<'de> ::serde::de::Visitor<'de> for HexVisitor {
+                    type Value = $type;
+
+                    fn expecting(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        write!(f, "a number or hex string")
+                    }
+
+                    fn visit_i64<E: ::serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                        Ok($type(v as $num))
+                    }
+
+                    fn visit_u64<E: ::serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                        Ok($type(v as $num))
+                    }
+
+                    fn visit_str<E: ::serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                        v.parse().map_err(::serde::de::Error::custom)
+                    }
+                }
+
+                deserializer.deserialize_any(HexVisitor)
+            }
+        }
+    };
+}
+
+/// Helper macro to implement serialization from both numeric values or their
+/// hex representation as string.
+///
+/// This implements `Serialize`, `Deserialize`, `Display` and `FromStr`.
+/// Serialization will always use a `"0xbeef"` representation of the value.
+/// Deserialization supports raw numbers as well as string representations
+/// in hex and base10.
+macro_rules! impl_hex_serde {
+    ($type:ident, $num:ident) => {
+        impl_hex_ser!($type);
+        impl_hex_de!($type, $num);
+    };
+}
+
+#[cfg(test)]
+mod hex_tests {
+    use serde_json;
+    use std::io::Cursor;
+
+    #[derive(Debug, PartialEq)]
+    struct Hex(u32);
+
+    impl_hex_serde!(Hex, u32);
+
+    #[test]
+    fn test_hex_to_string() {
+        assert_eq!("0x0", &Hex(0).to_string());
+        assert_eq!("0x2a", &Hex(42).to_string());
+    }
+
+    #[test]
+    fn test_hex_serialize() {
+        assert_eq!("\"0x0\"", serde_json::to_string(&Hex(0)).unwrap());
+        assert_eq!("\"0x2a\"", serde_json::to_string(&Hex(42)).unwrap());
+    }
+
+    #[test]
+    fn test_hex_from_string() {
+        assert_eq!(Hex(0), "0".parse().unwrap());
+        assert_eq!(Hex(42), "42".parse().unwrap());
+        assert_eq!(Hex(42), "0x2a".parse().unwrap());
+        assert_eq!(Hex(42), "0X2A".parse().unwrap());
+    }
+
+    #[test]
+    fn test_hex_deserialize() {
+        assert_eq!(Hex(0), serde_json::from_str("\"0\"").unwrap());
+        assert_eq!(Hex(42), serde_json::from_str("\"42\"").unwrap());
+        assert_eq!(Hex(42), serde_json::from_str("\"0x2a\"").unwrap());
+        assert_eq!(Hex(42), serde_json::from_str("\"0X2A\"").unwrap());
+    }
+
+    #[test]
+    fn test_hex_deserialize_owned() {
+        assert_eq!(
+            Hex(0),
+            serde_json::from_reader(Cursor::new("\"0\"")).unwrap()
+        );
+        assert_eq!(
+            Hex(42),
+            serde_json::from_reader(Cursor::new("\"42\"")).unwrap()
+        );
+        assert_eq!(
+            Hex(42),
+            serde_json::from_reader(Cursor::new("\"0x2a\"")).unwrap()
+        );
+        assert_eq!(
+            Hex(42),
+            serde_json::from_reader(Cursor::new("\"0X2A\"")).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_invalid() {
+        let result = serde_json::from_str::<Hex>("true").unwrap_err();
+        assert_eq!(
+            "invalid type: boolean `true`, expected a number or hex string at line 1 column 4",
+            result.to_string()
+        );
+    }
+}

--- a/sentry-types/src/project_id.rs
+++ b/sentry-types/src/project_id.rs
@@ -1,0 +1,121 @@
+use std::convert::TryFrom;
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Raised if a project ID cannot be parsed from a string.
+#[derive(Debug, Error, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ParseProjectIdError {
+    /// Raised if the value is not an integer in the supported range.
+    #[error("invalid value for project id")]
+    InvalidValue,
+    /// Raised if an empty value is parsed.
+    #[error("empty or missing project id")]
+    EmptyValue,
+}
+
+/// Represents a project ID.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+pub struct ProjectId(u64);
+
+impl ProjectId {
+    /// Creates a new project ID from its numeric value.
+    #[inline]
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the numeric value of this project id.
+    #[inline]
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for ProjectId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.value())
+    }
+}
+
+macro_rules! impl_from {
+    ($ty:ty) => {
+        impl From<$ty> for ProjectId {
+            #[inline]
+            fn from(val: $ty) -> Self {
+                Self::new(val as u64)
+            }
+        }
+    };
+}
+
+impl_from!(u8);
+impl_from!(u16);
+impl_from!(u32);
+impl_from!(u64);
+
+macro_rules! impl_try_from {
+    ($ty:ty) => {
+        impl TryFrom<$ty> for ProjectId {
+            type Error = ParseProjectIdError;
+
+            #[inline]
+            fn try_from(val: $ty) -> Result<Self, Self::Error> {
+                match u64::try_from(val) {
+                    Ok(id) => Ok(Self::new(id)),
+                    Err(_) => Err(ParseProjectIdError::InvalidValue),
+                }
+            }
+        }
+    };
+}
+
+impl_try_from!(usize);
+impl_try_from!(i8);
+impl_try_from!(i16);
+impl_try_from!(i32);
+impl_try_from!(i64);
+
+impl FromStr for ProjectId {
+    type Err = ParseProjectIdError;
+
+    fn from_str(s: &str) -> Result<ProjectId, ParseProjectIdError> {
+        if s.is_empty() {
+            return Err(ParseProjectIdError::EmptyValue);
+        }
+
+        match s.parse::<u64>() {
+            Ok(val) => Ok(ProjectId::new(val)),
+            Err(_) => Err(ParseProjectIdError::InvalidValue),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_basic_api() {
+        let id: ProjectId = "42".parse().unwrap();
+        assert_eq!(id, ProjectId::new(42));
+        assert_eq!(
+            "42xxx".parse::<ProjectId>(),
+            Err(ParseProjectIdError::InvalidValue)
+        );
+        assert_eq!(
+            "".parse::<ProjectId>(),
+            Err(ParseProjectIdError::EmptyValue)
+        );
+        assert_eq!(ProjectId::new(42).to_string(), "42");
+
+        assert_eq!(serde_json::to_string(&ProjectId::new(42)).unwrap(), "42");
+        assert_eq!(
+            serde_json::from_str::<ProjectId>("42").unwrap(),
+            ProjectId::new(42)
+        );
+    }
+}

--- a/sentry-types/src/protocol/mod.rs
+++ b/sentry-types/src/protocol/mod.rs
@@ -1,0 +1,13 @@
+//! This module exposes the types for the Sentry protocol in different versions.
+
+#[cfg(feature = "with_protocol")]
+pub mod v7;
+
+/// The latest version of the protocol.
+pub const LATEST: u16 = 7;
+
+/// the always latest sentry protocol version
+#[cfg(feature = "with_protocol")]
+pub mod latest {
+    pub use super::v7::*;
+}

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1,0 +1,1453 @@
+//! The current latest sentry protocol version.
+//!
+//! Most constructs in the protocol map directly to types here but some
+//! cleanup by renaming attributes has been applied.  The idea here is that
+//! a future sentry protocol will be a cleanup of the old one and is mapped
+//! to similar values on the rust side.
+#![allow(clippy::trivially_copy_pass_by_ref)]
+
+use std::borrow::Cow;
+use std::cmp;
+use std::fmt;
+use std::iter::FromIterator;
+use std::net::{AddrParseError, IpAddr};
+use std::ops;
+use std::str;
+
+use ::debugid::DebugId;
+use chrono::{DateTime, Utc};
+use serde::Serializer;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+use uuid::Uuid;
+
+use crate::utils::ts_seconds_float;
+
+/// An arbitrary (JSON) value.
+pub mod value {
+    pub use serde_json::value::{from_value, to_value, Index, Map, Number, Value};
+}
+
+/// The internally used arbitrary data map type.
+pub mod map {
+    pub use std::collections::btree_map::{BTreeMap as Map, *};
+}
+
+/// Represents a debug ID.
+pub mod debugid {
+    pub use debugid::{BreakpadFormat, DebugId, ParseDebugIdError};
+}
+
+/// An arbitrary (JSON) value.
+pub use self::value::Value;
+
+/// The internally useed map type.
+pub use self::map::Map;
+
+/// A wrapper type for collections with attached meta data.
+///
+/// The JSON payload can either directly be an array or an object containing a `values` field and
+/// arbitrary other fields. All other fields will be collected into `Values::data` when
+/// deserializing and re-serialized in the same place. The shorthand array notation is always
+/// reserialized as object.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Values<T> {
+    /// The values of the collection.
+    pub values: Vec<T>,
+}
+
+impl<T> Values<T> {
+    /// Creates an empty values struct.
+    pub fn new() -> Values<T> {
+        Values { values: Vec::new() }
+    }
+
+    /// Checks whether this struct is empty in both values and data.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+impl<T> Default for Values<T> {
+    fn default() -> Self {
+        // Default implemented manually even if <T> does not impl Default.
+        Values::new()
+    }
+}
+
+impl<T> From<Vec<T>> for Values<T> {
+    fn from(values: Vec<T>) -> Self {
+        Values { values }
+    }
+}
+
+impl<T> AsRef<[T]> for Values<T> {
+    fn as_ref(&self) -> &[T] {
+        &self.values
+    }
+}
+
+impl<T> AsMut<Vec<T>> for Values<T> {
+    fn as_mut(&mut self) -> &mut Vec<T> {
+        &mut self.values
+    }
+}
+
+impl<T> ops::Deref for Values<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl<T> ops::DerefMut for Values<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.values
+    }
+}
+
+impl<T> FromIterator<T> for Values<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Vec::<T>::from_iter(iter).into()
+    }
+}
+
+impl<T> Extend<T> for Values<T> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.values.extend(iter)
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Values<T> {
+    type Item = <&'a mut Vec<T> as IntoIterator>::Item;
+    type IntoIter = <&'a mut Vec<T> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter_mut()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Values<T> {
+    type Item = <&'a Vec<T> as IntoIterator>::Item;
+    type IntoIter = <&'a Vec<T> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter()
+    }
+}
+
+impl<T> IntoIterator for Values<T> {
+    type Item = <Vec<T> as IntoIterator>::Item;
+    type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter()
+    }
+}
+
+/// Represents a log entry message.
+///
+/// A log message is similar to the `message` attribute on the event itself but
+/// can additionally hold optional parameters.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct LogEntry {
+    /// The log message with parameters replaced by `%s`
+    pub message: String,
+    /// Positional parameters to be inserted into the log entry.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub params: Vec<Value>,
+}
+
+/// Represents a frame.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct Frame {
+    /// The name of the function is known.
+    ///
+    /// Note that this might include the name of a class as well if that makes
+    /// sense for the language.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    /// The potentially mangled name of the symbol as it appears in an executable.
+    ///
+    /// This is different from a function name by generally being the mangled
+    /// name that appears natively in the binary.  This is relevant for languages
+    /// like Swift, C++ or Rust.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// The name of the module the frame is contained in.
+    ///
+    /// Note that this might also include a class name if that is something the
+    /// language natively considers to be part of the stack (for instance in Java).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+    /// The name of the package that contains the frame.
+    ///
+    /// For instance this can be a dylib for native languages, the name of the jar
+    /// or .NET assembly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    /// The filename (basename only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// If known the absolute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abs_path: Option<String>,
+    /// The line number if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lineno: Option<u64>,
+    /// The column number if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub colno: Option<u64>,
+    /// The sources of the lines leading up to the current line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pre_context: Vec<String>,
+    /// The current line as source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_line: Option<String>,
+    /// The sources of the lines after the current line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_context: Vec<String>,
+    /// In-app indicator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_app: Option<bool>,
+    /// Optional local variables.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub vars: Map<String, Value>,
+    /// If known the location of the image.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_addr: Option<Addr>,
+    /// If known the location of the instruction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instruction_addr: Option<Addr>,
+    /// If known the location of symbol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol_addr: Option<Addr>,
+}
+
+/// Represents template debug info.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct TemplateInfo {
+    /// The filename (basename only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// If known the absolute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abs_path: Option<String>,
+    /// The line number if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lineno: Option<u64>,
+    /// The column number if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub colno: Option<u64>,
+    /// The sources of the lines leading up to the current line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pre_context: Vec<String>,
+    /// The current line as source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_line: Option<String>,
+    /// The sources of the lines after the current line.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub post_context: Vec<String>,
+}
+
+/// Represents a stacktrace.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct Stacktrace {
+    /// The list of frames in the stacktrace.
+    #[serde(default)]
+    pub frames: Vec<Frame>,
+    /// Optionally a segment of frames removed (`start`, `end`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frames_omitted: Option<(u64, u64)>,
+    /// Optional register values of the thread.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub registers: Map<String, RegVal>,
+}
+
+impl Stacktrace {
+    /// Optionally creates a stacktrace from a list of stack frames.
+    pub fn from_frames_reversed(mut frames: Vec<Frame>) -> Option<Stacktrace> {
+        if frames.is_empty() {
+            None
+        } else {
+            frames.reverse();
+            Some(Stacktrace {
+                frames,
+                ..Default::default()
+            })
+        }
+    }
+}
+
+/// Represents a thread id.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[serde(untagged)]
+pub enum ThreadId {
+    /// Integer representation for the thread id
+    Int(u64),
+    /// String representation for the thread id
+    String(String),
+}
+
+impl Default for ThreadId {
+    fn default() -> ThreadId {
+        ThreadId::Int(0)
+    }
+}
+
+impl<'a> From<&'a str> for ThreadId {
+    fn from(id: &'a str) -> ThreadId {
+        ThreadId::String(id.to_string())
+    }
+}
+
+impl From<String> for ThreadId {
+    fn from(id: String) -> ThreadId {
+        ThreadId::String(id)
+    }
+}
+
+impl From<i64> for ThreadId {
+    fn from(id: i64) -> ThreadId {
+        ThreadId::Int(id as u64)
+    }
+}
+
+impl From<i32> for ThreadId {
+    fn from(id: i32) -> ThreadId {
+        ThreadId::Int(id as u64)
+    }
+}
+
+impl From<u32> for ThreadId {
+    fn from(id: u32) -> ThreadId {
+        ThreadId::Int(id as u64)
+    }
+}
+
+impl From<u16> for ThreadId {
+    fn from(id: u16) -> ThreadId {
+        ThreadId::Int(id as u64)
+    }
+}
+
+impl fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ThreadId::Int(i) => write!(f, "{}", i),
+            ThreadId::String(ref s) => write!(f, "{}", s),
+        }
+    }
+}
+
+/// Represents an address.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct Addr(pub u64);
+
+impl Addr {
+    /// Returns `true` if this address is the null pointer.
+    pub fn is_null(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl_hex_serde!(Addr, u64);
+
+impl From<u64> for Addr {
+    fn from(addr: u64) -> Addr {
+        Addr(addr)
+    }
+}
+
+impl From<i32> for Addr {
+    fn from(addr: i32) -> Addr {
+        Addr(addr as u64)
+    }
+}
+
+impl From<u32> for Addr {
+    fn from(addr: u32) -> Addr {
+        Addr(addr as u64)
+    }
+}
+
+impl From<usize> for Addr {
+    fn from(addr: usize) -> Addr {
+        Addr(addr as u64)
+    }
+}
+
+impl<T> From<*const T> for Addr {
+    fn from(addr: *const T) -> Addr {
+        Addr(addr as u64)
+    }
+}
+
+impl<T> From<*mut T> for Addr {
+    fn from(addr: *mut T) -> Addr {
+        Addr(addr as u64)
+    }
+}
+
+impl Into<u64> for Addr {
+    fn into(self) -> u64 {
+        self.0
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+/// Represents a register value.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct RegVal(pub u64);
+
+impl_hex_serde!(RegVal, u64);
+
+impl From<u64> for RegVal {
+    fn from(addr: u64) -> RegVal {
+        RegVal(addr)
+    }
+}
+
+impl From<i32> for RegVal {
+    fn from(addr: i32) -> RegVal {
+        RegVal(addr as u64)
+    }
+}
+
+impl From<u32> for RegVal {
+    fn from(addr: u32) -> RegVal {
+        RegVal(addr as u64)
+    }
+}
+
+impl From<usize> for RegVal {
+    fn from(addr: usize) -> RegVal {
+        RegVal(addr as u64)
+    }
+}
+
+impl<T> From<*const T> for RegVal {
+    fn from(addr: *const T) -> RegVal {
+        RegVal(addr as u64)
+    }
+}
+
+impl<T> From<*mut T> for RegVal {
+    fn from(addr: *mut T) -> RegVal {
+        RegVal(addr as u64)
+    }
+}
+
+impl Into<u64> for RegVal {
+    fn into(self) -> u64 {
+        self.0
+    }
+}
+
+/// Represents a single thread.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct Thread {
+    /// The optional ID of the thread (usually an integer)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<ThreadId>,
+    /// The optional name of the thread.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// If the thread suspended or crashed a stacktrace can be
+    /// attached here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stacktrace: Option<Stacktrace>,
+    /// Optional raw stacktrace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_stacktrace: Option<Stacktrace>,
+    /// True if this is the crashed thread.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub crashed: bool,
+    /// Indicates that the thread was not suspended when the
+    /// event was created.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub current: bool,
+}
+
+/// POSIX signal with optional extended data.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+pub struct CError {
+    /// The error code as specified by ISO C99, POSIX.1-2001 or POSIX.1-2008.
+    pub number: i32,
+    /// Optional name of the errno constant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl From<i32> for CError {
+    fn from(number: i32) -> CError {
+        CError { number, name: None }
+    }
+}
+
+impl Into<i32> for CError {
+    fn into(self) -> i32 {
+        self.number
+    }
+}
+
+/// Mach exception information.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+pub struct MachException {
+    /// The mach exception type.
+    pub exception: i32,
+    /// The mach exception code.
+    pub code: u64,
+    /// The mach exception subcode.
+    pub subcode: u64,
+    /// Optional name of the mach exception.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// POSIX signal with optional extended data.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+pub struct PosixSignal {
+    /// The POSIX signal number.
+    pub number: i32,
+    /// An optional signal code present on Apple systems.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<i32>,
+    /// Optional name of the errno constant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Optional name of the errno constant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_name: Option<String>,
+}
+
+impl From<i32> for PosixSignal {
+    fn from(number: i32) -> PosixSignal {
+        PosixSignal {
+            number,
+            code: None,
+            name: None,
+            code_name: None,
+        }
+    }
+}
+
+impl From<(i32, i32)> for PosixSignal {
+    fn from(tuple: (i32, i32)) -> PosixSignal {
+        let (number, code) = tuple;
+        PosixSignal {
+            number,
+            code: Some(code),
+            name: None,
+            code_name: None,
+        }
+    }
+}
+
+impl Into<i32> for PosixSignal {
+    fn into(self) -> i32 {
+        self.number
+    }
+}
+
+/// Operating system or runtime meta information to an exception mechanism.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct MechanismMeta {
+    /// Optional ISO C standard error code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub errno: Option<CError>,
+    /// Optional POSIX signal number.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<PosixSignal>,
+    /// Optional mach exception information.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mach_exception: Option<MachException>,
+}
+
+impl MechanismMeta {
+    fn is_empty(&self) -> bool {
+        self.errno.is_none() && self.signal.is_none() && self.mach_exception.is_none()
+    }
+}
+
+/// Represents a single exception.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct Mechanism {
+    /// The mechanism type identifier.
+    #[serde(rename = "type")]
+    pub ty: String,
+    /// Human readable detail description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// An optional link to online resources describing this error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub help_link: Option<Url>,
+    /// An optional flag indicating whether this exception was handled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handled: Option<bool>,
+    /// An optional flag indicating a synthetic exception.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synthetic: Option<bool>,
+    /// Additional attributes depending on the mechanism type.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub data: Map<String, Value>,
+    /// Operating system or runtime meta information.
+    #[serde(default, skip_serializing_if = "MechanismMeta::is_empty")]
+    pub meta: MechanismMeta,
+}
+
+/// Represents a single exception.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct Exception {
+    /// The type of the exception.
+    #[serde(rename = "type")]
+    pub ty: String,
+    /// The optional value of the exception.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    /// An optional module for this exception.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module: Option<String>,
+    /// Optionally the stacktrace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stacktrace: Option<Stacktrace>,
+    /// An optional raw stacktrace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_stacktrace: Option<Stacktrace>,
+    /// Optional identifier referring to a thread.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<ThreadId>,
+    /// The mechanism of the exception including OS specific exception values.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mechanism: Option<Mechanism>,
+}
+
+/// An error used when parsing `Level`.
+#[derive(Debug, Error)]
+#[error("invalid level")]
+pub struct ParseLevelError;
+
+/// Represents the level of severity of an event or breadcrumb.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Level {
+    /// Indicates very spammy debug information.
+    Debug,
+    /// Informational messages.
+    Info,
+    /// A warning.
+    Warning,
+    /// An error.
+    Error,
+    /// Similar to error but indicates a critical event that usually causes a shutdown.
+    Fatal,
+}
+
+impl Default for Level {
+    fn default() -> Level {
+        Level::Info
+    }
+}
+
+impl str::FromStr for Level {
+    type Err = ParseLevelError;
+
+    fn from_str(string: &str) -> Result<Level, Self::Err> {
+        Ok(match string {
+            "debug" => Level::Debug,
+            "info" | "log" => Level::Info,
+            "warning" => Level::Warning,
+            "error" => Level::Error,
+            "fatal" => Level::Fatal,
+            _ => return Err(ParseLevelError),
+        })
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Level::Debug => write!(f, "debug"),
+            Level::Info => write!(f, "info"),
+            Level::Warning => write!(f, "warning"),
+            Level::Error => write!(f, "error"),
+            Level::Fatal => write!(f, "fatal"),
+        }
+    }
+}
+
+impl Level {
+    /// A quick way to check if the level is `debug`.
+    pub fn is_debug(&self) -> bool {
+        *self == Level::Debug
+    }
+
+    /// A quick way to check if the level is `info`.
+    pub fn is_info(&self) -> bool {
+        *self == Level::Info
+    }
+
+    /// A quick way to check if the level is `warning`.
+    pub fn is_warning(&self) -> bool {
+        *self == Level::Warning
+    }
+
+    /// A quick way to check if the level is `error`.
+    pub fn is_error(&self) -> bool {
+        *self == Level::Error
+    }
+
+    /// A quick way to check if the level is `fatal`.
+    pub fn is_fatal(&self) -> bool {
+        *self == Level::Fatal
+    }
+}
+
+impl_str_serde!(Level);
+
+mod breadcrumb {
+    use super::*;
+
+    pub fn default_timestamp() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    pub fn default_type() -> String {
+        "default".to_string()
+    }
+
+    pub fn is_default_type(ty: &str) -> bool {
+        ty == "default"
+    }
+
+    pub fn default_level() -> Level {
+        Level::Info
+    }
+}
+
+/// Represents a single breadcrumb.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Breadcrumb {
+    /// The timestamp of the breadcrumb.  This is required.
+    #[serde(default = "breadcrumb::default_timestamp", with = "ts_seconds_float")]
+    pub timestamp: DateTime<Utc>,
+    /// The type of the breadcrumb.
+    #[serde(
+        rename = "type",
+        default = "breadcrumb::default_type",
+        skip_serializing_if = "breadcrumb::is_default_type"
+    )]
+    pub ty: String,
+    /// The optional category of the breadcrumb.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    /// The non optional level of the breadcrumb.  It
+    /// defaults to info.
+    #[serde(
+        default = "breadcrumb::default_level",
+        skip_serializing_if = "Level::is_info"
+    )]
+    pub level: Level,
+    /// An optional human readbale message for the breadcrumb.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Arbitrary breadcrumb data that should be send along.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub data: Map<String, Value>,
+}
+
+impl Default for Breadcrumb {
+    fn default() -> Breadcrumb {
+        Breadcrumb {
+            timestamp: breadcrumb::default_timestamp(),
+            ty: breadcrumb::default_type(),
+            category: Default::default(),
+            level: breadcrumb::default_level(),
+            message: Default::default(),
+            data: Default::default(),
+        }
+    }
+}
+
+/// An IP address, either IPv4, IPv6 or Auto.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum IpAddress {
+    /// The IP address needs to be infered from the user's context.
+    Auto,
+    /// The exact given IP address (v4 or v6).
+    Exact(IpAddr),
+}
+
+impl PartialEq<IpAddr> for IpAddress {
+    fn eq(&self, other: &IpAddr) -> bool {
+        match *self {
+            IpAddress::Auto => false,
+            IpAddress::Exact(ref addr) => addr == other,
+        }
+    }
+}
+
+impl cmp::PartialOrd<IpAddr> for IpAddress {
+    fn partial_cmp(&self, other: &IpAddr) -> Option<cmp::Ordering> {
+        match *self {
+            IpAddress::Auto => None,
+            IpAddress::Exact(ref addr) => addr.partial_cmp(other),
+        }
+    }
+}
+
+impl Default for IpAddress {
+    fn default() -> IpAddress {
+        IpAddress::Auto
+    }
+}
+
+impl fmt::Display for IpAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            IpAddress::Auto => write!(f, "{{{{auto}}}}"),
+            IpAddress::Exact(ref addr) => write!(f, "{}", addr),
+        }
+    }
+}
+
+impl From<IpAddr> for IpAddress {
+    fn from(addr: IpAddr) -> IpAddress {
+        IpAddress::Exact(addr)
+    }
+}
+
+impl str::FromStr for IpAddress {
+    type Err = AddrParseError;
+
+    fn from_str(string: &str) -> Result<IpAddress, AddrParseError> {
+        match string {
+            "{{auto}}" => Ok(IpAddress::Auto),
+            other => other.parse().map(IpAddress::Exact),
+        }
+    }
+}
+
+impl_str_serde!(IpAddress);
+
+/// Represents user info.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct User {
+    /// The ID of the user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// The email address of the user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// The remote ip address of the user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ip_address: Option<IpAddress>,
+    /// A human readable username of the user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
+}
+
+/// Represents http request data.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct Request {
+    /// The current URL of the request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<Url>,
+    /// The HTTP request method.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// Optionally some associated request data (human readable)
+    // XXX: this makes absolutely no sense because of unicode
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+    /// Optionally the encoded query string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_string: Option<String>,
+    /// An encoded cookie string if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cookies: Option<String>,
+    /// HTTP request headers.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub headers: Map<String, String>,
+    /// Optionally a CGI/WSGI etc. environment dictionary.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub env: Map<String, String>,
+}
+
+/// Holds information about the system SDK.
+///
+/// This is relevant for iOS and other platforms that have a system
+/// SDK.  Not to be confused with the client SDK.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SystemSdkInfo {
+    /// The internal name of the SDK
+    pub sdk_name: String,
+    /// the major version of the SDK as integer or 0
+    pub version_major: u32,
+    /// the minor version of the SDK as integer or 0
+    pub version_minor: u32,
+    /// the patch version of the SDK as integer or 0
+    pub version_patchlevel: u32,
+}
+
+/// Represents a debug image.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum DebugImage {
+    /// Apple debug images (machos).  This is currently also used for
+    /// non apple platforms with similar debug setups.
+    Apple(AppleDebugImage),
+    /// Symbolic (new style) debug infos.
+    Symbolic(SymbolicDebugImage),
+    /// A reference to a proguard debug file.
+    Proguard(ProguardDebugImage),
+}
+
+impl DebugImage {
+    /// Returns the name of the type on sentry.
+    pub fn type_name(&self) -> &str {
+        match *self {
+            DebugImage::Apple(..) => "apple",
+            DebugImage::Symbolic(..) => "symbolic",
+            DebugImage::Proguard(..) => "proguard",
+        }
+    }
+}
+
+macro_rules! into_debug_image {
+    ($kind:ident, $ty:ty) => {
+        impl From<$ty> for DebugImage {
+            fn from(data: $ty) -> DebugImage {
+                DebugImage::$kind(data)
+            }
+        }
+    };
+}
+
+/// Represents an apple debug image in the debug meta.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct AppleDebugImage {
+    /// The name of the debug image (usually filename)
+    pub name: String,
+    /// The optional CPU architecture of the debug image.
+    pub arch: Option<String>,
+    /// Alternatively a macho cpu type.
+    pub cpu_type: Option<u32>,
+    /// Alternatively a macho cpu subtype.
+    pub cpu_subtype: Option<u32>,
+    /// The starting address of the image.
+    pub image_addr: Addr,
+    /// The size of the image in bytes.
+    pub image_size: u64,
+    /// The address where the image is loaded at runtime.
+    #[serde(default, skip_serializing_if = "Addr::is_null")]
+    pub image_vmaddr: Addr,
+    /// The unique UUID of the image.
+    pub uuid: Uuid,
+}
+
+/// Represents a symbolic debug image.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SymbolicDebugImage {
+    /// The name of the debug image (usually filename)
+    pub name: String,
+    /// The optional CPU architecture of the debug image.
+    pub arch: Option<String>,
+    /// The starting address of the image.
+    pub image_addr: Addr,
+    /// The size of the image in bytes.
+    pub image_size: u64,
+    /// The address where the image is loaded at runtime.
+    #[serde(default, skip_serializing_if = "Addr::is_null")]
+    pub image_vmaddr: Addr,
+    /// The unique debug id of the image.
+    pub id: DebugId,
+}
+
+/// Represents a proguard mapping file reference.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ProguardDebugImage {
+    /// The UUID of the associated proguard file.
+    pub uuid: Uuid,
+}
+
+into_debug_image!(Apple, AppleDebugImage);
+into_debug_image!(Symbolic, SymbolicDebugImage);
+into_debug_image!(Proguard, ProguardDebugImage);
+
+/// Represents debug meta information.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct DebugMeta {
+    /// Optional system SDK information.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sdk_info: Option<SystemSdkInfo>,
+    /// A list of debug information files.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<DebugImage>,
+}
+
+impl DebugMeta {
+    /// Returns true if the debug meta is empty.
+    ///
+    /// This is used by the serializer to entirely skip the section.
+    pub fn is_empty(&self) -> bool {
+        self.sdk_info.is_none() && self.images.is_empty()
+    }
+}
+
+/// Information on the SDK client.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ClientSdkInfo {
+    /// The name of the SDK.
+    pub name: String,
+    /// The version of the SDK.
+    pub version: String,
+    /// An optional list of integrations that are enabled in this SDK.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub integrations: Vec<String>,
+    /// An optional list of packages that are installed in the SDK's environment.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub packages: Vec<ClientSdkPackage>,
+}
+
+/// Represents an installed package relevant to the SDK.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ClientSdkPackage {
+    /// The name of the package installed.
+    pub name: String,
+    /// The version of the package.
+    pub version: String,
+}
+
+/// Typed contextual data.
+///
+/// Types like `OsContext` can be directly converted with `.into()`
+/// to `Context`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum Context {
+    /// Device data.
+    Device(Box<DeviceContext>),
+    /// Operating system data.
+    Os(Box<OsContext>),
+    /// Runtime data.
+    Runtime(Box<RuntimeContext>),
+    /// Application data.
+    App(Box<AppContext>),
+    /// Web browser data.
+    Browser(Box<BrowserContext>),
+    /// Generic other context data.
+    #[serde(rename = "unknown")]
+    Other(Map<String, Value>),
+}
+
+impl Context {
+    /// Returns the name of the type for sentry.
+    pub fn type_name(&self) -> &str {
+        match *self {
+            Context::Device(..) => "device",
+            Context::Os(..) => "os",
+            Context::Runtime(..) => "runtime",
+            Context::App(..) => "app",
+            Context::Browser(..) => "browser",
+            Context::Other(..) => "unknown",
+        }
+    }
+}
+
+/// Optional device screen orientation
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum Orientation {
+    /// Portrait device orientation.
+    Portrait,
+    /// Landscape device orientation.
+    Landscape,
+}
+
+/// Holds device information.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct DeviceContext {
+    /// The name of the device.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The family of the device model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    /// The device model (human readable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// The device model (internal identifier).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    /// The native cpu architecture of the device.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arch: Option<String>,
+    /// The current battery level (0-100).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub battery_level: Option<f32>,
+    /// The current screen orientation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orientation: Option<Orientation>,
+    /// Simulator/prod indicator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub simulator: Option<bool>,
+    /// Total memory available in byts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_size: Option<u64>,
+    /// How much memory is still available in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub free_memory: Option<u64>,
+    /// How much memory is usable for the app in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usable_memory: Option<u64>,
+    /// Total storage size of the device in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_size: Option<u64>,
+    /// How much storage is free in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub free_storage: Option<u64>,
+    /// Total size of the attached external storage in bytes (eg: android SDK card).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_storage_size: Option<u64>,
+    /// Free size of the attached external storage in bytes (eg: android SDK card).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_free_storage: Option<u64>,
+    /// Optionally an indicator when the device was booted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boot_time: Option<DateTime<Utc>>,
+    /// The timezone of the device.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
+}
+
+/// Holds operating system information.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct OsContext {
+    /// The name of the operating system.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The version of the operating system.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// The internal build number of the operating system.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build: Option<String>,
+    /// The current kernel version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kernel_version: Option<String>,
+    /// An indicator if the os is rooted (mobile mostly).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rooted: Option<bool>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
+}
+
+/// Holds information about the runtime.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct RuntimeContext {
+    /// The name of the runtime (for instance JVM).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The version of the runtime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
+}
+
+/// Holds app information.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct AppContext {
+    /// Optional start time of the app.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_start_time: Option<DateTime<Utc>>,
+    /// Optional device app hash (app specific device ID)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device_app_hash: Option<String>,
+    /// Optional build identicator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_type: Option<String>,
+    /// Optional app identifier (dotted bundle id).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_identifier: Option<String>,
+    /// Application name as it appears on the platform.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_name: Option<String>,
+    /// Application version as it appears on the platform.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_version: Option<String>,
+    /// Internal build ID as it appears on the platform.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_build: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
+}
+
+/// Holds information about the web browser.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct BrowserContext {
+    /// The name of the browser (for instance "Chrome").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The version of the browser.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Additional arbitrary fields for forwards compatibility.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
+}
+
+macro_rules! into_context {
+    ($kind:ident, $ty:ty) => {
+        impl From<$ty> for Context {
+            fn from(data: $ty) -> Self {
+                Context::$kind(Box::new(data))
+            }
+        }
+    };
+}
+
+into_context!(App, AppContext);
+into_context!(Device, DeviceContext);
+into_context!(Os, OsContext);
+into_context!(Runtime, RuntimeContext);
+into_context!(Browser, BrowserContext);
+
+mod event {
+    use super::*;
+
+    pub fn default_id() -> Uuid {
+        Uuid::new_v4()
+    }
+
+    pub fn serialize_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_some(&uuid.to_simple_ref().to_string())
+    }
+
+    pub fn default_level() -> Level {
+        Level::Error
+    }
+
+    pub fn default_platform() -> Cow<'static, str> {
+        Cow::Borrowed("other")
+    }
+
+    pub fn is_default_platform(value: &str) -> bool {
+        value == "other"
+    }
+
+    static DEFAULT_FINGERPRINT: &[Cow<'static, str>] = &[Cow::Borrowed("{{ default }}")];
+
+    pub fn default_fingerprint<'a>() -> Cow<'a, [Cow<'a, str>]> {
+        Cow::Borrowed(DEFAULT_FINGERPRINT)
+    }
+
+    #[allow(clippy::ptr_arg)]
+    pub fn is_default_fingerprint<'a>(fp: &[Cow<'a, str>]) -> bool {
+        fp.len() == 1 && ((&fp)[0] == "{{ default }}" || (&fp)[0] == "{{default}}")
+    }
+
+    pub fn default_timestamp() -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// Represents a full event for Sentry.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Event<'a> {
+    /// The ID of the event
+    #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
+    pub event_id: Uuid,
+    /// The level of the event (defaults to error)
+    #[serde(
+        default = "event::default_level",
+        skip_serializing_if = "Level::is_error"
+    )]
+    pub level: Level,
+    /// An optional fingerprint configuration to override the default.
+    #[serde(
+        default = "event::default_fingerprint",
+        skip_serializing_if = "event::is_default_fingerprint"
+    )]
+    pub fingerprint: Cow<'a, [Cow<'a, str>]>,
+    /// The culprit of the event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub culprit: Option<String>,
+    /// The transaction name of the event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction: Option<String>,
+    /// A message to be sent with the event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Optionally a log entry that can be used instead of the message for
+    /// more complex cases.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logentry: Option<LogEntry>,
+    /// Optionally the name of the logger that created this event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logger: Option<String>,
+    /// Optionally a name to version mapping of installed modules.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub modules: Map<String, String>,
+    /// A platform identifier for this event.
+    #[serde(
+        default = "event::default_platform",
+        skip_serializing_if = "event::is_default_platform"
+    )]
+    pub platform: Cow<'a, str>,
+    /// The timestamp of when the event was created.
+    ///
+    /// This can be set to `None` in which case the server will set a timestamp.
+    #[serde(default = "event::default_timestamp", with = "ts_seconds_float")]
+    pub timestamp: DateTime<Utc>,
+    /// Optionally the server (or device) name of this event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_name: Option<Cow<'a, str>>,
+    /// A release identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release: Option<Cow<'a, str>>,
+    /// An optional distribution identifer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dist: Option<Cow<'a, str>>,
+    /// An optional environment identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<Cow<'a, str>>,
+    /// Optionally user data to be sent along.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
+    /// Optionally HTTP request data to be sent along.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request: Option<Request>,
+    /// Optional contexts.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub contexts: Map<String, Context>,
+    /// List of breadcrumbs to send along.
+    #[serde(default, skip_serializing_if = "Values::is_empty")]
+    pub breadcrumbs: Values<Breadcrumb>,
+    /// Exceptions to be attached (one or multiple if chained).
+    #[serde(default, skip_serializing_if = "Values::is_empty")]
+    pub exception: Values<Exception>,
+    /// A single stacktrace (deprecated)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stacktrace: Option<Stacktrace>,
+    /// Simplified template error location info
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template: Option<TemplateInfo>,
+    /// A list of threads.
+    #[serde(default, skip_serializing_if = "Values::is_empty")]
+    pub threads: Values<Thread>,
+    /// Optional tags to be attached to the event.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub tags: Map<String, String>,
+    /// Optional extra information to be sent with the event.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub extra: Map<String, Value>,
+    /// Debug meta information.
+    #[serde(default, skip_serializing_if = "DebugMeta::is_empty")]
+    pub debug_meta: Cow<'a, DebugMeta>,
+    /// SDK metadata
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sdk: Option<Cow<'a, ClientSdkInfo>>,
+}
+
+impl<'a> Default for Event<'a> {
+    fn default() -> Self {
+        Event {
+            event_id: event::default_id(),
+            level: event::default_level(),
+            fingerprint: event::default_fingerprint(),
+            culprit: Default::default(),
+            transaction: Default::default(),
+            message: Default::default(),
+            logentry: Default::default(),
+            logger: Default::default(),
+            modules: Default::default(),
+            platform: event::default_platform(),
+            timestamp: event::default_timestamp(),
+            server_name: Default::default(),
+            release: Default::default(),
+            dist: Default::default(),
+            environment: Default::default(),
+            user: Default::default(),
+            request: Default::default(),
+            contexts: Default::default(),
+            breadcrumbs: Default::default(),
+            exception: Default::default(),
+            stacktrace: Default::default(),
+            template: Default::default(),
+            threads: Default::default(),
+            tags: Default::default(),
+            extra: Default::default(),
+            debug_meta: Default::default(),
+            sdk: Default::default(),
+        }
+    }
+}
+
+impl<'a> Event<'a> {
+    /// Creates a new event with the current timestamp and random id.
+    pub fn new() -> Event<'a> {
+        Default::default()
+    }
+
+    /// Creates a fully owned version of the event.
+    pub fn into_owned(self) -> Event<'static> {
+        Event {
+            event_id: self.event_id,
+            level: self.level,
+            fingerprint: Cow::Owned(
+                self.fingerprint
+                    .iter()
+                    .map(|x| Cow::Owned(x.to_string()))
+                    .collect(),
+            ),
+            culprit: self.culprit,
+            transaction: self.transaction,
+            message: self.message,
+            logentry: self.logentry,
+            logger: self.logger,
+            modules: self.modules,
+            platform: Cow::Owned(self.platform.into_owned()),
+            timestamp: self.timestamp,
+            server_name: self.server_name.map(|x| Cow::Owned(x.into_owned())),
+            release: self.release.map(|x| Cow::Owned(x.into_owned())),
+            dist: self.dist.map(|x| Cow::Owned(x.into_owned())),
+            environment: self.environment.map(|x| Cow::Owned(x.into_owned())),
+            user: self.user,
+            request: self.request,
+            contexts: self.contexts,
+            breadcrumbs: self.breadcrumbs,
+            exception: self.exception,
+            stacktrace: self.stacktrace,
+            template: self.template,
+            threads: self.threads,
+            tags: self.tags,
+            extra: self.extra,
+            debug_meta: Cow::Owned(self.debug_meta.into_owned()),
+            sdk: self.sdk.map(|x| Cow::Owned(x.into_owned())),
+        }
+    }
+}
+
+impl<'a> fmt::Display for Event<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Event(id: {}, ts: {})", self.event_id, self.timestamp)
+    }
+}

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -1,0 +1,91 @@
+#![cfg_attr(not(feature = "with_protocol"), allow(unused))]
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
+
+/// Converts a datetime object into a float timestamp.
+pub fn datetime_to_timestamp(dt: &DateTime<Utc>) -> f64 {
+    if dt.timestamp_subsec_nanos() == 0 {
+        dt.timestamp() as f64
+    } else {
+        (dt.timestamp() as f64) + ((dt.timestamp_subsec_micros() as f64) / 1_000_000f64)
+    }
+}
+
+pub fn timestamp_to_datetime(ts: f64) -> LocalResult<DateTime<Utc>> {
+    let secs = ts as i64;
+    let micros = (ts.fract() * 1_000_000f64) as u32;
+    Utc.timestamp_opt(secs, micros * 1000)
+}
+
+pub mod ts_seconds_float {
+    use chrono::{DateTime, LocalResult, TimeZone, Utc};
+    use serde::{de, ser};
+    use std::fmt;
+
+    use super::timestamp_to_datetime;
+
+    pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Ok(d.deserialize_any(SecondsTimestampVisitor)
+            .map(|dt| dt.with_timezone(&Utc))?)
+    }
+
+    pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        if dt.timestamp_subsec_nanos() == 0 {
+            serializer.serialize_i64(dt.timestamp())
+        } else {
+            serializer.serialize_f64(
+                (dt.timestamp() as f64) + ((dt.timestamp_subsec_micros() as f64) / 1_000_000f64),
+            )
+        }
+    }
+
+    struct SecondsTimestampVisitor;
+
+    impl<'de> de::Visitor<'de> for SecondsTimestampVisitor {
+        type Value = DateTime<Utc>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a unix timestamp")
+        }
+
+        fn visit_f64<E>(self, value: f64) -> Result<DateTime<Utc>, E>
+        where
+            E: de::Error,
+        {
+            match timestamp_to_datetime(value) {
+                LocalResult::None => Err(E::custom(format!("No such local time for {}", value))),
+                LocalResult::Single(date) => Ok(date),
+                LocalResult::Ambiguous(t1, t2) => Err(E::custom(format!(
+                    "Ambiguous local time, ranging from {:?} to {:?}",
+                    t1, t2
+                ))),
+            }
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<DateTime<Utc>, E>
+        where
+            E: de::Error,
+        {
+            Ok(Utc.timestamp_opt(value, 0).unwrap())
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<DateTime<Utc>, E>
+        where
+            E: de::Error,
+        {
+            Ok(Utc.timestamp_opt(value as i64, 0).unwrap())
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<DateTime<Utc>, E>
+        where
+            E: de::Error,
+        {
+            value.parse().map_err(|e| E::custom(format!("{}", e)))
+        }
+    }
+}

--- a/sentry-types/tests/test_auth.rs
+++ b/sentry-types/tests/test_auth.rs
@@ -1,0 +1,118 @@
+use serde_json;
+
+use std::collections::HashMap;
+
+use chrono::{TimeZone, Utc};
+use sentry_types::{protocol, Auth, Dsn};
+
+#[test]
+fn test_auth_parsing() {
+    let auth: Auth = "Sentry sentry_timestamp=1328055286.5, \
+                      sentry_client=raven-python/42, \
+                      sentry_version=6, \
+                      sentry_key=public, \
+                      sentry_secret=secret"
+        .parse()
+        .unwrap();
+    assert_eq!(
+        auth.timestamp(),
+        Some(Utc.ymd(2012, 2, 1).and_hms_milli(0, 14, 46, 500))
+    );
+    assert_eq!(auth.client_agent(), Some("raven-python/42"));
+    assert_eq!(auth.version(), 6);
+    assert_eq!(auth.public_key(), "public");
+    assert_eq!(auth.secret_key(), Some("secret"));
+
+    assert_eq!(
+        auth.to_string(),
+        "Sentry sentry_key=public, \
+         sentry_version=6, \
+         sentry_timestamp=1328055286.5, \
+         sentry_client=raven-python/42, \
+         sentry_secret=secret"
+    );
+}
+
+#[test]
+fn test_auth_float_parsing() {
+    let auth: Auth = "Sentry sentry_version=2.0, \
+                      sentry_key=public"
+        .parse()
+        .unwrap();
+    assert_eq!(auth.version(), 2);
+    assert_eq!(auth.public_key(), "public");
+
+    assert_eq!(
+        auth.to_string(),
+        "Sentry sentry_key=public, \
+         sentry_version=2"
+    );
+}
+#[test]
+fn test_auth_from_iterator() {
+    let mut cont = HashMap::new();
+    cont.insert("sentry_version", "7");
+    cont.insert("sentry_client", "raven-js/3.23.3");
+    cont.insert("sentry_key", "4bb5d94de752a36b8b87851a3f82726a");
+
+    let auth = Auth::from_pairs(cont.into_iter()).unwrap();
+    assert_eq!(auth.timestamp(), None);
+    assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));
+    assert_eq!(auth.version(), 7);
+    assert_eq!(auth.public_key(), "4bb5d94de752a36b8b87851a3f82726a");
+    assert_eq!(auth.secret_key(), None);
+}
+
+#[test]
+fn test_auth_from_querystring() {
+    let auth = Auth::from_querystring(b"sentry_version=7&sentry_client=raven-js/3.23.3&sentry_key=4bb5d94de752a36b8b87851a3f82726a").unwrap();
+
+    assert_eq!(auth.timestamp(), None);
+    assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));
+    assert_eq!(auth.version(), 7);
+    assert_eq!(auth.public_key(), "4bb5d94de752a36b8b87851a3f82726a");
+    assert_eq!(auth.secret_key(), None);
+}
+
+#[test]
+fn test_auth_to_dsn() {
+    let url = "https://username:password@domain:8888/23";
+    let dsn = url.parse::<Dsn>().unwrap();
+    let auth = dsn.to_auth(Some("sentry-rust/1.0"));
+    assert_eq!(auth.client_agent(), Some("sentry-rust/1.0"));
+    assert_eq!(auth.version(), protocol::LATEST);
+    assert_eq!(auth.public_key(), "username");
+    assert_eq!(auth.secret_key(), Some("password"));
+}
+
+#[test]
+fn test_auth_to_json() {
+    let mut cont = HashMap::new();
+    cont.insert("sentry_version", "7");
+    cont.insert("sentry_client", "raven-js/3.23.3");
+    cont.insert("sentry_key", "4bb5d94de752a36b8b87851a3f82726a");
+
+    let auth = Auth::from_pairs(cont.into_iter()).unwrap();
+    assert_eq!(
+        serde_json::to_string(&auth).expect("could not serialize").as_str(),
+        "{\"sentry_client\":\"raven-js/3.23.3\",\"sentry_version\":7,\"sentry_key\":\"4bb5d94de752a36b8b87851a3f82726a\",\"sentry_secret\":null}"
+    );
+}
+
+#[test]
+fn test_auth_from_json() {
+    let json = "{\"sentry_client\":\"raven-js/3.23.3\",\"sentry_version\":7,\"sentry_key\":\"4bb5d94de752a36b8b87851a3f82726a\"}";
+    let auth: Auth = serde_json::from_str(json).expect("could not deserialize");
+
+    assert_eq!(auth.timestamp(), None);
+    assert_eq!(auth.client_agent(), Some("raven-js/3.23.3"));
+    assert_eq!(auth.version(), 7);
+    assert_eq!(auth.public_key(), "4bb5d94de752a36b8b87851a3f82726a");
+    assert_eq!(auth.secret_key(), None);
+}
+
+#[test]
+fn test_auth_string_timestamp() {
+    let auth = Auth::from_querystring(b"sentry_version=7&sentry_client=raven-clj&sentry_key=4bb5d94de752a36b8b87851a3f82726a&sentry_timestamp=2019-12-13 12:02:58.94").unwrap();
+    assert_eq!(auth.timestamp(), None);
+}

--- a/sentry-types/tests/test_protocol_v7.rs
+++ b/sentry-types/tests/test_protocol_v7.rs
@@ -1,0 +1,1439 @@
+#[macro_use]
+extern crate serde_json;
+
+use chrono;
+
+use uuid;
+
+use chrono::{DateTime, TimeZone, Utc};
+use std::borrow::Cow;
+use uuid::Uuid;
+
+use sentry_types::protocol::v7;
+
+fn event_id() -> Uuid {
+    "d43e86c9-6e42-4a93-a4fb-da156dd17341".parse().unwrap()
+}
+
+fn event_time() -> DateTime<Utc> {
+    Utc.ymd(2017, 12, 24).and_hms(8, 12, 0)
+}
+
+fn reserialize(event: &v7::Event<'_>) -> v7::Event<'static> {
+    let json = serde_json::to_string(event).unwrap();
+    serde_json::from_str(&json).unwrap()
+}
+
+fn assert_roundtrip(event: &v7::Event<'_>) {
+    let event_roundtripped = reserialize(event);
+    assert_eq!(&event.clone().into_owned(), &event_roundtripped);
+}
+
+mod test_event {
+    use super::*;
+
+    #[test]
+    fn test_event_default_vs_new() {
+        let event = reserialize(&v7::Event::new());
+
+        assert!(event.event_id != uuid::Uuid::nil());
+        assert_eq!(event.fingerprint, vec!["{{ default }}".to_string()]);
+        assert_eq!(event.platform, "other");
+        assert_eq!(event.level, v7::Level::Error);
+        assert_eq!(event.sdk, None);
+    }
+
+    #[test]
+    fn test_event_to_string_timestamp() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            ..Default::default()
+        };
+        assert_eq!(
+            event.to_string(),
+            "Event(id: d43e86c9-6e42-4a93-a4fb-da156dd17341, ts: 2017-12-24 08:12:00 UTC)"
+        );
+    }
+
+    #[test]
+    fn test_event_release_and_dist() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            dist: Some("42".into()),
+            release: Some("my.awesome.app-1.0".into()),
+            environment: Some("prod".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"release\":\"my.awesome.app-1.0\",\"dist\":\"42\",\"environment\":\"prod\"}"
+        );
+    }
+
+    #[test]
+    fn test_transaction() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            message: Some("Hello World!".to_string()),
+            transaction: Some("bar::foo".to_string()),
+            level: v7::Level::Info,
+            ..Default::default()
+        };
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"info\",\
+             \"transaction\":\"bar::foo\",\"message\":\"Hello World!\",\"timestamp\":1514103120}"
+        );
+    }
+
+    #[test]
+    fn test_logger() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            level: v7::Level::Warning,
+            message: Some("Hello World!".to_string()),
+            logger: Some("root".to_string()),
+            ..Default::default()
+        };
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"warning\",\"message\":\
+             \"Hello World!\",\"logger\":\"root\",\"timestamp\":1514103120}"
+        );
+    }
+
+    #[test]
+    fn test_culprit() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            message: Some("Hello World!".to_string()),
+            culprit: Some("foo in bar".to_string()),
+            level: v7::Level::Info,
+            ..Default::default()
+        };
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"info\",\"culprit\":\
+             \"foo in bar\",\"message\":\"Hello World!\",\"timestamp\":1514103120}"
+        );
+    }
+}
+
+mod test_fingerprint {
+    use super::*;
+
+    #[test]
+    fn test_fingerprint_simple() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            fingerprint: Cow::Owned(vec!["{{ default }}".into(), "extra".into()]),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"fingerprint\":[\"{{ default \
+             }}\",\"extra\"],\"timestamp\":1514103120}"
+        );
+    }
+
+    #[test]
+    fn test_fingerprint_string() {
+        assert_eq!(
+            v7::Event {
+                event_id: event_id(),
+                timestamp: event_time(),
+                fingerprint: Cow::Borrowed(&["fingerprint".into()]),
+                ..Default::default()
+            },
+            serde_json::from_str(
+                "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"fingerprint\":\
+                 [\"fingerprint\"],\"timestamp\":1514103120}"
+            )
+            .unwrap()
+        )
+    }
+
+    #[test]
+    fn test_fingerprint_empty() {
+        assert_eq!(
+            v7::Event {
+                event_id: event_id(),
+                timestamp: event_time(),
+                fingerprint: Cow::Borrowed(&[]),
+                ..Default::default()
+            },
+            serde_json::from_str(
+                "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"fingerprint\":[],\
+                 \"timestamp\":1514103120}"
+            )
+            .unwrap()
+        )
+    }
+}
+
+mod test_values {
+    use super::*;
+
+    #[test]
+    fn test_values_object() {
+        let values = v7::Values {
+            values: vec![1, 2, 3],
+        };
+
+        assert_eq!(
+            values,
+            serde_json::from_str("{\"values\":[1,2,3]}").unwrap()
+        );
+
+        assert_eq!(
+            serde_json::to_string(&values).unwrap(),
+            "{\"values\":[1,2,3]}".to_string()
+        );
+    }
+
+    #[test]
+    fn test_values_option() {
+        assert_eq!(
+            None,
+            serde_json::from_str::<Option<v7::Values<u32>>>("null").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_values_empty() {
+        assert!(v7::Values::<u32>::new().is_empty());
+        assert!(!v7::Values::from(vec![1, 2, 3]).is_empty())
+    }
+}
+
+mod test_logentry {
+    use super::*;
+
+    #[test]
+    fn test_logentry_basics() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            logentry: Some(v7::LogEntry {
+                message: "Hello %s!".to_string(),
+                params: vec!["World".into()],
+            }),
+            culprit: Some("foo in bar".to_string()),
+            level: v7::Level::Debug,
+            ..Default::default()
+        };
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"level\":\"debug\",\"culprit\":\
+             \"foo in bar\",\"logentry\":{\"message\":\"Hello \
+             %s!\",\"params\":[\"World\"]},\"timestamp\":1514103120}"
+        );
+    }
+
+    #[test]
+    fn test_logentry_no_params() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            logentry: Some(v7::LogEntry {
+                message: "Hello World!".to_string(),
+                params: vec![],
+            }),
+            ..Default::default()
+        };
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"logentry\":{\"message\":\"Hello \
+             World!\"},\"timestamp\":1514103120}"
+        );
+    }
+}
+
+#[test]
+fn test_modules() {
+    let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
+        modules: {
+            let mut m = v7::Map::new();
+            m.insert("System".into(), "1.0.0".into());
+            m
+        },
+        ..Default::default()
+    };
+    assert_roundtrip(&event);
+    assert_eq!(
+        serde_json::to_string(&event).unwrap(),
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"modules\":{\"System\":\"1.0.0\"},\
+         \"timestamp\":1514103120}"
+    );
+}
+
+mod test_timestamp {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_timestamp_utc() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120}"
+        );
+
+        let event: v7::Event<'_> =
+            serde_json::from_slice(b"{\"timestamp\":\"2017-12-24T08:12:00Z\"}").unwrap();
+        assert_eq!(event.timestamp, event_time());
+    }
+
+    #[test]
+    fn test_timestamp_float() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: Utc.ymd(2017, 12, 24).and_hms_milli(8, 12, 0, 500),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120.5}"
+        );
+    }
+}
+
+mod test_user {
+    use super::*;
+
+    #[test]
+    fn test_user_minimal() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            user: Some(v7::User {
+                id: Some("8fd5a33b-5b0e-45b2-aff2-9e4f067756ba".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"user\":\
+             {\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\"}}"
+        );
+    }
+
+    #[test]
+    fn test_user_full() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            user: Some(v7::User {
+                id: Some("8fd5a33b-5b0e-45b2-aff2-9e4f067756ba".into()),
+                email: Some("foo@example.invalid".into()),
+                ip_address: Some("127.0.0.1".parse().unwrap()),
+                username: Some("john-doe".into()),
+                other: {
+                    let mut hm = v7::Map::new();
+                    hm.insert("foo".into(), "bar".into());
+                    hm
+                },
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"user\":\
+             {\"id\":\"8fd5a33b-5b0e-45b2-aff2-9e4f067756ba\",\"email\":\"foo@example.invalid\",\
+             \"ip_address\":\"127.0.0.1\",\"username\":\"john-doe\",\"foo\":\"bar\"}}"
+        );
+    }
+
+    #[test]
+    fn test_user_ip_address_auto() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            user: Some(v7::User {
+                ip_address: Some(v7::IpAddress::Auto),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"user\":\
+             {\"ip_address\":\"{{auto}}\"}}"
+        );
+    }
+}
+
+mod test_breadcrumbs {
+    use super::*;
+
+    #[test]
+    fn test_breadcrumbs_values() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            breadcrumbs: vec![
+                v7::Breadcrumb {
+                    timestamp: event_time(),
+                    category: Some("ui.click".into()),
+                    message: Some("span.platform-card > li.platform-tile".into()),
+                    ..Default::default()
+                },
+                v7::Breadcrumb {
+                    timestamp: event_time(),
+                    ty: "http".into(),
+                    category: Some("xhr".into()),
+                    data: {
+                        let mut m = v7::Map::new();
+                        m.insert("url".into(), "/api/0/organizations/foo".into());
+                        m.insert("status_code".into(), 200.into());
+                        m.insert("method".into(), "GET".into());
+                        m
+                    },
+                    ..Default::default()
+                },
+            ]
+            .into(),
+            ..Default::default()
+        };
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"breadcrumbs\":{\"values\":[{\"timestamp\":1514103120,\"category\":\"ui.click\",\
+             \"message\":\"span.platform-card > \
+             li.platform-tile\"},{\"timestamp\":1514103120,\"type\":\"http\",\"category\":\"xhr\",\
+             \"data\":{\"method\":\"GET\",\"status_code\":200,\"url\":\
+             \"/api/0/organizations/foo\"}}]}}"
+        );
+    }
+}
+
+mod test_stacktrace {
+    use super::*;
+
+    #[test]
+    fn test_stacktrace() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            stacktrace: Some(v7::Stacktrace {
+                frames: vec![v7::Frame {
+                    function: Some("main".into()),
+                    filename: Some("hello.py".into()),
+                    lineno: Some(1),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"stacktrace\":{\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\
+             \"lineno\":1}]}}"
+        );
+    }
+}
+
+mod test_template_info {
+    use super::*;
+
+    #[test]
+    fn test_template_info() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            template: Some(v7::TemplateInfo {
+                filename: Some("hello.html".into()),
+                lineno: Some(1),
+                pre_context: vec!["foo1".into(), "bar2".into()],
+                context_line: Some("hey hey hey3".into()),
+                post_context: vec!["foo4".into(), "bar5".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"template\":{\"filename\":\"hello.html\",\"lineno\":1,\"pre_context\":[\"foo1\",\
+             \"bar2\"],\"context_line\":\"hey hey hey3\",\"post_context\":[\"foo4\",\"bar5\"]}}"
+        );
+    }
+}
+
+mod test_threads {
+    use super::*;
+
+    #[test]
+    fn test_threads_values() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            threads: vec![v7::Thread {
+                id: Some("#1".into()),
+                name: Some("Awesome Thread".into()),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"threads\":{\"values\":[{\"id\":\"#1\",\"name\":\"Awesome Thread\"}]}}"
+        );
+    }
+
+    #[test]
+    fn test_threads_flags() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            threads: vec![v7::Thread {
+                id: Some(42.into()),
+                name: Some("Awesome Thread".into()),
+                crashed: true,
+                current: true,
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"threads\":{\"values\":[{\"id\":42,\"name\":\"Awesome \
+             Thread\",\"crashed\":true,\"current\":true}]}}"
+        );
+    }
+
+    #[test]
+    fn test_threads_stacktrace() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            threads: vec![v7::Thread {
+                stacktrace: Some(v7::Stacktrace {
+                    frames: vec![v7::Frame {
+                        function: Some("main".into()),
+                        filename: Some("hello.py".into()),
+                        lineno: Some(1),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                raw_stacktrace: Some(v7::Stacktrace {
+                    frames: vec![v7::Frame {
+                        function: Some("main".into()),
+                        filename: Some("hello.py".into()),
+                        lineno: Some(1),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"threads\":{\"values\":[{\"stacktrace\":{\"frames\":[{\"function\":\"main\",\
+             \"filename\":\"hello.py\",\"lineno\":1}]},\"raw_stacktrace\":{\"frames\":\
+             [{\"function\":\"main\",\"filename\":\"hello.py\",\"lineno\":1}]}}]}}"
+        );
+    }
+}
+
+mod test_request {
+    use super::*;
+
+    #[test]
+    fn test_request_full() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            request: Some(v7::Request {
+                url: "https://www.example.invalid/bar".parse().ok(),
+                method: Some("GET".into()),
+                data: Some("{}".into()),
+                query_string: Some("foo=bar&blub=blah".into()),
+                cookies: Some("dummy=42".into()),
+                headers: {
+                    let mut hm = v7::Map::new();
+                    hm.insert("Content-Type".into(), "text/plain".into());
+                    hm
+                },
+                env: {
+                    let mut env = v7::Map::new();
+                    env.insert("PATH_INFO".into(), "/bar".into());
+                    env
+                },
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"request\":{\"url\":\"https://www.example.invalid/bar\",\"method\":\"GET\",\"data\":\
+             \"{}\",\"query_string\":\"foo=bar&blub=blah\",\"cookies\":\"dummy=42\",\"headers\":\
+             {\"Content-Type\":\"text/plain\"},\"env\":{\"PATH_INFO\":\"/bar\"}}}"
+        );
+    }
+
+    #[test]
+    fn test_request_other() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            request: Some(v7::Request {
+                url: "https://www.example.invalid/bar".parse().ok(),
+                method: Some("GET".into()),
+                data: Some("{}".into()),
+                query_string: Some("foo=bar&blub=blah".into()),
+                cookies: Some("dummy=42".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"request\":{\"url\":\"https://www.example.invalid/bar\",\"method\":\"GET\",\"data\":\
+             \"{}\",\"query_string\":\"foo=bar&blub=blah\",\"cookies\":\"dummy=42\"}}"
+        );
+    }
+
+    #[test]
+    fn test_request_defaults() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            request: Some(Default::default()),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"request\":{}}"
+        );
+    }
+}
+
+#[test]
+fn test_tags() {
+    let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
+        tags: {
+            let mut m = v7::Map::new();
+            m.insert("device_type".into(), "mobile".into());
+            m.insert("interpreter".into(), "7".into());
+            m
+        },
+        ..Default::default()
+    };
+
+    assert_roundtrip(&event);
+    assert_eq!(
+        serde_json::to_string(&event).unwrap(),
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"tags\":\
+         {\"device_type\":\"mobile\",\"interpreter\":\"7\"}}"
+    );
+}
+
+#[test]
+fn test_extra() {
+    let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
+        extra: {
+            let mut m = v7::Map::new();
+            m.insert(
+                "component_state".into(),
+                json!({
+                    "dirty": true,
+                    "revision": 17
+                }),
+            );
+            m
+        },
+        ..Default::default()
+    };
+
+    assert_roundtrip(&event);
+    assert_eq!(
+        serde_json::to_string(&event).unwrap(),
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"extra\":\
+         {\"component_state\":{\"dirty\":true,\"revision\":17}}}"
+    );
+}
+
+mod test_debug_meta {
+    use super::*;
+
+    #[test]
+    fn test_debug_meta() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            debug_meta: Cow::Owned(v7::DebugMeta {
+                sdk_info: Some(v7::SystemSdkInfo {
+                    sdk_name: "iOS".into(),
+                    version_major: 10,
+                    version_minor: 3,
+                    version_patchlevel: 0,
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"debug_meta\":{\"sdk_info\":{\"sdk_name\":\"iOS\",\"version_major\":10,\
+             \"version_minor\":3,\"version_patchlevel\":0}}}"
+        );
+    }
+
+    #[test]
+    fn test_debug_meta_images() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            debug_meta: Cow::Owned(v7::DebugMeta {
+                images: vec![
+                    v7::AppleDebugImage {
+                        name: "CoreFoundation".into(),
+                        arch: Some("arm64".into()),
+                        cpu_type: Some(1233),
+                        cpu_subtype: Some(3),
+                        image_addr: 0.into(),
+                        image_size: 4096,
+                        image_vmaddr: 32768.into(),
+                        uuid: "494f3aea-88fa-4296-9644-fa8ef5d139b6".parse().unwrap(),
+                    }
+                    .into(),
+                    v7::SymbolicDebugImage {
+                        name: "CoreFoundation".into(),
+                        arch: Some("arm64".into()),
+                        image_addr: 0.into(),
+                        image_size: 4096,
+                        image_vmaddr: 32768.into(),
+                        id: "494f3aea-88fa-4296-9644-fa8ef5d139b6-1234".parse().unwrap(),
+                    }
+                    .into(),
+                    v7::ProguardDebugImage {
+                        uuid: "8c954262-f905-4992-8a61-f60825f4553b".parse().unwrap(),
+                    }
+                    .into(),
+                ],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"debug_meta\":{\"images\":[{\"type\":\"apple\",\"name\":\"CoreFoundation\",\"arch\":\
+             \"arm64\",\"cpu_type\":1233,\"cpu_subtype\":3,\"image_addr\":\"0x0\",\"image_size\":\
+             4096,\"image_vmaddr\":\"0x8000\",\"uuid\":\"494f3aea-88fa-4296-9644-fa8ef5d139b6\"},\
+             {\"type\":\"symbolic\",\"name\":\"CoreFoundation\",\"arch\":\"arm64\",\"image_addr\":\
+             \"0x0\",\"image_size\":4096,\"image_vmaddr\":\"0x8000\",\"id\":\
+             \"494f3aea-88fa-4296-9644-fa8ef5d139b6-1234\"},{\"type\":\"proguard\",\"uuid\":\
+             \"8c954262-f905-4992-8a61-f60825f4553b\"}]}}"
+        );
+    }
+}
+
+mod test_exception {
+    use super::*;
+
+    #[test]
+    fn test_exception_values() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            exception: vec![v7::Exception {
+                ty: "ZeroDivisionError".into(),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"ZeroDivisionError\"}]}}"
+        );
+    }
+
+    #[test]
+    fn test_exception_stacktrace_minimal() {
+        let event: v7::Event<'_> = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            exception: vec![v7::Exception {
+                ty: "DivisionByZero".into(),
+                value: Some("integer division or modulo by zero".into()),
+                module: None,
+                stacktrace: Some(v7::Stacktrace {
+                    frames: vec![v7::Frame {
+                        function: Some("main".into()),
+                        filename: Some("hello.py".into()),
+                        lineno: Some(1),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                raw_stacktrace: None,
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\"integer division \
+             or modulo by \
+             zero\",\"stacktrace\":{\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\
+             \"lineno\":1}]}}]}}"
+        );
+    }
+
+    #[test]
+    fn test_exception_stacktrace_larger() {
+        let event: v7::Event<'_> = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            exception: vec![v7::Exception {
+                ty: "DivisionByZero".into(),
+                value: Some("integer division or modulo by zero".into()),
+                module: None,
+                stacktrace: Some(v7::Stacktrace {
+                    frames: vec![v7::Frame {
+                        function: Some("main".into()),
+                        filename: Some("hello.py".into()),
+                        lineno: Some(7),
+                        colno: Some(42),
+                        pre_context: vec!["foo".into(), "bar".into()],
+                        context_line: Some("hey hey hey".into()),
+                        post_context: vec!["foo".into(), "bar".into()],
+                        in_app: Some(true),
+                        vars: {
+                            let mut m = v7::Map::new();
+                            m.insert("var".into(), "value".into());
+                            m
+                        },
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                raw_stacktrace: None,
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\"integer division \
+             or modulo by \
+             zero\",\"stacktrace\":{\"frames\":[{\"function\":\"main\",\"filename\":\"hello.py\",\
+             \"lineno\":7,\"colno\":42,\"pre_context\":[\"foo\",\"bar\"],\"context_line\":\"hey \
+             hey hey\",\"post_context\":[\"foo\",\"bar\"],\"in_app\":true,\"vars\":{\"var\":\
+             \"value\"}}]}}]}}"
+        );
+    }
+
+    #[test]
+    fn test_exception_stacktrace_full() {
+        let event: v7::Event<'_> = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            exception: vec![v7::Exception {
+                ty: "DivisionByZero".into(),
+                value: Some("integer division or modulo by zero".into()),
+                module: Some("x".into()),
+                stacktrace: Some(v7::Stacktrace {
+                    frames: vec![v7::Frame {
+                        function: Some("main".into()),
+                        symbol: Some("main".into()),
+                        filename: Some("hello.py".into()),
+                        abs_path: Some("/app/hello.py".into()),
+                        lineno: Some(7),
+                        colno: Some(42),
+                        pre_context: vec!["foo".into(), "bar".into()],
+                        context_line: Some("hey hey hey".into()),
+                        post_context: vec!["foo".into(), "bar".into()],
+                        in_app: Some(true),
+                        vars: {
+                            let mut m = v7::Map::new();
+                            m.insert("var".into(), "value".into());
+                            m
+                        },
+                        package: Some("hello.whl".into()),
+                        module: Some("hello".into()),
+                        image_addr: Some(v7::Addr(0)),
+                        instruction_addr: Some(v7::Addr(0)),
+                        symbol_addr: Some(v7::Addr(0)),
+                    }],
+                    frames_omitted: Some((1, 2)),
+                    registers: {
+                        let mut m = v7::Map::new();
+                        m.insert("x8".into(), v7::RegVal(0x0));
+                        m.insert("x20".into(), v7::RegVal(0x1));
+                        m.insert("x21".into(), v7::RegVal(0x1));
+                        m.insert("x28".into(), v7::RegVal(0x1_7025_f650));
+                        m.insert("x4".into(), v7::RegVal(0x1_702e_b100));
+                        m.insert("x24".into(), v7::RegVal(0x1_b139_9c20));
+                        m.insert("sp".into(), v7::RegVal(0x1_6fd7_5060));
+                        m.insert("x1".into(), v7::RegVal(0x1_b139_9bb1));
+                        m.insert("x23".into(), v7::RegVal(0x1_afe1_0040));
+                        m.insert("x14".into(), v7::RegVal(0x1));
+                        m.insert("x19".into(), v7::RegVal(0x0));
+                        m.insert("x18".into(), v7::RegVal(0x0));
+                        m.insert("x3".into(), v7::RegVal(0x1));
+                        m.insert("pc".into(), v7::RegVal(0x1_8a31_0ea4));
+                        m.insert("x7".into(), v7::RegVal(0x0));
+                        m.insert("x10".into(), v7::RegVal(0x57b));
+                        m.insert("x6".into(), v7::RegVal(0x0));
+                        m.insert("x13".into(), v7::RegVal(0x1));
+                        m.insert("x2".into(), v7::RegVal(0x1));
+                        m.insert("x27".into(), v7::RegVal(0x1));
+                        m.insert("x26".into(), v7::RegVal(0x1_91ec_48d1));
+                        m.insert("x9".into(), v7::RegVal(0x1_b139_9c20));
+                        m.insert("x29".into(), v7::RegVal(0x1_6fd7_5060));
+                        m.insert("x5".into(), v7::RegVal(0x1_702e_b100));
+                        m.insert("fp".into(), v7::RegVal(0x1_6fd7_5060));
+                        m.insert("x0".into(), v7::RegVal(0x1));
+                        m.insert("lr".into(), v7::RegVal(0x1_8a31_aadc));
+                        m.insert("x25".into(), v7::RegVal(0x0));
+                        m.insert("x16".into(), v7::RegVal(0x1_8a31_aa34));
+                        m.insert("x11".into(), v7::RegVal(0x1_b3b3_7b1d));
+                        m.insert("cpsr".into(), v7::RegVal(0x2000_0000));
+                        m.insert("x17".into(), v7::RegVal(0x0));
+                        m.insert("x15".into(), v7::RegVal(0x881));
+                        m.insert("x22".into(), v7::RegVal(0x1_b139_9bb0));
+                        m.insert("x12".into(), v7::RegVal(0x1_b3b3_7b1d));
+                        m
+                    },
+                }),
+                raw_stacktrace: Some(v7::Stacktrace {
+                    frames: vec![v7::Frame {
+                        function: Some("main".into()),
+                        image_addr: Some(v7::Addr(0)),
+                        instruction_addr: Some(v7::Addr(0)),
+                        symbol_addr: Some(v7::Addr(0)),
+                        ..Default::default()
+                    }],
+                    frames_omitted: Some((1, 2)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"DivisionByZero\",\"value\":\"integer division \
+             or modulo by \
+             zero\",\"module\":\"x\",\"stacktrace\":{\"frames\":[{\"function\":\"main\",\
+             \"symbol\":\"main\",\"module\":\"hello\",\"package\":\"hello.whl\",\"filename\":\
+             \"hello.py\",\"abs_path\":\"/app/hello.py\",\"lineno\":7,\"colno\":42,\
+             \"pre_context\":[\"foo\",\"bar\"],\"context_line\":\"hey hey \
+             hey\",\"post_context\":[\"foo\",\"bar\"],\"in_app\":true,\"vars\":{\"var\":\
+             \"value\"},\"image_addr\":\"0x0\",\"instruction_addr\":\"0x0\",\"symbol_addr\":\
+             \"0x0\"}],\"frames_omitted\":[1,2],\"registers\":{\"cpsr\":\"0x20000000\",\"fp\":\
+             \"0x16fd75060\",\"lr\":\"0x18a31aadc\",\"pc\":\"0x18a310ea4\",\"sp\":\"0x16fd75060\",\
+             \"x0\":\"0x1\",\"x1\":\"0x1b1399bb1\",\"x10\":\"0x57b\",\"x11\":\"0x1b3b37b1d\",\
+             \"x12\":\"0x1b3b37b1d\",\"x13\":\"0x1\",\"x14\":\"0x1\",\"x15\":\"0x881\",\"x16\":\
+             \"0x18a31aa34\",\"x17\":\"0x0\",\"x18\":\"0x0\",\"x19\":\"0x0\",\"x2\":\"0x1\",\
+             \"x20\":\"0x1\",\"x21\":\"0x1\",\"x22\":\"0x1b1399bb0\",\"x23\":\"0x1afe10040\",\
+             \"x24\":\"0x1b1399c20\",\"x25\":\"0x0\",\"x26\":\"0x191ec48d1\",\"x27\":\"0x1\",\
+             \"x28\":\"0x17025f650\",\"x29\":\"0x16fd75060\",\"x3\":\"0x1\",\"x4\":\
+             \"0x1702eb100\",\"x5\":\"0x1702eb100\",\"x6\":\"0x0\",\"x7\":\"0x0\",\"x8\":\"0x0\",\
+             \"x9\":\"0x1b1399c20\"}},\"raw_stacktrace\":{\"frames\":[{\"function\":\"main\",\
+             \"image_addr\":\"0x0\",\"instruction_addr\":\"0x0\",\"symbol_addr\":\"0x0\"}],\
+             \"frames_omitted\":[1,2]}}]}}"
+        );
+    }
+
+    #[test]
+    fn test_exception_mechanism() {
+        let event: v7::Event<'_> = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            exception: vec![v7::Exception {
+                ty: "EXC_BAD_ACCESS".into(),
+                value: Some("Attempted to dereference garbage pointer 0x1".into()),
+                mechanism: Some(v7::Mechanism {
+                    ty: "mach".into(),
+                    description: None,
+                    help_link: Some(
+                        "https://developer.apple.com/library/content/qa/qa1367/_index.html"
+                            .parse()
+                            .unwrap(),
+                    ),
+                    handled: Some(false),
+                    synthetic: None,
+                    data: {
+                        let mut map = v7::Map::new();
+                        map.insert("relevant_address".into(), "0x1".into());
+                        map
+                    },
+                    meta: v7::MechanismMeta {
+                        errno: Some(v7::CError {
+                            number: 2,
+                            name: None,
+                        }),
+                        signal: Some(v7::PosixSignal {
+                            number: 11,
+                            code: None,
+                            name: None,
+                            code_name: None,
+                        }),
+                        mach_exception: Some(v7::MachException {
+                            exception: 1,
+                            code: 1,
+                            subcode: 8,
+                            name: None,
+                        }),
+                    },
+                }),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"exception\":{\"values\":[{\"type\":\"EXC_BAD_ACCESS\",\"value\":\"Attempted to \
+             dereference garbage pointer \
+             0x1\",\"mechanism\":{\"type\":\"mach\",\"help_link\":\"https://developer.apple.\
+             com/library/content/qa/qa1367/_index.html\",\"handled\":false,\"data\":\
+             {\"relevant_address\":\"0x1\"},\"meta\":{\"errno\":{\"number\":2},\"signal\":\
+             {\"number\":11},\"mach_exception\":{\"exception\":1,\"code\":1,\"subcode\":8}}}}]}}"
+        );
+    }
+}
+
+#[test]
+fn test_sdk_info() {
+    let event = v7::Event {
+        event_id: event_id(),
+        timestamp: event_time(),
+        sdk: Some(Cow::Owned(v7::ClientSdkInfo {
+            name: "sentry-rust".into(),
+            version: "1.0".into(),
+            integrations: vec!["rocket".into()],
+            packages: vec![v7::ClientSdkPackage {
+                name: "cargo:sentry".into(),
+                version: "1.0".into(),
+            }],
+        })),
+        ..Default::default()
+    };
+
+    assert_roundtrip(&event);
+    assert_eq!(
+        serde_json::to_string(&event).unwrap(),
+        "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\"sdk\":\
+         {\"name\":\"sentry-rust\",\"version\":\"1.0\",\"integrations\":[\"rocket\"],\"packages\":\
+         [{\"name\":\"cargo:sentry\",\"version\":\"1.0\"}]}}"
+    );
+}
+
+mod test_contexts {
+    use super::*;
+
+    #[test]
+    fn test_device_context() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "device".into(),
+                    v7::DeviceContext {
+                        name: Some("iphone".into()),
+                        family: Some("iphone".into()),
+                        model: Some("iphone7,3".into()),
+                        model_id: Some("AH223".into()),
+                        arch: Some("arm64".into()),
+                        battery_level: Some(58.5),
+                        orientation: Some(v7::Orientation::Landscape),
+                        simulator: Some(true),
+                        memory_size: Some(3_137_978_368),
+                        free_memory: Some(322_781_184),
+                        usable_memory: Some(2_843_525_120),
+                        storage_size: Some(63_989_469_184),
+                        free_storage: Some(31_994_734_592),
+                        external_storage_size: Some(2_097_152),
+                        external_free_storage: Some(2_097_152),
+                        boot_time: Some("2018-02-08T12:52:12Z".parse().unwrap()),
+                        timezone: Some("Europe/Vienna".into()),
+                        other: Default::default(),
+                    }
+                    .into(),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"device\":{\"type\":\"device\",\"name\":\"iphone\",\"family\":\
+             \"iphone\",\"model\":\"iphone7,3\",\"model_id\":\"AH223\",\"arch\":\"arm64\",\
+             \"battery_level\":58.5,\"orientation\":\"landscape\",\"simulator\":true,\
+             \"memory_size\":3137978368,\"free_memory\":322781184,\"usable_memory\":2843525120,\
+             \"storage_size\":63989469184,\"free_storage\":31994734592,\"external_storage_size\":\
+             2097152,\"external_free_storage\":2097152,\"boot_time\":\"2018-02-08T12:52:12Z\",\
+             \"timezone\":\"Europe/Vienna\"}}}"
+        );
+    }
+
+    #[test]
+    fn test_os_context() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "os".into(),
+                    v7::OsContext {
+                        name: Some("iOS".into()),
+                        version: Some("11.4.2".into()),
+                        build: Some("ADSA23".into()),
+                        kernel_version: Some("17.4.0".into()),
+                        rooted: Some(true),
+                        other: Default::default(),
+                    }
+                    .into(),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"os\":{\"type\":\"os\",\"name\":\"iOS\",\"version\":\"11.4.2\",\
+             \"build\":\"ADSA23\",\"kernel_version\":\"17.4.0\",\"rooted\":true}}}"
+        );
+    }
+
+    #[test]
+    fn test_app_context() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "app".into(),
+                    v7::AppContext {
+                        app_start_time: Some("2018-02-08T22:21:57Z".parse().unwrap()),
+                        device_app_hash: Some("4c793e3776474877ae30618378e9662a".into()),
+                        build_type: Some("testflight".into()),
+                        app_identifier: Some("foo.bar.baz".into()),
+                        app_name: Some("Baz App".into()),
+                        app_version: Some("1.0".into()),
+                        app_build: Some("100001".into()),
+                        other: Default::default(),
+                    }
+                    .into(),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"app\":{\"type\":\"app\",\"app_start_time\":\"2018-02-08T22:21:57Z\",\
+             \"device_app_hash\":\"4c793e3776474877ae30618378e9662a\",\"build_type\":\
+             \"testflight\",\"app_identifier\":\"foo.bar.baz\",\"app_name\":\"Baz \
+             App\",\"app_version\":\"1.0\",\"app_build\":\"100001\"}}}"
+        );
+    }
+
+    #[test]
+    fn test_browser_context() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "browser".into(),
+                    v7::BrowserContext {
+                        name: Some("Chrome".into()),
+                        version: Some("59.0.3071".into()),
+                        other: Default::default(),
+                    }
+                    .into(),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"browser\":{\"type\":\"browser\",\"name\":\"Chrome\",\"version\":\"59.\
+             0.3071\"}}}"
+        );
+    }
+
+    #[test]
+    fn test_runtime_context() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "runtime".into(),
+                    v7::RuntimeContext {
+                        name: Some("magicvm".into()),
+                        version: Some("5.3".into()),
+                        other: Default::default(),
+                    }
+                    .into(),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"runtime\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.\
+             3\"}}}"
+        );
+    }
+
+    #[test]
+    fn test_renamed_contexts() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "magicvm".into(),
+                    v7::RuntimeContext {
+                        name: Some("magicvm".into()),
+                        version: Some("5.3".into()),
+                        other: Default::default(),
+                    }
+                    .into(),
+                );
+                m.insert(
+                    "othervm".into(),
+                    v7::RuntimeContext {
+                        name: Some("magicvm".into()),
+                        version: Some("5.3".into()),
+                        other: Default::default(),
+                    }
+                    .into(),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"magicvm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.\
+             3\"},\"othervm\":{\"type\":\"runtime\",\"name\":\"magicvm\",\"version\":\"5.3\"}}}"
+        );
+    }
+
+    #[test]
+    fn test_other_context() {
+        let event = v7::Event {
+            event_id: event_id(),
+            timestamp: event_time(),
+            contexts: {
+                let mut m = v7::Map::new();
+                m.insert(
+                    "other".into(),
+                    v7::Context::Other({
+                        let mut m = v7::Map::new();
+                        m.insert("aha".into(), "oho".into());
+                        m
+                    }),
+                );
+                m
+            },
+            ..Default::default()
+        };
+
+        assert_roundtrip(&event);
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            "{\"event_id\":\"d43e86c96e424a93a4fbda156dd17341\",\"timestamp\":1514103120,\
+             \"contexts\":{\"other\":{\"type\":\"unknown\",\"aha\":\"oho\"}}}"
+        );
+    }
+}
+
+#[test]
+fn test_level_log() {
+    assert_eq!(v7::Level::Info, serde_json::from_str("\"log\"").unwrap());
+}
+
+#[test]
+fn test_addr_format() {
+    assert_eq!(serde_json::to_string(&v7::Addr(0)).unwrap(), "\"0x0\"");
+    assert_eq!(serde_json::to_string(&v7::Addr(42)).unwrap(), "\"0x2a\"");
+    assert_eq!(serde_json::from_str::<v7::Addr>("0").unwrap(), v7::Addr(0));
+    assert_eq!(
+        serde_json::from_str::<v7::Addr>("\"0\"").unwrap(),
+        v7::Addr(0)
+    );
+    assert_eq!(
+        serde_json::from_str::<v7::Addr>("\"0x0\"").unwrap(),
+        v7::Addr(0)
+    );
+    assert_eq!(
+        serde_json::from_str::<v7::Addr>("42").unwrap(),
+        v7::Addr(42)
+    );
+    assert_eq!(
+        serde_json::from_str::<v7::Addr>("\"42\"").unwrap(),
+        v7::Addr(42)
+    );
+    assert_eq!(
+        serde_json::from_str::<v7::Addr>("\"0x2a\"").unwrap(),
+        v7::Addr(42)
+    );
+    assert_eq!(
+        serde_json::from_str::<v7::Addr>("\"0X2A\"").unwrap(),
+        v7::Addr(42)
+    );
+}
+
+#[test]
+fn test_addr_api() {
+    use std::ptr;
+    assert_eq!(v7::Addr::from(42u64), v7::Addr(42));
+    assert_eq!(v7::Addr::from(42), v7::Addr(42));
+    assert_eq!(v7::Addr::from(ptr::null::<()>()), v7::Addr(0));
+}
+
+#[test]
+fn test_thread_id_format() {
+    assert_eq!(serde_json::to_string(&v7::ThreadId::Int(0)).unwrap(), "0");
+    assert_eq!(serde_json::to_string(&v7::ThreadId::Int(42)).unwrap(), "42");
+    assert_eq!(
+        serde_json::to_string(&v7::ThreadId::String("x".into())).unwrap(),
+        "\"x\""
+    );
+    assert_eq!(
+        serde_json::from_str::<v7::ThreadId>("0").unwrap(),
+        v7::ThreadId::Int(0)
+    );
+    assert_eq!(
+        serde_json::from_str::<v7::ThreadId>("\"0\"").unwrap(),
+        v7::ThreadId::String("0".into())
+    );
+}
+
+#[test]
+fn test_orientation() {
+    assert_eq!(
+        serde_json::to_string(&v7::Orientation::Landscape).unwrap(),
+        "\"landscape\""
+    );
+    assert_eq!(
+        serde_json::to_string(&v7::Orientation::Portrait).unwrap(),
+        "\"portrait\""
+    );
+}

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -42,7 +42,7 @@ backtrace = { version = "0.3.44", optional = true }
 url = { version = "2.1.1", optional = true }
 failure = { version = "0.1.6", optional = true }
 log = { version = "0.4.8", optional = true, features = ["std"] }
-sentry-types = "0.14.1"
+sentry-types = { path = "../sentry-types", version = "0.15.0" }
 env_logger = { version = "0.7.1", optional = true }
 reqwest = { version = "0.10.1", optional = true, features = ["blocking", "json"], default-features = false }
 lazy_static = "1.4.0"


### PR DESCRIPTION
This imports the whole sentry-types repo, including all its history.
This was done using:
```
git remote add types https://github.com/getsentry/rust-sentry-types.git
git fetch types master

… move things into the sentry-types directory, delete everything unrelated …

git commit --all
git checkout -b types-head
git checkout master
git merge types-head --allow-unrelated-histories
```