### PR TITLE
ref: Move the init function to sentry crate

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -9,7 +9,6 @@ use rand::random;
 use crate::backtrace_support::process_event_stacktrace;
 pub use crate::clientoptions::ClientOptions;
 use crate::constants::SDK_INFO;
-use crate::hub::Hub;
 use crate::internals::{Dsn, Uuid};
 use crate::protocol::{DebugMeta, Event};
 use crate::scope::Scope;
@@ -70,14 +69,6 @@ impl Client {
         Client::with_options(opts.into())
     }
 
-    #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
-    pub fn with_dsn(dsn: Dsn) -> Client {
-        let mut options = ClientOptions::default();
-        options.dsn = Some(dsn);
-        Client::with_options(options)
-    }
-
     /// Creates a new sentry client for the given options.
     ///
     /// If the DSN on the options is set to `None` the client will be entirely
@@ -90,29 +81,6 @@ impl Client {
         Client { options, transport }
     }
 
-    #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
-    pub fn with_dsn_and_options(dsn: Dsn, mut options: ClientOptions) -> Client {
-        options.dsn = Some(dsn);
-        Client::with_options(options)
-    }
-
-    #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
-    pub fn disabled() -> Client {
-        Client::with_options(Default::default())
-    }
-
-    #[doc(hidden)]
-    #[deprecated(since = "0.8.0", note = "Please use Client::with_options instead")]
-    pub fn disabled_with_options(options: ClientOptions) -> Client {
-        Client {
-            options,
-            transport: RwLock::new(None),
-        }
-    }
-
-    #[allow(clippy::cognitive_complexity)]
     fn prepare_event(
         &self,
         mut event: Event<'static>,
@@ -230,84 +198,4 @@ impl Client {
             random::<f32>() <= rate
         }
     }
-}
-
-/// Helper struct that is returned from `init`.
-///
-/// When this is dropped events are drained with a 1 second timeout.
-#[must_use = "when the init guard is dropped the transport will be shut down and no further \
-              events can be sent.  If you do want to ignore this use mem::forget on it."]
-pub struct ClientInitGuard(Arc<Client>);
-
-impl ClientInitGuard {
-    /// Quick check if the client is enabled.
-    pub fn is_enabled(&self) -> bool {
-        self.0.is_enabled()
-    }
-}
-
-impl Drop for ClientInitGuard {
-    fn drop(&mut self) {
-        if self.is_enabled() {
-            sentry_debug!("dropping client guard -> disposing client");
-        } else {
-            sentry_debug!("dropping client guard (no client to dispose)");
-        }
-        self.0.close(None);
-    }
-}
-
-/// Creates the Sentry client for a given client config and binds it.
-///
-/// This returns a client init guard that must kept in scope will help the
-/// client send events before the application closes.  When the guard is
-/// dropped then the transport that was initialized shuts down and no
-/// further events can be set on it.
-///
-/// If you don't want (or can) keep the guard around it's permissible to
-/// call `mem::forget` on it.
-///
-/// # Examples
-///
-/// ```
-/// # use sentry_core as sentry;
-/// let _sentry = sentry::init("https://key@sentry.io/1234");
-/// ```
-///
-/// Or if draining on shutdown should be ignored:
-///
-/// ```
-/// # use sentry_core as sentry;
-/// std::mem::forget(sentry::init("https://key@sentry.io/1234"));
-/// ```
-///
-/// The guard returned can also be inspected to see if a client has been
-/// created to enable further configuration:
-///
-/// ```
-/// # use sentry_core as sentry;
-/// use sentry::integrations::panic::register_panic_handler;
-///
-/// let sentry = sentry::init(sentry::ClientOptions {
-///     release: Some("foo-bar-baz@1.0.0".into()),
-///     ..Default::default()
-/// });
-/// if sentry.is_enabled() {
-///     register_panic_handler();
-/// }
-/// ```
-///
-/// This behaves similar to creating a client by calling `Client::from_config`
-/// and to then bind it to the hub except it's also possible to directly pass
-/// a client.  For more information about the formats accepted see
-/// `Client::from_config`.
-pub fn init<C: Into<Client>>(cfg: C) -> ClientInitGuard {
-    let client = Arc::new(cfg.into());
-    Hub::with(|hub| hub.bind_client(Some(client.clone())));
-    if let Some(dsn) = client.dsn() {
-        sentry_debug!("enabled sentry client for DSN {}", dsn);
-    } else {
-        sentry_debug!("initialized disabled sentry client due to disabled or invalid DSN");
-    }
-    ClientInitGuard(client)
 }

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -21,7 +21,7 @@
 //! applications might slightly delay as a result of this.  Keep the guard around or sending events
 //! will not work.
 //!
