### PR TITLE
Bump findshlibs to 0.7.0

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -37,7 +37,7 @@ regex = { version = "1.3.4", optional = true }
 im = { version = "14.2.0", optional = true }
 libc = { version = "0.2.66", optional = true }
 hostname = { version = "0.3.0", optional = true }
-findshlibs = { version = "0.5.0", optional = true }
+findshlibs = { version = "0.7.0", optional = true }
 rand = { version = "0.7.3", optional = true }
 
 [target."cfg(not(windows))".dependencies]


### PR DESCRIPTION
findshlibs 0.5.0 has a serious defect in `SharedLibrary::id`, where it
uses file sizes and offsets when examining the PT_NOTE sections of an
ELF binary instead of the memory size/offset fields. This issue was
corrected by gimli-rs/findshlibs@046a431, but was released along with a
couple of semver breaking changes so it needs a bump in Cargo.toml to be
picked up.

This has a fairly major impact on projects where you have `with_debug_meta` enabled,
as it can lead to all sorts of issues, ranging from at best corrupted crash uploads reaching
Sentry, to SEGFAULTs when a thread panics, to wild UB as we try and read from totally
random memory addresses.

We have tested this in production by patching `findshlibs` with Cargo's patch function.

I'd suggest pushing out a 0.18.1 release for this if possible, given the impact of the above.
