### PR TITLE
ref: Move a few things into separate files

### DIFF
--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -2,7 +2,7 @@
 use crate::hub::Hub;
 use crate::scope::Scope;
 
-use crate::hub::IntoBreadcrumbs;
+use crate::breadcrumbs::IntoBreadcrumbs;
 use crate::internals;
 use crate::protocol::{Event, Level};
 

--- a/sentry-core/src/breadcrumbs.rs
+++ b/sentry-core/src/breadcrumbs.rs
@@ -1,0 +1,41 @@
+use crate::protocol::Breadcrumb;
+/// A helper trait that converts self into an Iterator of Breadcrumbs
+pub trait IntoBreadcrumbs {
+    /// The iterator type for the breadcrumbs.
+    type Output: Iterator<Item = Breadcrumb>;
+
+    /// This converts the object into an optional breadcrumb.
+    fn into_breadcrumbs(self) -> Self::Output;
+}
+
+impl IntoBreadcrumbs for Breadcrumb {
+    type Output = std::iter::Once<Breadcrumb>;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        std::iter::once(self)
+    }
+}
+
+impl IntoBreadcrumbs for Vec<Breadcrumb> {
+    type Output = std::vec::IntoIter<Breadcrumb>;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        self.into_iter()
+    }
+}
+
+impl IntoBreadcrumbs for Option<Breadcrumb> {
+    type Output = std::option::IntoIter<Breadcrumb>;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        self.into_iter()
+    }
+}
+
+impl<F: FnOnce() -> I, I: IntoBreadcrumbs> IntoBreadcrumbs for F {
+    type Output = I::Output;
+
+    fn into_breadcrumbs(self) -> Self::Output {
+        self().into_breadcrumbs()
+    }
+}

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -1,21 +1,20 @@
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
-use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 
 use rand::random;
-use regex::Regex;
 
-use crate::backtrace_support::{function_starts_with, is_sys_function, trim_stacktrace};
-use crate::constants::{SDK_INFO, USER_AGENT};
+use crate::backtrace_support::process_event_stacktrace;
+pub use crate::clientoptions::ClientOptions;
+use crate::constants::SDK_INFO;
 use crate::hub::Hub;
 use crate::internals::{Dsn, ParseDsnError, Uuid};
-use crate::protocol::{Breadcrumb, DebugMeta, Event};
+use crate::protocol::{DebugMeta, Event};
 use crate::scope::Scope;
-use crate::transport::{DefaultTransportFactory, Transport, TransportFactory};
+use crate::transport::Transport;
 use crate::utils;
 
 /// The Sentry client object.
@@ -40,194 +39,6 @@ impl Clone for Client {
             transport: RwLock::new(self.transport.read().unwrap().clone()),
         }
     }