-//! ```
+//! ```ignore
 //! # use sentry_core as sentry;
 //! let _guard = sentry::init("https://key@sentry.io/42");
 //! sentry::capture_message("Hello World!", sentry::Level::Info);
@@ -150,7 +150,6 @@ pub mod internals {
 
     #[cfg(feature = "with_client_implementation")]
     pub use crate::{
-        client::ClientInitGuard,
         clientoptions::IntoDsn,
         transport::{Transport, TransportFactory},
     };
@@ -183,7 +182,7 @@ pub use crate::hub::Hub;
 pub use crate::scope::Scope;
 
 #[cfg(feature = "with_client_implementation")]
-pub use crate::client::{init, Client, ClientOptions};
+pub use crate::client::{Client, ClientOptions};
 
 // public api from other crates
 pub use sentry_types::protocol::v7 as protocol;

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -33,6 +33,9 @@ macro_rules! sentry_crate_release {
     };
 }
 
+// TODO: temporarily hidden for use in `sentry` crate
+#[macro_export]
+#[doc(hidden)]
 macro_rules! with_client_impl {
     ($body:block) => {
         #[cfg(feature = "with_client_implementation")]
@@ -46,7 +49,9 @@ macro_rules! with_client_impl {
     };
 }
 
-#[allow(unused_macros)]
+// TODO: temporarily hidden for use in `sentry` crate
+#[macro_export]
+#[doc(hidden)]
 macro_rules! sentry_debug {
     ($($arg:tt)*) => {
         with_client_impl! {{

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -33,7 +33,7 @@ macro_rules! sentry_crate_release {
     };
 }
 
-// TODO: temporarily hidden for use in `sentry` crate
+// TODO: temporarily exported for use in `sentry` crate
 #[macro_export]
 #[doc(hidden)]
 macro_rules! with_client_impl {
@@ -49,12 +49,12 @@ macro_rules! with_client_impl {
     };
 }
 
-// TODO: temporarily hidden for use in `sentry` crate
+// TODO: temporarily exported for use in `sentry` crate
 #[macro_export]
 #[doc(hidden)]
 macro_rules! sentry_debug {
     ($($arg:tt)*) => {
-        with_client_impl! {{
+        $crate::with_client_impl! {{
             #[cfg(feature = "with_debug_to_log")] {
                 ::log::debug!(target: "sentry", $($arg)*);
             }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -26,7 +26,7 @@ with_backtrace = ["sentry-core/with_backtrace"]
 with_panic = ["sentry-core/with_panic"]
 with_failure = ["sentry-core/with_failure"]
 with_log = ["sentry-core/with_log"]
-with_debug_to_log = ["sentry-core/with_debug_to_log"]
+with_debug_to_log = ["log", "sentry-core/with_debug_to_log"]
 with_env_logger = ["sentry-core/with_env_logger"]
 with_error_chain = ["sentry-core/with_error_chain"]
 with_device_info = ["sentry-core/with_device_info"]
@@ -38,12 +38,12 @@ with_native_tls = ["sentry-core/with_native_tls"]
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core", default-features = false }
+log = { version = "0.4.8", optional = true, features = ["std"] }
 
 [dev-dependencies]
 failure_derive = "0.1.6"
 actix-web = { version = "0.7.19", default-features = false }
 tokio = { version = "0.2", features = ["macros"] }
-log = { version = "0.4.8", features = ["std"] }
 failure = "0.1.6"
 pretty_env_logger = "0.4.0"
 error-chain = "0.12.1"

--- a/sentry/src/init.rs
+++ b/sentry/src/init.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use crate::{Client, Hub};
+
+/// Helper struct that is returned from `init`.
+///
+/// When this is dropped events are drained with a 1 second timeout.
+#[must_use = "when the init guard is dropped the transport will be shut down and no further \
+              events can be sent.  If you do want to ignore this use mem::forget on it."]
+pub struct ClientInitGuard(Arc<Client>);
+
+impl ClientInitGuard {
+    /// Quick check if the client is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.0.is_enabled()
+    }
+}
+
+impl Drop for ClientInitGuard {
+    fn drop(&mut self) {
+        if self.is_enabled() {
+            sentry_debug!("dropping client guard -> disposing client");
+        } else {
+            sentry_debug!("dropping client guard (no client to dispose)");
+        }
+        self.0.close(None);
+    }
+}
+
+/// Creates the Sentry client for a given client config and binds it.
+///
+/// This returns a client init guard that must kept in scope will help the
+/// client send events before the application closes.  When the guard is
+/// dropped then the transport that was initialized shuts down and no
+/// further events can be set on it.
+///
+/// If you don't want (or can) keep the guard around it's permissible to
+/// call `mem::forget` on it.
+///
+/// # Examples
+///
+/// ```
+/// let _sentry = sentry::init("https://key@sentry.io/1234");
+/// ```
+///
+/// Or if draining on shutdown should be ignored:
+///
+/// ```
+/// std::mem::forget(sentry::init("https://key@sentry.io/1234"));
+/// ```
+///
+/// The guard returned can also be inspected to see if a client has been
+/// created to enable further configuration:
+///
+/// ```
+/// use sentry::integrations::panic::register_panic_handler;
+///
+/// let sentry = sentry::init(sentry::ClientOptions {
+///     release: Some("foo-bar-baz@1.0.0".into()),
+///     ..Default::default()
+/// });
+/// if sentry.is_enabled() {
+///     register_panic_handler();
+/// }
+/// ```
+///
+/// This behaves similar to creating a client by calling `Client::from_config`
+/// and to then bind it to the hub except it's also possible to directly pass
+/// a client.  For more information about the formats accepted see
+/// `Client::from_config`.
+pub fn init<C: Into<Client>>(cfg: C) -> ClientInitGuard {
+    let client = Arc::new(cfg.into());
+    Hub::with(|hub| hub.bind_client(Some(client.clone())));
+    if let Some(dsn) = client.dsn() {
+        sentry_debug!("enabled sentry client for DSN {}", dsn);
+    } else {
+        sentry_debug!("initialized disabled sentry client due to disabled or invalid DSN");
+    }
+    ClientInitGuard(client)
+}

--- a/sentry/src/init.rs
+++ b/sentry/src/init.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{Client, Hub};
+use sentry_core::sentry_debug;
 
 /// Helper struct that is returned from `init`.
 ///

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -111,5 +111,26 @@
 //! * `with_test_support`: Enables the test support module.
 #![warn(missing_docs)]
 
+#[macro_use]
+extern crate sentry_core;
+
+#[cfg(feature = "with_client_implementation")]
+mod init;
+
 #[doc(inline)]
 pub use sentry_core::*;
+
+/// Useful internals.
+///
+/// This module contains types that users of the crate typically do not
+/// have to interface with directly.  These are often returned
+/// from methods on other types.
+pub mod internals {
+    pub use sentry_core::internals::*;
+
+    #[cfg(feature = "with_client_implementation")]
+    pub use crate::init::ClientInitGuard;
+}
+
+#[cfg(feature = "with_client_implementation")]
+pub use crate::init::init;

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -111,9 +111,6 @@
 //! * `with_test_support`: Enables the test support module.
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate sentry_core;
-
 #[cfg(feature = "with_client_implementation")]
 mod init;
 


### PR DESCRIPTION
This is in preparation of moving the default options to the sentry
crate as well, which is needed to move the default transport and
integrations out of `sentry-core`.

Along with this, it removes some deprecated functions.