### PR TITLE
ref: Clean up the feature flags a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ check-curl-transport:
 	@echo 'CURL TRANSPORT'
 	@cd sentry && RUSTFLAGS=-Dwarnings cargo check --features with_curl_transport
 	@echo 'CURL TRANSPORT ONLY'
-	@cd sentry && RUSTFLAGS=-Dwarnings cargo check --no-default-features --features 'with_curl_transport,with_client_implementation,with_panic'
+	@cd sentry && RUSTFLAGS=-Dwarnings cargo check --no-default-features --features 'with_curl_transport,with_panic'
 .PHONY: check-curl-transport
 
 check-actix:

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 [features]
 default = ["with_sentry_default"]
 with_sentry_default = [
-    "sentry/with_client_implementation",
     "sentry/with_default_transport",
     "sentry/with_panic",
     "sentry/with_native_tls"

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -16,10 +16,10 @@ edition = "2018"
 all-features = true
 
 [features]
-default = ["with_client_implementation"]
-with_client_implementation = ["im", "url", "rand"]
-with_debug_to_log = ["log"]
-with_test_support = []
+default = []
+client = ["im", "url", "rand"]
+debug-to-log = ["log"]
+test = []
 
 [dependencies]
 url = { version = "2.1.1", optional = true }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -18,7 +18,9 @@ all-features = true
 [features]
 default = []
 client = ["im", "rand"]
-debug-to-log = ["log"]
+# I would love to just have a `log` feature, but this is used inside a macro,
+# and macros actually expand features where they are used!
+debug-logs = ["log"]
 test = []
 
 [dependencies]

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -17,23 +17,19 @@ all-features = true
 
 [features]
 default = []
-client = ["im", "url", "rand"]
+client = ["im", "rand"]
 debug-to-log = ["log"]
 test = []
 
 [dependencies]
-url = { version = "2.1.1", optional = true }
-log = { version = "0.4.8", optional = true, features = ["std"] }
-sentry-types = { path = "../sentry-types", version = "0.15.0" }
-env_logger = { version = "0.7.1", optional = true }
+sentry-types = { version = "0.15.0", path = "../sentry-types" }
 lazy_static = "1.4.0"
 im = { version = "14.2.0", optional = true }
 rand = { version = "0.7.3", optional = true }
+log = { version = "0.4.8", optional = true, features = ["std"] }
 
 [dev-dependencies]
-pretty_env_logger = "0.4.0"
 thiserror = "1.0.15"
 anyhow = "1.0.30"
 failure = "0.1.8"
-sentry-failure = { version = "0.18.0", path = "../sentry-failure" }
 tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -19,8 +19,8 @@ all-features = true
 default = []
 client = ["im", "rand"]
 # I would love to just have a `log` feature, but this is used inside a macro,
-# and macros actually expand features where they are used!
-debug-logs = ["log"]
+# and macros actually expand features (and extern crate) where they are used!
+debug-logs = ["log_"]
 test = []
 
 [dependencies]
@@ -28,7 +28,7 @@ sentry-types = { version = "0.15.0", path = "../sentry-types" }
 lazy_static = "1.4.0"
 im = { version = "14.2.0", optional = true }
 rand = { version = "0.7.3", optional = true }
-log = { version = "0.4.8", optional = true, features = ["std"] }
+log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
 
 [dev-dependencies]
 thiserror = "1.0.15"

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -1,5 +1,4 @@
 use crate::breadcrumbs::IntoBreadcrumbs;
-#[cfg(feature = "with_client_implementation")]
 use crate::hub::Hub;
 use crate::internals;
 use crate::protocol::{Event, Level};
@@ -24,23 +23,15 @@ use crate::scope::Scope;
 ///     ..Default::default()
 /// });
 /// ```
-#[allow(unused_variables)]
 pub fn capture_event(event: Event<'static>) -> internals::Uuid {
-    with_client_impl! {{
-        Hub::with(|hub| hub.capture_event(event))
-    }}
+    Hub::with_active(|hub| hub.capture_event(event))
 }
 
 /// Captures an arbitrary message.
 ///
 /// This creates an event from the given message and sends it to the current hub.
-#[allow(unused_variables)]
 pub fn capture_message(msg: &str, level: Level) -> internals::Uuid {
-    with_client_impl! {{
-        Hub::with_active(|hub| {
-            hub.capture_message(msg, level)
-        })
-    }}
+    Hub::with_active(|hub| hub.capture_message(msg, level))
 }
 
 /// Records a breadcrumb by calling a function.
@@ -77,13 +68,8 @@ pub fn capture_message(msg: &str, level: Level) -> internals::Uuid {
 ///     ..Default::default()
 /// });
 /// ```
-#[allow(unused_variables)]
 pub fn add_breadcrumb<B: IntoBreadcrumbs>(breadcrumb: B) {
-    with_client_impl! {{
-        Hub::with_active(|hub| {
-            hub.add_breadcrumb(breadcrumb)
-        })
-    }}
+    Hub::with_active(|hub| hub.add_breadcrumb(breadcrumb))
 }
 
 /// Invokes a function that can modify the current scope.
@@ -112,17 +98,12 @@ pub fn add_breadcrumb<B: IntoBreadcrumbs>(breadcrumb: B) {
 /// not permitted.  In this case a wide range of panics will be raised.  It's
 /// unsafe to call into `sentry::bind_client` or similar functions from within
 /// the callback as a result of this.
-#[allow(unused_variables)]
 pub fn configure_scope<F, R>(f: F) -> R
 where
     R: Default,
     F: FnOnce(&mut Scope) -> R,
 {
-    with_client_impl! {{
-        Hub::with_active(|hub| {
-            hub.configure_scope(f)
-        })
-    }}
+    Hub::with_active(|hub| hub.configure_scope(f))
 }
 
 /// Temporarily pushes a scope for a single call optionally reconfiguring it.
@@ -148,7 +129,7 @@ where
     C: FnOnce(&mut Scope),
     F: FnOnce() -> R,
 {
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     {
         Hub::with(|hub| {
             if hub.is_active_and_usage_safe() {
@@ -158,7 +139,7 @@ where
             }
         })
     }
-    #[cfg(not(feature = "with_client_implementation"))]
+    #[cfg(not(feature = "client"))]
     {
         let _scope_config = scope_config;
         callback()
@@ -167,9 +148,5 @@ where
 
 /// Returns the last event ID captured.
 pub fn last_event_id() -> Option<internals::Uuid> {
-    with_client_impl! {{
-        Hub::with_active(|hub| {
-            hub.last_event_id()
-        })
-    }}
+    Hub::with_active(|hub| hub.last_event_id())
 }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -147,6 +147,10 @@ where
 }
 
 /// Returns the last event ID captured.
+///
+/// This uses the current thread local hub.
 pub fn last_event_id() -> Option<internals::Uuid> {
-    Hub::with_active(|hub| hub.last_event_id())
+    with_client_impl! {{
+        Hub::with(|hub| hub.last_event_id())
+    }}
 }

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -10,11 +10,11 @@ use rand::random;
 
 pub use crate::clientoptions::ClientOptions;
 use crate::constants::SDK_INFO;
-use crate::integrations::Integration;
 use crate::internals::{Dsn, Uuid};
 use crate::protocol::{ClientSdkInfo, Event};
 use crate::scope::Scope;
 use crate::transport::Transport;
+use crate::Integration;
 
 impl<T: Into<ClientOptions>> From<T> for Client {
     fn from(o: T) -> Client {

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::constants::USER_AGENT;
-use crate::integrations::Integration;
 use crate::internals::Dsn;
 use crate::intodsn::IntoDsn;
 use crate::protocol::{Breadcrumb, Event};
 use crate::transport::TransportFactory;
+use crate::Integration;
 
 /// Type alias for before event/breadcrumb handlers.
 pub type BeforeCallback<T> = Arc<dyn Fn(T) -> Option<T> + Send + Sync>;

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -25,7 +25,7 @@ pub struct ClientOptions {
     /// Enables debug mode.
     ///
     /// In debug mode debug information is printed to stderr to help you understand what
-    /// sentry is doing.  When the `with_debug_to_log` flag is enabled Sentry will instead
+    /// sentry is doing.  When the `log` feature is enabled, Sentry will instead
     /// log to the `sentry` logger independently of this flag with the `Debug` level.
     pub debug: bool,
     /// The release to be sent with events.

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -9,12 +9,11 @@ use std::thread;
 use std::time::Duration;
 
 use crate::breadcrumbs::IntoBreadcrumbs;
-#[cfg(feature = "client")]
 use crate::error::event_from_error;
-use crate::integrations::Integration;
 use crate::internals::Uuid;
 use crate::protocol::{Breadcrumb, Event, Level};
 use crate::scope::{Scope, ScopeGuard};
+use crate::Integration;
 #[cfg(feature = "client")]
 use crate::{client::Client, scope::Stack};
 

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -9,16 +9,16 @@ use std::thread;
 use std::time::Duration;
 
 use crate::breadcrumbs::IntoBreadcrumbs;
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 use crate::error::event_from_error;
 use crate::integrations::Integration;
 use crate::internals::Uuid;
 use crate::protocol::{Breadcrumb, Event, Level};
 use crate::scope::{Scope, ScopeGuard};
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 use crate::{client::Client, scope::Stack};
 
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 lazy_static::lazy_static! {
     static ref PROCESS_HUB: (Arc<Hub>, thread::ThreadId) = (
         Arc::new(Hub::new(None, Arc::new(Default::default()))),
@@ -26,20 +26,20 @@ lazy_static::lazy_static! {
     );
 }
 
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 thread_local! {
     static THREAD_HUB: UnsafeCell<Arc<Hub>> = UnsafeCell::new(
         Arc::new(Hub::new_from_top(&PROCESS_HUB.0)));
     static USE_PROCESS_HUB: Cell<bool> = Cell::new(PROCESS_HUB.1 == thread::current().id());
 }
 
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 #[derive(Debug)]
 pub(crate) struct HubImpl {
     stack: Arc<RwLock<Stack>>,
 }
 
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 impl HubImpl {
     pub(crate) fn with<F: FnOnce(&Stack) -> R, R>(&self, f: F) -> R {
         let guard = self.stack.read().unwrap_or_else(PoisonError::into_inner);
@@ -86,14 +86,14 @@ impl HubImpl {
 /// * `Hub::new_from_top`: creates a new hub with just the top scope of another hub.
 #[derive(Debug)]
 pub struct Hub {
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub(crate) inner: HubImpl,
     last_event_id: RwLock<Option<Uuid>>,
 }
 
 impl Hub {
     /// Creates a new hub from the given client and scope.
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub fn new(client: Option<Arc<Client>>, scope: Arc<Scope>) -> Hub {
         Hub {
             inner: HubImpl {
@@ -104,7 +104,7 @@ impl Hub {
     }
 
     /// Creates a new hub based on the top scope of the given hub.
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub fn new_from_top<H: AsRef<Hub>>(other: H) -> Hub {
         let hub = other.as_ref();
         hub.inner.with(|stack| {
@@ -121,7 +121,7 @@ impl Hub {
     ///
     /// This method is unavailable if the client implementation is disabled.
     /// When using the minimal API set use `Hub::with_active` instead.
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub fn current() -> Arc<Hub> {
         Hub::with(Arc::clone)
     }
@@ -130,7 +130,7 @@ impl Hub {
     ///
     /// This is similar to `current` but instead of picking the current
     /// thread's hub it returns the main thread's hub instead.
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub fn main() -> Arc<Hub> {
         PROCESS_HUB.0.clone()
     }
@@ -139,7 +139,7 @@ impl Hub {
     ///
     /// This is a slightly more efficient version than `Hub::current()` and
     /// also unavailable in minimal mode.
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub fn with<F, R>(f: F) -> R
     where
         F: FnOnce(&Arc<Hub>) -> R,
@@ -179,8 +179,7 @@ impl Hub {
     }
 
     /// Binds a hub to the current thread for the duration of the call.
-    #[cfg(feature = "with_client_implementation")]
-    #[allow(clippy::needless_pass_by_value)]
+    #[cfg(feature = "client")]
     pub fn run<F: FnOnce() -> R, R>(hub: Arc<Hub>, f: F) -> R {
         let mut restore_process_hub = false;
         let did_switch = THREAD_HUB.with(|ctx| unsafe {
@@ -306,23 +305,17 @@ impl Hub {
     }
 
     /// Returns the currently bound client.
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub fn client(&self) -> Option<Arc<Client>> {
-        with_client_impl! {{
-            self.inner.with(|stack| {
-                stack.top().client.clone()
-            })
-        }}
+        self.inner.with(|stack| stack.top().client.clone())
     }
 
     /// Binds a new client to the hub.
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub fn bind_client(&self, client: Option<Arc<Client>>) {
-        with_client_impl! {{
-            self.inner.with_mut(|stack| {
-                stack.top_mut().client = client;
-            })
-        }}
+        self.inner.with_mut(|stack| {
+            stack.top_mut().client = client;
+        })
     }
 
     /// Pushes a new scope.
@@ -345,13 +338,13 @@ impl Hub {
         C: FnOnce(&mut Scope),
         F: FnOnce() -> R,
     {
-        #[cfg(feature = "with_client_implementation")]
+        #[cfg(feature = "client")]
         {
             let _guard = self.push_scope();
             self.configure_scope(scope_config);
             callback()
         }
-        #[cfg(not(feature = "with_client_implementation"))]
+        #[cfg(not(feature = "client"))]
         {
             let _scope_config = scope_config;
             callback()
@@ -405,17 +398,17 @@ impl Hub {
         }}
     }
 
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub(crate) fn is_active_and_usage_safe(&self) -> bool {
         self.inner.is_active_and_usage_safe()
     }
 
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub(crate) fn with_current_scope<F: FnOnce(&Arc<Scope>) -> R, R>(&self, f: F) -> R {
         self.inner.with(|stack| f(&stack.top().scope))
     }
 
-    #[cfg(feature = "with_client_implementation")]
+    #[cfg(feature = "client")]
     pub(crate) fn with_current_scope_mut<F: FnOnce(&mut Scope) -> R, R>(&self, f: F) -> R {
         self.inner
             .with_mut(|stack| f(Arc::make_mut(&mut stack.top_mut().scope)))

--- a/sentry-core/src/integration.rs
+++ b/sentry-core/src/integration.rs
@@ -1,7 +1,3 @@
-//! This module provides support for various integrations.
-//!
-//! Which integerations are available depends on the features that were compiled in.
-
 use std::any::{type_name, Any};
 
 use crate::protocol::Event;

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -79,15 +79,15 @@
 //!
 //! Default features:
 //!
-//! * `with_client_implementation`: Turns on the real client implementation.
+//! * `client`: Turns on the real client implementation.
 //!
 //! Additional integrations:
 //!
-//! * `with_debug_to_log`: When enabled sentry will debug log to a debug log at all times.
+//! * `log`: When enabled sentry will debug log to `log` at all times.
 //!
 //! Testing:
 //!
-//! * `with_test_support`: Enables the test support module.
+//! * `test`: Enables the test support module.
 #![warn(missing_docs)]
 
 #[macro_use]
@@ -101,7 +101,7 @@ mod scope;
 
 pub mod integrations;
 
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 mod client;
 mod clientoptions;
 mod constants;
@@ -109,7 +109,7 @@ mod error;
 mod intodsn;
 mod transport;
 
-#[cfg(any(test, feature = "with_test_support"))]
+#[cfg(any(test, feature = "test"))]
 pub mod test;
 
 /// Useful internals.
@@ -139,7 +139,7 @@ pub use crate::hub::Hub;
 pub use crate::integrations::Integration;
 pub use crate::scope::Scope;
 
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 pub use crate::client::Client;
 
 // public api from other crates

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -81,36 +81,30 @@
 //!
 //! * `client`: Turns on the real client implementation.
 //!
-//! Additional integrations:
+//! Additional features:
 //!
 //! * `log`: When enabled sentry will debug log to `log` at all times.
-//!
-//! Testing:
-//!
 //! * `test`: Enables the test support module.
+
 #![warn(missing_docs)]
 
 #[macro_use]
 mod macros;
-
 mod api;
 mod breadcrumbs;
-mod futures;
-mod hub;
-mod scope;
-
-pub mod integrations;
-
 #[cfg(feature = "client")]
 mod client;
 mod clientoptions;
 mod constants;
 mod error;
+mod futures;
+mod hub;
+mod integration;
 mod intodsn;
-mod transport;
-
+mod scope;
 #[cfg(any(test, feature = "test"))]
 pub mod test;
+mod transport;
 
 /// Useful internals.
 ///
@@ -132,15 +126,14 @@ pub mod internals {
 
 // public api or exports from this crate
 pub use crate::api::*;
+#[cfg(feature = "client")]
+pub use crate::client::Client;
 pub use crate::clientoptions::ClientOptions;
 pub use crate::error::{capture_error, event_from_error, parse_type_from_debug};
 pub use crate::futures::{FutureExt, SentryFuture as Future};
 pub use crate::hub::Hub;
-pub use crate::integrations::Integration;
+pub use crate::integration::Integration;
 pub use crate::scope::Scope;
-
-#[cfg(feature = "client")]
-pub use crate::client::Client;
 
 // public api from other crates
 pub use sentry_types::protocol::v7 as protocol;

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -90,6 +90,7 @@
 
 #[macro_use]
 mod macros;
+
 mod api;
 mod breadcrumbs;
 #[cfg(feature = "client")]
@@ -102,9 +103,10 @@ mod hub;
 mod integration;
 mod intodsn;
 mod scope;
+mod transport;
+
 #[cfg(any(test, feature = "test"))]
 pub mod test;
-mod transport;
 
 /// Useful internals.
 ///

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -43,7 +43,7 @@ macro_rules! with_client_impl {
 #[doc(hidden)]
 macro_rules! sentry_debug {
     ($($arg:tt)*) => {
-        $crate::with_client_impl! {{
+        #[cfg(feature = "client")] {
             #[cfg(feature = "debug-logs")] {
                 ::log_::debug!(target: "sentry", $($arg)*);
             }
@@ -55,7 +55,10 @@ macro_rules! sentry_debug {
                     }
                 });
             }
-        }}
+        }
+        #[cfg(not(feature = "client"))] {
+            let _ = ($($arg)*);
+        }
     }
 }
 

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -44,10 +44,10 @@ macro_rules! with_client_impl {
 macro_rules! sentry_debug {
     ($($arg:tt)*) => {
         $crate::with_client_impl! {{
-            #[cfg(feature = "log")] {
+            #[cfg(feature = "debug-logs")] {
                 ::log::debug!(target: "sentry", $($arg)*);
             }
-            #[cfg(not(feature = "log"))] {
+            #[cfg(not(feature = "debug-logs"))] {
                 $crate::Hub::with(|hub| {
                     if hub.client().map_or(false, |c| c.options().debug) {
                         eprint!("[sentry] ");

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -45,7 +45,7 @@ macro_rules! sentry_debug {
     ($($arg:tt)*) => {
         $crate::with_client_impl! {{
             #[cfg(feature = "debug-logs")] {
-                ::log::debug!(target: "sentry", $($arg)*);
+                ::log_::debug!(target: "sentry", $($arg)*);
             }
             #[cfg(not(feature = "debug-logs"))] {
                 $crate::Hub::with(|hub| {

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -3,7 +3,6 @@
 /// This can be used with `ClientOptions` to set the release name.  It uses
 /// the information supplied by cargo to calculate a release.
 #[macro_export]
-#[cfg(feature = "with_client_implementation")]
 macro_rules! release_name {
     () => {{
         use std::sync::Once;
@@ -23,26 +22,16 @@ macro_rules! release_name {
     }};
 }
 
-#[macro_export]
-#[cfg(feature = "with_client_implementation")]
-#[deprecated(since = "0.13.0", note = "use sentry::release_name! instead")]
-#[doc(hidden)]
-macro_rules! sentry_crate_release {
-    () => {
-        ::sentry::release_name!()
-    };
-}
-
 // TODO: temporarily exported for use in `sentry` crate
 #[macro_export]
 #[doc(hidden)]
 macro_rules! with_client_impl {
     ($body:block) => {
-        #[cfg(feature = "with_client_implementation")]
+        #[cfg(feature = "client")]
         {
             $body
         }
-        #[cfg(not(feature = "with_client_implementation"))]
+        #[cfg(not(feature = "client"))]
         {
             Default::default()
         }
@@ -55,10 +44,10 @@ macro_rules! with_client_impl {
 macro_rules! sentry_debug {
     ($($arg:tt)*) => {
         $crate::with_client_impl! {{
-            #[cfg(feature = "with_debug_to_log")] {
+            #[cfg(feature = "log")] {
                 ::log::debug!(target: "sentry", $($arg)*);
             }
-            #[cfg(not(feature = "with_debug_to_log"))] {
+            #[cfg(not(feature = "log"))] {
                 $crate::Hub::with(|hub| {
                     if hub.client().map_or(false, |c| c.options().debug) {
                         eprint!("[sentry] ");

--- a/sentry-core/src/scope/mod.rs
+++ b/sentry-core/src/scope/mod.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 mod real;
 
-#[cfg(not(feature = "with_client_implementation"))]
+#[cfg(not(feature = "client"))]
 pub(crate) mod noop;
 
-#[cfg(feature = "with_client_implementation")]
+#[cfg(feature = "client")]
 pub use self::real::*;
 
-#[cfg(not(feature = "with_client_implementation"))]
+#[cfg(not(feature = "client"))]
 pub use self::noop::*;

--- a/sentry-core/src/test.rs
+++ b/sentry-core/src/test.rs
@@ -1,6 +1,6 @@
 //! This provides testing functionality for building tests.
 //!
-//! **Feature:** `with_test_support` (*disabled by default*)
+//! **Feature:** `test` (*disabled by default*)
 //!
 //! If the sentry crate has been compiled with the test support feature this
 //! module becomes available and provides functionality to capture events

--- a/sentry-error-chain/src/lib.rs
+++ b/sentry-error-chain/src/lib.rs
@@ -23,10 +23,12 @@
 //! # Ok(()) }
 //! ```
 
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+
 use std::fmt::{Debug, Display};
 
 use error_chain::ChainedError;
-
 use sentry_backtrace::backtrace_to_stacktrace;
 use sentry_core::internals::Uuid;
 use sentry_core::parse_type_from_debug;
@@ -100,7 +102,16 @@ impl ErrorChainHubExt for Hub {
     }
 }
 
+/// The Sentry `error-chain` Integration.
+#[derive(Default)]
 pub struct ErrorChainIntegration;
+
+impl ErrorChainIntegration {
+    /// Creates a new `error-chain` Integration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 impl Integration for ErrorChainIntegration {
     fn name(&self) -> &'static str {

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = ["sentry-anyhow"]
 debug-images = ["sentry-debug-images"]
 error-chain = ["sentry-error-chain"]
 log = ["sentry-log"]
+slog = ["sentry-slog"]
 
 # other features
 test = ["sentry-core/test"]
@@ -69,6 +70,7 @@ sentry-error-chain = { version = "0.1.0", path = "../sentry-error-chain", option
 sentry-failure = { version = "0.18.0", path = "../sentry-failure", optional = true }
 sentry-log = { version = "0.18.0", path = "../sentry-log", optional = true }
 sentry-panic = { version = "0.18.0", path = "../sentry-panic", optional = true }
+sentry-slog = { version = "0.18.0", path = "../sentry-slog", optional = true }
 log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
 reqwest = { version = "0.10.1", optional = true, features = ["blocking", "json"], default-features = false }
 curl = { version = "0.4.25", optional = true }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -21,7 +21,7 @@ default = ["client", "backtrace", "contexts", "failure", "panic", "transport"]
 
 # we still need a "client" feature, here, because `sentry_debug!` tests for that
 client = []
-debug-logs = ["log", "sentry-core/debug-logs"]
+debug-logs = ["log_", "sentry-core/debug-logs"]
 
 # default integrations
 backtrace = ["sentry-backtrace"]

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -17,25 +17,51 @@ autoexamples = true
 all-features = true
 
 [features]
-default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure"]
+default = ["client", "backtrace", "contexts", "panic", "transport", "with_failure"]
+
+# we still need a "client" feature, here, because `sentry_debug!` tests for that
+client = []
+debug-to-log = ["log", "sentry-core/debug-to-log"]
+
+# default features
+backtrace = ["sentry-backtrace"]
+contexts = ["sentry-contexts"]
+panic = ["sentry-panic"]
+
+transport = ["with_default_transport"]
+
+# other features
+test = ["sentry-core/test"]
+debug-images = ["sentry-debug-images"]
+
+# deprecated feature flags, here for backwards compatibility, will be removed
+# at some point
+with_client_implementation = ["client"]
+with_backtrace = ["backtrace"]
+with_failure = ["sentry-failure"]
+with_panic = ["panic"]
+with_error_chain = ["sentry-error-chain"]
+with_debug_to_log = ["debug-to-log"]
+with_test_support = ["test"]
+with_debug_meta = ["debug-images"]
+with_device_info = ["contexts"]
+with_rust_info = ["contexts"]
+
+# transport related features, should be cleaned up further in the future
+with_default_transport = ["with_reqwest_transport", "with_native_tls"]
 with_reqwest_transport = ["reqwest", "httpdate", "with_client_implementation"]
 with_curl_transport = ["curl", "httpdate", "serde_json", "with_client_implementation"]
-with_default_transport = ["with_reqwest_transport", "with_native_tls"]
-with_client_implementation = ["sentry-core/with_client_implementation"]
-with_backtrace = ["sentry-backtrace"]
-with_panic = ["sentry-panic"]
-with_failure = ["sentry-failure"]
-with_debug_to_log = ["log", "sentry-core/with_debug_to_log"]
-with_test_support = ["sentry-core/with_test_support"]
 with_rustls = ["reqwest/rustls-tls"]
 with_native_tls = ["reqwest/default-tls"]
 
 [dependencies]
-sentry-core = { version = "0.18.0", path = "../sentry-core", default-features = false }
+sentry-core = { version = "0.18.0", path = "../sentry-core", features = ["client"] }
 sentry-backtrace = { version = "0.18.0", path = "../sentry-backtrace", optional = true }
+sentry-contexts = { version = "0.18.0", path = "../sentry-contexts", optional = true }
+sentry-debug-images = { version = "0.18.0", path = "../sentry-debug-images", optional = true }
+sentry-error-chain = { version = "0.1.0", path = "../sentry-error-chain", optional = true }
 sentry-failure = { version = "0.18.0", path = "../sentry-failure", optional = true }
 sentry-panic = { version = "0.18.0", path = "../sentry-panic", optional = true }
-sentry-contexts = { version = "0.18.0", path = "../sentry-contexts" }
 log = { version = "0.4.8", optional = true, features = ["std"] }
 reqwest = { version = "0.10.1", optional = true, features = ["blocking", "json"], default-features = false }
 curl = { version = "0.4.25", optional = true }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -17,31 +17,35 @@ autoexamples = true
 all-features = true
 
 [features]
-default = ["client", "backtrace", "contexts", "panic", "transport", "with_failure"]
+default = ["client", "backtrace", "contexts", "failure", "panic", "transport"]
 
 # we still need a "client" feature, here, because `sentry_debug!` tests for that
 client = []
-debug-to-log = ["log", "sentry-core/debug-to-log"]
+debug-logs = ["log", "sentry-core/debug-logs"]
 
-# default features
+# default integrations
 backtrace = ["sentry-backtrace"]
 contexts = ["sentry-contexts"]
+failure = ["sentry-failure"]
 panic = ["sentry-panic"]
-
-transport = ["with_default_transport"]
+# other integrations
+anyhow = ["sentry-anyhow"]
+debug-images = ["sentry-debug-images"]
+error-chain = ["sentry-error-chain"]
+log = ["sentry-log"]
 
 # other features
 test = ["sentry-core/test"]
-debug-images = ["sentry-debug-images"]
+transport = ["with_default_transport"]
 
 # deprecated feature flags, here for backwards compatibility, will be removed
 # at some point
 with_client_implementation = ["client"]
 with_backtrace = ["backtrace"]
-with_failure = ["sentry-failure"]
+with_failure = ["failure"]
 with_panic = ["panic"]
-with_error_chain = ["sentry-error-chain"]
-with_debug_to_log = ["debug-to-log"]
+with_error_chain = ["error-chain"]
+with_debug_to_log = ["debug-logs"]
 with_test_support = ["test"]
 with_debug_meta = ["debug-images"]
 with_device_info = ["contexts"]
@@ -56,13 +60,15 @@ with_native_tls = ["reqwest/default-tls"]
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core", features = ["client"] }
+sentry-anyhow = { version = "0.18.0", path = "../sentry-anyhow", optional = true }
 sentry-backtrace = { version = "0.18.0", path = "../sentry-backtrace", optional = true }
 sentry-contexts = { version = "0.18.0", path = "../sentry-contexts", optional = true }
 sentry-debug-images = { version = "0.18.0", path = "../sentry-debug-images", optional = true }
 sentry-error-chain = { version = "0.1.0", path = "../sentry-error-chain", optional = true }
 sentry-failure = { version = "0.18.0", path = "../sentry-failure", optional = true }
+sentry-log = { version = "0.18.0", path = "../sentry-log", optional = true }
 sentry-panic = { version = "0.18.0", path = "../sentry-panic", optional = true }
-log = { version = "0.4.8", optional = true, features = ["std"] }
+log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
 reqwest = { version = "0.10.1", optional = true, features = ["blocking", "json"], default-features = false }
 curl = { version = "0.4.25", optional = true }
 httpdate = { version = "0.3.2", optional = true }
@@ -70,13 +76,13 @@ serde_json = { version = "1.0.48", optional = true }
 
 [dev-dependencies]
 sentry-log = { version = "0.18.0", path = "../sentry-log", features = ["env_logger"] }
-log = { version = "0.4.8", features = ["std"] }
+log_ = { package = "log", version = "0.4.8", features = ["std"] }
 failure_derive = "0.1.6"
 actix-web = { version = "0.7.19", default-features = false }
 tokio = { version = "0.2", features = ["macros"] }
-failure = "0.1.6"
+failure_ = { package = "failure", version = "0.1.6" }
 pretty_env_logger = "0.4.0"
-error-chain = "0.12.1"
+error-chain_ = { package = "error-chain", version = "0.12.1" }
 sentry-error-chain = { version = "0.1.0", path = "../sentry-error-chain" }
 sentry-anyhow = { version = "0.18.0", path = "../sentry-anyhow" }
-anyhow = "1.0.30"
+anyhow_ = { package = "anyhow", version = "1.0.30" }

--- a/sentry/examples/anyhow-demo.rs
+++ b/sentry/examples/anyhow-demo.rs
@@ -1,3 +1,5 @@
+use anyhow_ as anyhow;
+
 fn execute() -> anyhow::Result<usize> {
     let parsed = "NaN".parse()?;
     Ok(parsed)

--- a/sentry/examples/error-chain-demo.rs
+++ b/sentry/examples/error-chain-demo.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate error_chain;
+extern crate error_chain_;
 
 use sentry_error_chain::{capture_error_chain, ErrorChainIntegration};
 

--- a/sentry/examples/failure-demo.rs
+++ b/sentry/examples/failure-demo.rs
@@ -1,4 +1,5 @@
 use failure::Fail;
+use failure_ as failure;
 use sentry_failure::capture_error;
 
 #[derive(Fail, Debug)]

--- a/sentry/examples/log-demo.rs
+++ b/sentry/examples/log-demo.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info, warn};
+use log_::{debug, error, info, warn};
 
 fn main() {
     let mut log_builder = pretty_env_logger::formatted_builder();

--- a/sentry/examples/thread-demo.rs
+++ b/sentry/examples/thread-demo.rs
@@ -1,3 +1,4 @@
+use log_ as log;
 use std::sync::Arc;
 use std::thread;
 

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -45,7 +45,7 @@ pub fn apply_defaults(mut opts: ClientOptions) -> ClientOptions {
                 sentry_debug_images::DebugImagesIntegration::default(),
             ))
         }
-        #[cfg(feature = "sentry-error-chain")]
+        #[cfg(feature = "error-chain")]
         {
             integrations.push(Arc::new(
                 sentry_error_chain::ErrorChainIntegration::default(),
@@ -55,7 +55,7 @@ pub fn apply_defaults(mut opts: ClientOptions) -> ClientOptions {
         {
             integrations.push(Arc::new(sentry_contexts::ContextIntegration::default()));
         }
-        #[cfg(feature = "with_failure")]
+        #[cfg(feature = "failure")]
         {
             integrations.push(Arc::new(sentry_failure::FailureIntegration::default()));
         }
@@ -63,7 +63,7 @@ pub fn apply_defaults(mut opts: ClientOptions) -> ClientOptions {
         {
             #[allow(unused_mut)]
             let mut integration = sentry_panic::PanicIntegration::default();
-            #[cfg(feature = "with_failure")]
+            #[cfg(feature = "failure")]
             {
                 integration = integration.add_extractor(sentry_failure::panic_extractor);
             }

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -33,18 +33,33 @@ pub fn apply_defaults(mut opts: ClientOptions) -> ClientOptions {
         // default integrations need to be ordered *before* custom integrations,
         // since they also process events in order
         let mut integrations: Vec<Arc<dyn Integration>> = vec![];
-        #[cfg(feature = "with_backtrace")]
+        #[cfg(feature = "backtrace")]
         {
             integrations.push(Arc::new(
                 sentry_backtrace::AttachStacktraceIntegration::default(),
             ));
         }
-        integrations.push(Arc::new(sentry_contexts::ContextIntegration::default()));
+        #[cfg(feature = "debug-images")]
+        {
+            integrations.push(Arc::new(
+                sentry_debug_images::DebugImagesIntegration::default(),
+            ))
+        }
+        #[cfg(feature = "sentry-error-chain")]
+        {
+            integrations.push(Arc::new(
+                sentry_error_chain::ErrorChainIntegration::default(),
+            ))
+        }
+        #[cfg(feature = "contexts")]
+        {
+            integrations.push(Arc::new(sentry_contexts::ContextIntegration::default()));
+        }
         #[cfg(feature = "with_failure")]
         {
             integrations.push(Arc::new(sentry_failure::FailureIntegration::default()));
         }
-        #[cfg(feature = "with_panic")]
+        #[cfg(feature = "panic")]
         {
             #[allow(unused_mut)]
             let mut integration = sentry_panic::PanicIntegration::default();
@@ -54,7 +69,7 @@ pub fn apply_defaults(mut opts: ClientOptions) -> ClientOptions {
             }
             integrations.push(Arc::new(integration));
         }
-        #[cfg(feature = "with_backtrace")]
+        #[cfg(feature = "backtrace")]
         {
             integrations.push(Arc::new(
                 sentry_backtrace::ProcessStacktraceIntegration::default(),

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -111,21 +111,32 @@ pub use sentry_core::*;
 /// Available Sentry Integrations.
 pub mod integrations {
     #[cfg(feature = "anyhow")]
+    #[doc(inline)]
     pub use sentry_anyhow as anyhow;
     #[cfg(feature = "backtrace")]
+    #[doc(inline)]
     pub use sentry_backtrace as backtrace;
     #[cfg(feature = "contexts")]
+    #[doc(inline)]
     pub use sentry_contexts as contexts;
     #[cfg(feature = "debug-images")]
+    #[doc(inline)]
     pub use sentry_debug_images as debug_images;
     #[cfg(feature = "error-chain")]
+    #[doc(inline)]
     pub use sentry_error_chain as error_chain;
     #[cfg(feature = "failure")]
+    #[doc(inline)]
     pub use sentry_failure as failure;
     #[cfg(feature = "log")]
+    #[doc(inline)]
     pub use sentry_log as log;
     #[cfg(feature = "panic")]
+    #[doc(inline)]
     pub use sentry_panic as panic;
+    #[cfg(feature = "slog")]
+    #[doc(inline)]
+    pub use sentry_slog as slog;
 }
 
 /// Useful internals.

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -107,6 +107,26 @@ mod transport;
 #[doc(inline)]
 pub use sentry_core::*;
 
+/// Available Sentry Integrations.
+pub mod integrations {
+    #[cfg(feature = "anyhow")]
+    pub use sentry_anyhow as anyhow;
+    #[cfg(feature = "backtrace")]
+    pub use sentry_backtrace as backtrace;
+    #[cfg(feature = "contexts")]
+    pub use sentry_contexts as contexts;
+    #[cfg(feature = "debug-images")]
+    pub use sentry_debug_images as debug_images;
+    #[cfg(feature = "error-chain")]
+    pub use sentry_error_chain as error_chain;
+    #[cfg(feature = "failure")]
+    pub use sentry_failure as failure;
+    #[cfg(feature = "log")]
+    pub use sentry_log as log;
+    #[cfg(feature = "panic")]
+    pub use sentry_panic as panic;
+}
+
 /// Useful internals.
 ///
 /// This module contains types that users of the crate typically do not

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -144,14 +144,16 @@ pub mod internals {
 /// library.  The `with_reqwest_transport` and `with_curl_transport` flags
 /// turn on these transports.
 pub mod transports {
-    #[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
-    pub use crate::transport::{DefaultTransportFactory, HttpTransport};
+    pub use crate::transport::DefaultTransportFactory;
 
     #[cfg(feature = "with_reqwest_transport")]
     pub use crate::transport::ReqwestHttpTransport;
 
     #[cfg(feature = "with_curl_transport")]
     pub use crate::transport::CurlHttpTransport;
+
+    #[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+    pub use crate::transport::HttpTransport;
 }
 
 pub use crate::init::init;

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -78,7 +78,6 @@
 //!
 //! Default features:
 //!
-//! * `with_client_implementation`: Turns on the real client implementation.
 //! * `with_default_transport`: Compiles in the default HTTP transport (see below).
 //! * `with_backtrace`: Enables backtrace support (automatically turned on in a few cases).
 //! * `with_panic`: Enables the panic integration.
@@ -101,11 +100,8 @@
 //! * `with_test_support`: Enables the test support module.
 #![warn(missing_docs)]
 
-#[cfg(feature = "with_client_implementation")]
 mod defaults;
-#[cfg(feature = "with_client_implementation")]
 mod init;
-#[cfg(feature = "with_client_implementation")]
 mod transport;
 
 #[doc(inline)]
@@ -117,13 +113,9 @@ pub use sentry_core::*;
 /// have to interface with directly.  These are often returned
 /// from methods on other types.
 pub mod internals {
-    pub use sentry_core::internals::*;
-
-    #[cfg(feature = "with_client_implementation")]
-    pub use crate::init::ClientInitGuard;
-
-    #[cfg(feature = "with_client_implementation")]
     pub use crate::defaults::apply_defaults;
+    pub use crate::init::ClientInitGuard;
+    pub use sentry_core::internals::*;
 }
 
 /// The provided transports.
@@ -142,5 +134,4 @@ pub mod transports {
     pub use crate::transport::CurlHttpTransport;
 }
 
-#[cfg(feature = "with_client_implementation")]
 pub use crate::init::init;

--- a/sentry/src/transport.rs
+++ b/sentry/src/transport.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::{Arc, Condvar, Mutex};
@@ -36,6 +38,7 @@ impl TransportFactory for DefaultTransportFactory {
         }
         #[cfg(not(any(feature = "with_reqwest_transport", feature = "with_curl_transport")))]
         {
+            let _ = options;
             panic!("sentry crate was compiled without transport")
         }
     }
@@ -52,6 +55,7 @@ fn parse_retry_after(s: &str) -> Option<SystemTime> {
     }
 }
 
+#[allow(unused)]
 macro_rules! implement_http_transport {
     (
         $(#[$attr:meta])*

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "with_test_support")]
+#![cfg(feature = "test")]
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/sentry/tests/test_client.rs
+++ b/sentry/tests/test_client.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "with_test_support")]
+#![cfg(feature = "test")]
 
 use std::panic;
 use std::sync::Arc;

--- a/sentry/tests/test_log.rs
+++ b/sentry/tests/test_log.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "test")]
 
+use log_ as log;
+
 #[test]
 fn test_log() {
     let log_integration = sentry_log::LogIntegration::default();

--- a/sentry/tests/test_log.rs
+++ b/sentry/tests/test_log.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "with_test_support")]
+#![cfg(feature = "test")]
 
 #[test]
 fn test_log() {

--- a/sentry/tests/test_processors.rs
+++ b/sentry/tests/test_processors.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "with_test_support")]
+#![cfg(feature = "test")]
 
 use std::sync::Arc;
 


### PR DESCRIPTION
Cleans up the feature flags of `sentry-core`, but tries to keep the existing feature flags of `sentry`, for backwards compatibility. Not quite sure if we want to do that, or rather just remove the non-default features, and rename the others.