-}
-
-/// Type alias for before event/breadcrumb handlers.
-pub type BeforeCallback<T> = Arc<Box<dyn Fn(T) -> Option<T> + Send + Sync>>;
-
-/// Configuration settings for the client.
-pub struct ClientOptions {
-    /// The DSN to use.  If not set the client is effectively disabled.
-    pub dsn: Option<Dsn>,
-    /// The transport to use.
-    ///
-    /// This is typically either a boxed function taking the client options by
-    /// reference and returning a `Transport`, a boxed `Arc<Transport>` or
-    /// alternatively the `DefaultTransportFactory`.
-    pub transport: Box<dyn TransportFactory>,
-    /// module prefixes that are always considered in_app
-    pub in_app_include: Vec<&'static str>,
-    /// module prefixes that are never in_app
-    pub in_app_exclude: Vec<&'static str>,
-    /// border frames which indicate a border from a backtrace to
-    /// useless internals.  Some are automatically included.
-    pub extra_border_frames: Vec<&'static str>,
-    /// Maximum number of breadcrumbs (0 to disable feature).
-    pub max_breadcrumbs: usize,
-    /// Automatically trim backtraces of junk before sending.
-    pub trim_backtraces: bool,
-    /// The release to be sent with events.
-    pub release: Option<Cow<'static, str>>,
-    /// The environment to be sent with events.
-    pub environment: Option<Cow<'static, str>>,
-    /// The server name to be reported.
-    pub server_name: Option<Cow<'static, str>>,
-    /// The sample rate for event submission (0.0 - 1.0, defaults to 1.0)
-    pub sample_rate: f32,
-    /// The user agent that should be reported.
-    pub user_agent: Cow<'static, str>,
-    /// An optional HTTP proxy to use.
-    ///
-    /// This will default to the `http_proxy` environment variable.
-    pub http_proxy: Option<Cow<'static, str>>,
-    /// An optional HTTPS proxy to use.
-    ///
-    /// This will default to the `HTTPS_PROXY` environment variable
-    /// or `http_proxy` if that one exists.
-    pub https_proxy: Option<Cow<'static, str>>,
-    /// The timeout on client drop for draining events on shutdown.
-    pub shutdown_timeout: Duration,
-    /// Enables debug mode.
-    ///
-    /// In debug mode debug information is printed to stderr to help you understand what
-    /// sentry is doing.  When the `with_debug_to_log` flag is enabled Sentry will instead
-    /// log to the `sentry` logger independently of this flag with the `Debug` level.
-    pub debug: bool,
-    /// Attaches stacktraces to messages.
-    pub attach_stacktrace: bool,
-    /// If turned on some default PII informat is attached.
-    pub send_default_pii: bool,
-    /// Before send callback.
-    pub before_send: Option<BeforeCallback<Event<'static>>>,
-    /// Before breadcrumb add callback.
-    pub before_breadcrumb: Option<BeforeCallback<Breadcrumb>>,
-}
-
-// make this unwind safe.  It's not out of the box because of the contained `BeforeCallback`s.
-impl RefUnwindSafe for ClientOptions {}
-
-impl fmt::Debug for ClientOptions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[derive(Debug)]
-        struct TransportFactory;
-        #[derive(Debug)]
-        struct BeforeSendSet(bool);
-        #[derive(Debug)]
-        struct BeforeBreadcrumbSet(bool);
-        f.debug_struct("ClientOptions")
-            .field("dsn", &self.dsn)
-            .field("transport", &TransportFactory)
-            .field("in_app_include", &self.in_app_include)
-            .field("in_app_exclude", &self.in_app_exclude)
-            .field("extra_border_frames", &self.extra_border_frames)
-            .field("max_breadcrumbs", &self.max_breadcrumbs)
-            .field("trim_backtraces", &self.trim_backtraces)
-            .field("release", &self.release)
-            .field("environment", &self.environment)
-            .field("server_name", &self.server_name)
-            .field("sample_rate", &self.sample_rate)
-            .field("user_agent", &self.user_agent)
-            .field("http_proxy", &self.http_proxy)
-            .field("https_proxy", &self.https_proxy)
-            .field("shutdown_timeout", &self.shutdown_timeout)
-            .field("debug", &self.debug)
-            .field("attach_stacktrace", &self.attach_stacktrace)
-            .field("send_default_pii", &self.send_default_pii)
-            .field("before_send", &BeforeSendSet(self.before_send.is_some()))
-            .field(
-                "before_send",
-                &BeforeBreadcrumbSet(self.before_breadcrumb.is_some()),
-            )
-            .finish()
-    }
-}
-
-impl Clone for ClientOptions {
-    fn clone(&self) -> ClientOptions {
-        ClientOptions {
-            dsn: self.dsn.clone(),
-            transport: self.transport.clone_factory(),
-            in_app_include: self.in_app_include.clone(),
-            in_app_exclude: self.in_app_exclude.clone(),
-            extra_border_frames: self.extra_border_frames.clone(),
-            max_breadcrumbs: self.max_breadcrumbs,
-            trim_backtraces: self.trim_backtraces,
-            release: self.release.clone(),
-            environment: self.environment.clone(),
-            server_name: self.server_name.clone(),
-            sample_rate: self.sample_rate,
-            user_agent: self.user_agent.clone(),
-            http_proxy: self.http_proxy.clone(),
-            https_proxy: self.https_proxy.clone(),
-            shutdown_timeout: self.shutdown_timeout,
-            debug: self.debug,
-            attach_stacktrace: self.attach_stacktrace,
-            send_default_pii: self.send_default_pii,
-            before_send: self.before_send.clone(),
-            before_breadcrumb: self.before_breadcrumb.clone(),
-        }
-    }
-}
-
-impl Default for ClientOptions {
-    fn default() -> ClientOptions {
-        ClientOptions {
-            // any invalid dsn including the empty string disables the dsn
-            dsn: std::env::var("SENTRY_DSN")
-                .ok()
-                .and_then(|dsn| dsn.parse::<Dsn>().ok()),
-            transport: Box::new(DefaultTransportFactory),
-            in_app_include: vec![],
-            in_app_exclude: vec![],
-            extra_border_frames: vec![],
-            max_breadcrumbs: 100,
-            trim_backtraces: true,
-            release: std::env::var("SENTRY_RELEASE").ok().map(Cow::Owned),
-            environment: std::env::var("SENTRY_ENVIRONMENT")
-                .ok()
-                .map(Cow::Owned)
-                .or_else(|| {
-                    Some(Cow::Borrowed(if cfg!(debug_assertions) {
-                        "debug"
-                    } else {
-                        "release"
-                    }))
-                }),
-            server_name: utils::server_name().map(Cow::Owned),
-            sample_rate: 1.0,
-            user_agent: Cow::Borrowed(&USER_AGENT),
-            http_proxy: std::env::var("http_proxy").ok().map(Cow::Owned),
-            https_proxy: std::env::var("https_proxy")
-                .ok()
-                .map(Cow::Owned)
-                .or_else(|| std::env::var("HTTPS_PROXY").ok().map(Cow::Owned))
-                .or_else(|| std::env::var("http_proxy").ok().map(Cow::Owned)),
-            shutdown_timeout: Duration::from_secs(2),
-            debug: false,
-            attach_stacktrace: false,
-            send_default_pii: false,
-            before_send: None,
-            before_breadcrumb: None,
-        }
-    }
-}
-
-lazy_static::lazy_static! {
-    static ref CRATE_RE: Regex = Regex::new(r#"(?x)
-        ^
-        (?:_?<)?           # trait impl syntax
-        (?:\w+\ as \ )?    # anonymous implementor
-        ([a-zA-Z0-9_]+?)   # crate name
-        (?:\.\.|::)        # crate delimiter (.. or ::)
-    "#).unwrap();
-}
-
-/// Tries to parse the rust crate from a function name.
-fn parse_crate_name(func_name: &str) -> Option<String> {
-    CRATE_RE
-        .captures(func_name)
-        .and_then(|caps| caps.get(1))
-        .map(|cr| cr.as_str().into())
 }
 
 /// Helper trait to convert a string into an `Option<Dsn>`.
@@ -438,76 +249,7 @@ impl Client {
 
         for exc in &mut event.exception {
             if let Some(ref mut stacktrace) = exc.stacktrace {
-                // automatically trim backtraces
-                if self.options.trim_backtraces {
-                    trim_stacktrace(stacktrace, |frame, _| {
-                        if let Some(ref func) = frame.function {
-                            self.options.extra_border_frames.contains(&func.as_str())
-                        } else {
-                            false
-                        }
-                    })
-                }
-
-                // automatically prime in_app and set package
-                let mut any_in_app = false;
-                for frame in &mut stacktrace.frames {
-                    let func_name = match frame.function {
-                        Some(ref func) => func,
-                        None => continue,
-                    };
-
-                    // set package if missing to crate prefix
-                    if frame.package.is_none() {
-                        frame.package = parse_crate_name(func_name);
-                    }
-
-                    match frame.in_app {
-                        Some(true) => {
-                            any_in_app = true;
-                            continue;
-                        }
-                        Some(false) => {
-                            continue;
-                        }
-                        None => {}
-                    }
-
-                    for m in &self.options.in_app_exclude {
-                        if function_starts_with(func_name, m) {
-                            frame.in_app = Some(false);
-                            break;
-                        }
-                    }
-
-                    if frame.in_app.is_some() {
-                        continue;
-                    }
-
-                    for m in &self.options.in_app_include {
-                        if function_starts_with(func_name, m) {
-                            frame.in_app = Some(true);
-                            any_in_app = true;
-                            break;
-                        }
-                    }
-
-                    if frame.in_app.is_some() {
-                        continue;
-                    }
-
-                    if is_sys_function(func_name) {
-                        frame.in_app = Some(false);
-                    }
-                }
-
-                if !any_in_app {
-                    for frame in &mut stacktrace.frames {
-                        if frame.in_app.is_none() {
-                            frame.in_app = Some(true);
-                        }
-                    }
-                }
+                process_event_stacktrace(stacktrace, &self.options);
             }
         }
 
@@ -658,46 +400,4 @@ pub fn init<C: Into<Client>>(cfg: C) -> ClientInitGuard {
         sentry_debug!("initialized disabled sentry client due to disabled or invalid DSN");
     }
     ClientInitGuard(client)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_crate_name() {
-        assert_eq!(
-            parse_crate_name("futures::task_impl::std::set"),
-            Some("futures".into())
-        );
-    }
-
-    #[test]
-    fn test_parse_crate_name_impl() {
-        assert_eq!(
-            parse_crate_name("_<futures..task_impl..Spawn<T>>::enter::_{{closure}}"),
-            Some("futures".into())
-        );
-    }
-
-    #[test]
-    fn test_parse_crate_name_anonymous_impl() {
-        assert_eq!(
-            parse_crate_name("_<F as alloc..boxed..FnBox<A>>::call_box"),
-            Some("alloc".into())
-        );
-    }
-
-    #[test]
-    fn test_parse_crate_name_none() {
-        assert_eq!(parse_crate_name("main"), None);
-    }
-
-    #[test]
-    fn test_parse_crate_name_newstyle() {
-        assert_eq!(
-            parse_crate_name("<failure::error::Error as core::convert::From<F>>::from"),
-            Some("failure".into())
-        );
-    }
 }

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -1,0 +1,181 @@
+use std::borrow::Cow;
+use std::fmt;
+use std::panic::RefUnwindSafe;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::constants::USER_AGENT;
+use crate::internals::Dsn;
+use crate::protocol::{Breadcrumb, Event};
+use crate::transport::{DefaultTransportFactory, TransportFactory};
+use crate::utils;
+
+/// Type alias for before event/breadcrumb handlers.
+pub type BeforeCallback<T> = Arc<Box<dyn Fn(T) -> Option<T> + Send + Sync>>;
+
+/// Configuration settings for the client.
+pub struct ClientOptions {
+    /// The DSN to use.  If not set the client is effectively disabled.
+    pub dsn: Option<Dsn>,
+    /// The transport to use.
+    ///
+    /// This is typically either a boxed function taking the client options by
+    /// reference and returning a `Transport`, a boxed `Arc<Transport>` or
+    /// alternatively the `DefaultTransportFactory`.
+    pub transport: Box<dyn TransportFactory>,
+    /// module prefixes that are always considered in_app
+    pub in_app_include: Vec<&'static str>,
+    /// module prefixes that are never in_app
+    pub in_app_exclude: Vec<&'static str>,
+    /// border frames which indicate a border from a backtrace to
+    /// useless internals.  Some are automatically included.
+    pub extra_border_frames: Vec<&'static str>,
+    /// Maximum number of breadcrumbs (0 to disable feature).
+    pub max_breadcrumbs: usize,
+    /// Automatically trim backtraces of junk before sending.
+    pub trim_backtraces: bool,
+    /// The release to be sent with events.
+    pub release: Option<Cow<'static, str>>,
+    /// The environment to be sent with events.
+    pub environment: Option<Cow<'static, str>>,
+    /// The server name to be reported.
+    pub server_name: Option<Cow<'static, str>>,
+    /// The sample rate for event submission (0.0 - 1.0, defaults to 1.0)
+    pub sample_rate: f32,
+    /// The user agent that should be reported.
+    pub user_agent: Cow<'static, str>,
+    /// An optional HTTP proxy to use.
+    ///
+    /// This will default to the `http_proxy` environment variable.
+    pub http_proxy: Option<Cow<'static, str>>,
+    /// An optional HTTPS proxy to use.
+    ///
+    /// This will default to the `HTTPS_PROXY` environment variable
+    /// or `http_proxy` if that one exists.
+    pub https_proxy: Option<Cow<'static, str>>,
+    /// The timeout on client drop for draining events on shutdown.
+    pub shutdown_timeout: Duration,
+    /// Enables debug mode.
+    ///
+    /// In debug mode debug information is printed to stderr to help you understand what
+    /// sentry is doing.  When the `with_debug_to_log` flag is enabled Sentry will instead
+    /// log to the `sentry` logger independently of this flag with the `Debug` level.
+    pub debug: bool,
+    /// Attaches stacktraces to messages.
+    pub attach_stacktrace: bool,
+    /// If turned on some default PII informat is attached.
+    pub send_default_pii: bool,
+    /// Before send callback.
+    pub before_send: Option<BeforeCallback<Event<'static>>>,
+    /// Before breadcrumb add callback.
+    pub before_breadcrumb: Option<BeforeCallback<Breadcrumb>>,
+}
+
+// make this unwind safe.  It's not out of the box because of the contained `BeforeCallback`s.
+impl RefUnwindSafe for ClientOptions {}
+
+impl fmt::Debug for ClientOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[derive(Debug)]
+        struct TransportFactory;
+        #[derive(Debug)]
+        struct BeforeSendSet(bool);
+        #[derive(Debug)]
+        struct BeforeBreadcrumbSet(bool);
+        f.debug_struct("ClientOptions")
+            .field("dsn", &self.dsn)
+            .field("transport", &TransportFactory)
+            .field("in_app_include", &self.in_app_include)
+            .field("in_app_exclude", &self.in_app_exclude)
+            .field("extra_border_frames", &self.extra_border_frames)
+            .field("max_breadcrumbs", &self.max_breadcrumbs)
+            .field("trim_backtraces", &self.trim_backtraces)
+            .field("release", &self.release)
+            .field("environment", &self.environment)
+            .field("server_name", &self.server_name)
+            .field("sample_rate", &self.sample_rate)
+            .field("user_agent", &self.user_agent)
+            .field("http_proxy", &self.http_proxy)
+            .field("https_proxy", &self.https_proxy)
+            .field("shutdown_timeout", &self.shutdown_timeout)
+            .field("debug", &self.debug)
+            .field("attach_stacktrace", &self.attach_stacktrace)
+            .field("send_default_pii", &self.send_default_pii)
+            .field("before_send", &BeforeSendSet(self.before_send.is_some()))
+            .field(
+                "before_breadcrumb",
+                &BeforeBreadcrumbSet(self.before_breadcrumb.is_some()),
+            )
+            .finish()
+    }
+}
+
+impl Clone for ClientOptions {
+    fn clone(&self) -> ClientOptions {
+        ClientOptions {
+            dsn: self.dsn.clone(),
+            transport: self.transport.clone_factory(),
+            in_app_include: self.in_app_include.clone(),
+            in_app_exclude: self.in_app_exclude.clone(),
+            extra_border_frames: self.extra_border_frames.clone(),
+            max_breadcrumbs: self.max_breadcrumbs,
+            trim_backtraces: self.trim_backtraces,
+            release: self.release.clone(),
+            environment: self.environment.clone(),
+            server_name: self.server_name.clone(),
+            sample_rate: self.sample_rate,
+            user_agent: self.user_agent.clone(),
+            http_proxy: self.http_proxy.clone(),
+            https_proxy: self.https_proxy.clone(),
+            shutdown_timeout: self.shutdown_timeout,
+            debug: self.debug,
+            attach_stacktrace: self.attach_stacktrace,
+            send_default_pii: self.send_default_pii,
+            before_send: self.before_send.clone(),
+            before_breadcrumb: self.before_breadcrumb.clone(),
+        }
+    }
+}
+
+impl Default for ClientOptions {
+    fn default() -> ClientOptions {
+        ClientOptions {
+            // any invalid dsn including the empty string disables the dsn
+            dsn: std::env::var("SENTRY_DSN")
+                .ok()
+                .and_then(|dsn| dsn.parse::<Dsn>().ok()),
+            transport: Box::new(DefaultTransportFactory),
+            in_app_include: vec![],
+            in_app_exclude: vec![],
+            extra_border_frames: vec![],
+            max_breadcrumbs: 100,
+            trim_backtraces: true,
+            release: std::env::var("SENTRY_RELEASE").ok().map(Cow::Owned),
+            environment: std::env::var("SENTRY_ENVIRONMENT")
+                .ok()
+                .map(Cow::Owned)
+                .or_else(|| {
+                    Some(Cow::Borrowed(if cfg!(debug_assertions) {
+                        "debug"
+                    } else {
+                        "release"
+                    }))
+                }),
+            server_name: utils::server_name().map(Cow::Owned),
+            sample_rate: 1.0,
+            user_agent: Cow::Borrowed(&USER_AGENT),
+            http_proxy: std::env::var("http_proxy").ok().map(Cow::Owned),
+            https_proxy: std::env::var("https_proxy")
+                .ok()
+                .map(Cow::Owned)
+                .or_else(|| std::env::var("HTTPS_PROXY").ok().map(Cow::Owned))
+                .or_else(|| std::env::var("http_proxy").ok().map(Cow::Owned)),
+            shutdown_timeout: Duration::from_secs(2),
+            debug: false,
+            attach_stacktrace: false,
+            send_default_pii: false,
+            before_send: None,
+            before_breadcrumb: None,
+        }
+    }
+}

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -116,6 +116,7 @@
 mod macros;
 
 mod api;
