### PR TITLE
feat: Add anyhow Integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "sentry",
     "sentry-actix",
+    "sentry-anyhow",
     "sentry-backtrace",
     "sentry-contexts",
     "sentry-core",

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sentry-anyhow"
+version = "0.18.0"
+authors = ["Sentry <hello@sentry.io>"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/getsentry/sentry-rust"
+homepage = "https://github.com/getsentry/sentry-rust"
+documentation = "https://getsentry.github.io/sentry-rust"
+description = """
+Sentry Integration for any errors.
+"""
+edition = "2018"
+
+
+[dependencies]
+sentry-core = { version = "0.18.0", path = "../sentry-core" }
+anyhow = "1.0.30"

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -1,0 +1,69 @@
+//! Adds support for capturing Sentry errors from `anyhow::Error`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # fn function_that_might_fail() -> anyhow::Result<()> { Ok(()) }
+//! use sentry_anyhow::capture_anyhow;
+//! # fn test() -> anyhow::Result<()> {
+//! let result = match function_that_might_fail() {
+//!     Ok(result) => result,
+//!     Err(err) => {
+//!         capture_anyhow(&err);
+//!         return Err(err);
+//!     }
+//! };
+//! # Ok(()) }
+//! ```
+
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+
+use std::error::Error;
+use std::fmt;
+
+use sentry_core::internals::Uuid;
+use sentry_core::Hub;
+
+/// Captures an `anyhow::Error`.
+///
+/// See [module level documentation](index.html) for more information.
+pub fn capture_anyhow(e: &anyhow::Error) -> Uuid {
+    Hub::with_active(|hub| hub.capture_anyhow(e))
+}
+
+/// Hub extension methods for working with `anyhow`.
+pub trait AnyhowHubExt {
+    /// Captures an `anyhow::Error` on a specific hub.
+    fn capture_anyhow(&self, e: &anyhow::Error) -> Uuid;
+}
+
+impl AnyhowHubExt for Hub {
+    fn capture_anyhow(&self, e: &anyhow::Error) -> Uuid {
+        self.capture_error(&AnyhowError(e))
+    }
+}
+
+// `anyhow::Error` itself does not impl `std::error::Error`, because it would
+// be incoherent. This can be worked around by wrapping it in a newtype
+// which impls `std::error::Error`.
+// Code adopted from: https://github.com/dtolnay/anyhow/issues/63#issuecomment-590983511
+struct AnyhowError<'a>(&'a anyhow::Error);
+
+impl fmt::Debug for AnyhowError<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+impl fmt::Display for AnyhowError<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+impl Error for AnyhowError<'_> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.0.source()
+    }
+}

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -52,12 +52,5 @@ failure = "0.1.6"
 pretty_env_logger = "0.4.0"
 error-chain = "0.12.1"
 sentry-error-chain = { version = "0.1.0", path = "../sentry-error-chain" }
-
-[[example]]
-name = "error-chain-demo"
-
-[[example]]
-name = "log-demo"
-
-[[example]]
-name = "thread-demo"
+sentry-anyhow = { version = "0.18.0", path = "../sentry-anyhow" }
+anyhow = "1.0.30"

--- a/sentry/examples/anyhow-demo.rs
+++ b/sentry/examples/anyhow-demo.rs
@@ -1,0 +1,19 @@
+fn execute() -> anyhow::Result<usize> {
+    let parsed = "NaN".parse()?;
+    Ok(parsed)
+}
+
+fn main() {
+    let _sentry = sentry::init((
+        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
+        sentry::ClientOptions {
+            release: sentry::release_name!(),
+            ..Default::default()
+        },
+    ));
+
+    if let Err(err) = execute() {
+        println!("error: {}", err);
+        sentry_anyhow::capture_anyhow(&err);
+    }
+}


### PR DESCRIPTION
Unfortunately, it does require a separate integration/method, since
`anyhow::Error` does not impl `std::error::Error`.