### PR TITLE
Remove some unnecessary allocations

### DIFF
--- a/sentry-core/src/backtrace_support.rs
+++ b/sentry-core/src/backtrace_support.rs
@@ -201,7 +201,6 @@ pub fn demangle_symbol(s: &str) -> String {
                 "u22" => "\"",
                 _ => unreachable!(),
             }
-            .to_string()
         })
         .to_string()
 }

--- a/sentry-core/src/integrations/failure.rs
+++ b/sentry-core/src/integrations/failure.rs
@@ -70,7 +70,7 @@ fn parse_stacktrace(bt: &str) -> Option<Stacktrace> {
         .captures_iter(&bt)
         .map(|captures| {
             let abs_path = captures.name("path").map(|m| m.as_str().to_string());
-            let filename = abs_path.as_ref().map(|p| filename(p));
+            let filename = abs_path.as_ref().map(|p| filename(p).to_string());
             let real_symbol = captures["symbol"].to_string();
             let symbol = strip_symbol(&real_symbol);
             let function = demangle_symbol(symbol);


### PR DESCRIPTION
I was reading the code for unrelated questions and noticed this.

Regarding `filename` I feel it's better to just return an `&str` when you can and let the caller convert *if needed*.

This is semver compatible (since `filename` ends up not being exported).