+mod breadcrumbs;
 mod hub;
 mod scope;
 
@@ -126,6 +127,8 @@ mod backtrace_support;
 
 #[cfg(feature = "with_client_implementation")]
 mod client;
+#[cfg(feature = "with_client_implementation")]
+mod clientoptions;
 #[cfg(feature = "with_client_implementation")]
 mod constants;
 #[cfg(feature = "with_client_implementation")]
@@ -142,7 +145,7 @@ pub mod test;
 /// have to directly interface with directly.  These are often returned
 /// from methods on other types.
 pub mod internals {
-    pub use crate::hub::IntoBreadcrumbs;
+    pub use crate::breadcrumbs::IntoBreadcrumbs;
     pub use crate::scope::ScopeGuard;
 
     #[cfg(feature = "with_client_implementation")]

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -141,8 +141,8 @@ pub mod test;
 
 /// Useful internals.
 ///
-/// This module contains types that users of the create typically do not
-/// have to directly interface with directly.  These are often returned
+/// This module contains types that users of the crate typically do not
+/// have to interface with directly.  These are often returned
 /// from methods on other types.
 pub mod internals {
     pub use crate::breadcrumbs::IntoBreadcrumbs;
@@ -150,7 +150,8 @@ pub mod internals {
 
     #[cfg(feature = "with_client_implementation")]
     pub use crate::{
-        client::{ClientInitGuard, IntoDsn},
+        client::ClientInitGuard,
+        clientoptions::IntoDsn,
         transport::{Transport, TransportFactory},
     };
 


### PR DESCRIPTION
In particular: `ClientOptions` and `IntoBreadcrumbs` into its own file, and some stacktrace utils into
the `stacktrace_support` file.