### PR TITLE
ref: Restructure and document the public core API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ members = [
     "sentry-slog",
     "sentry-types",
 ]
-
-[profile.dev.build-override]
-opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ members = [
     "sentry-slog",
     "sentry-types",
 ]
+
+[profile.dev.build-override]
+opt-level = 0

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -70,9 +70,9 @@ use std::sync::{Arc, Mutex};
 use actix_web::middleware::{Finished, Middleware, Response, Started};
 use actix_web::{Error, HttpMessage, HttpRequest, HttpResponse};
 use failure::Fail;
-use sentry::internals::{ScopeGuard, Uuid};
 use sentry::protocol::{ClientSdkPackage, Event, Level};
-use sentry::Hub;
+use sentry::types::Uuid;
+use sentry::{Hub, ScopeGuard};
 use sentry_failure::exception_from_single_fail;
 
 /// A helper construct that can be used to reconfigure and build the middleware.

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -22,7 +22,7 @@
 use std::error::Error;
 use std::fmt;
 
-use sentry_core::internals::Uuid;
+use sentry_core::types::Uuid;
 use sentry_core::Hub;
 
 /// Captures an `anyhow::Error`.

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -31,6 +31,10 @@ rand = { version = "0.7.3", optional = true }
 log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
 
 [dev-dependencies]
+# Because we re-export all the public API in `sentry`, we actually run all the
+# doctests using the `sentry` crate. This also takes care of the doctest
+# limitation documented in https://github.com/rust-lang/rust/issues/45599.
+sentry = { version = "0.18.0", path = "../sentry", default-features = false, features = ["test"] }
 thiserror = "1.0.15"
 anyhow = "1.0.30"
 failure = "0.1.8"

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -21,7 +21,7 @@ client = ["im", "rand"]
 # I would love to just have a `log` feature, but this is used inside a macro,
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["log_"]
-test = []
+test = ["client"]
 
 [dependencies]
 sentry-types = { version = "0.15.0", path = "../sentry-types" }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -43,6 +43,19 @@ pub fn capture_event(event: Event<'static>) -> Uuid {
 ///
 /// This creates an event from the given message and sends it via
 /// [`capture_event`](fn.capture_event.html).
+///
+/// # Examples
+///
+/// ```
+/// use sentry::protocol::Level;
+///
+/// # let events = sentry::test::with_captured_events(|| {
+/// sentry::capture_message("some message", Level::Info);
+/// # });
+/// # let captured_event = events.into_iter().next().unwrap();
+///
+/// assert_eq!(captured_event.message.as_deref(), Some("some message"));
+/// ```
 pub fn capture_message(msg: &str, level: Level) -> Uuid {
     Hub::with_active(|hub| hub.capture_message(msg, level))
 }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -1,8 +1,6 @@
-use crate::breadcrumbs::IntoBreadcrumbs;
-use crate::hub::Hub;
-use crate::internals;
 use crate::protocol::{Event, Level};
-use crate::scope::Scope;
+use crate::types::Uuid;
+use crate::{Hub, IntoBreadcrumbs, Scope};
 
 /// Captures an event on the currently active client if any.
 ///
@@ -23,14 +21,14 @@ use crate::scope::Scope;
 ///     ..Default::default()
 /// });
 /// ```
-pub fn capture_event(event: Event<'static>) -> internals::Uuid {
+pub fn capture_event(event: Event<'static>) -> Uuid {
     Hub::with_active(|hub| hub.capture_event(event))
 }
 
 /// Captures an arbitrary message.
 ///
 /// This creates an event from the given message and sends it to the current hub.
-pub fn capture_message(msg: &str, level: Level) -> internals::Uuid {
+pub fn capture_message(msg: &str, level: Level) -> Uuid {
     Hub::with_active(|hub| hub.capture_message(msg, level))
 }
 
@@ -149,7 +147,7 @@ where
 /// Returns the last event ID captured.
 ///
 /// This uses the current thread local hub.
-pub fn last_event_id() -> Option<internals::Uuid> {
+pub fn last_event_id() -> Option<Uuid> {
     with_client_impl! {{
         Hub::with(|hub| hub.last_event_id())
     }}

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -14,8 +14,8 @@ use crate::{Hub, IntoBreadcrumbs, Scope};
 /// # Examples
 ///
 /// ```
-/// use sentry::types::Uuid;
 /// use sentry::protocol::{Event, Level};
+/// use sentry::types::Uuid;
 ///
 /// let uuid = Uuid::new_v4();
 /// let event = Event {
@@ -28,7 +28,7 @@ use crate::{Hub, IntoBreadcrumbs, Scope};
 /// assert_eq!(sentry::capture_event(event.clone()), Uuid::nil());
 ///
 /// let events = sentry::test::with_captured_events(|| {
-/// assert_eq!(sentry::capture_event(event), uuid);
+///     assert_eq!(sentry::capture_event(event), uuid);
 /// });
 /// assert_eq!(events.len(), 1);
 /// ```
@@ -66,7 +66,7 @@ pub fn capture_message(msg: &str, level: Level) -> Uuid {
 /// # Examples
 ///
 /// ```
-/// use sentry::protocol::{Breadcrumb, Map, Level};
+/// use sentry::protocol::{Breadcrumb, Level, Map};
 ///
 /// let breadcrumb = Breadcrumb {
 ///     ty: "http".into(),
@@ -106,12 +106,12 @@ pub fn add_breadcrumb<B: IntoBreadcrumbs>(breadcrumb: B) {
 /// # Examples
 ///
 /// ```
-/// use sentry::protocol::{User, Level};
+/// use sentry::protocol::{Level, User};
 ///
 /// let user = Some(User {
-///         username: Some("john_doe".into()),
-///         ..Default::default()
-///     });
+///     username: Some("john_doe".into()),
+///     ..Default::default()
+/// });
 ///
 /// # let events = sentry::test::with_captured_events(|| {
 /// sentry::configure_scope(|scope| {
@@ -153,7 +153,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use sentry::protocol::{Level};
+/// use sentry::protocol::Level;
 ///
 /// # let events = sentry::test::with_captured_events(|| {
 /// sentry::with_scope(
@@ -195,8 +195,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use sentry::types::Uuid;
 /// use sentry::protocol::Level;
+/// use sentry::types::Uuid;
 ///
 /// # sentry::test::with_captured_events(|| {
 /// assert_eq!(sentry::last_event_id(), None);

--- a/sentry-core/src/breadcrumbs.rs
+++ b/sentry-core/src/breadcrumbs.rs
@@ -1,5 +1,9 @@
 use crate::protocol::Breadcrumb;
-/// A helper trait that converts self into an Iterator of Breadcrumbs
+/// A helper trait that converts self into an Iterator of Breadcrumbs.
+///
+/// This is used for the [`add_breadcrumb`] function.
+///
+/// [`add_breadcrumb`]: fn.add_breadcrumb.html
 pub trait IntoBreadcrumbs {
     /// The iterator type for the breadcrumbs.
     type Output: Iterator<Item = Breadcrumb>;

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -19,7 +19,22 @@ impl<T: Into<ClientOptions>> From<T> for Client {
     }
 }
 
-/// The Sentry client object.
+/// The Sentry Client.
+///
+/// The Client is responsible for event processing and sending events to the
+/// sentry server via the configured [`Transport`].
+/// See the [Unified API] document for more details.
+///
+/// A Client can be created from a [`ClientOptions`].
+///
+/// # Examples
+///
+/// ```
+/// sentry::Client::from(sentry::ClientOptions::default());
+/// ```
+///
+/// [`Transport`]: trait.Transport.html
+/// [Unified API]: https://develop.sentry.dev/sdk/unified-api/
 pub struct Client {
     options: ClientOptions,
     transport: RwLock<Option<Arc<dyn Transport>>>,
@@ -187,6 +202,24 @@ impl Client {
     }
 
     /// Quick check to see if the client is enabled.
+    ///
+    /// The Client is enabled if it has a valid DSN and Transport configured.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    ///
+    /// let client = sentry::Client::from(sentry::ClientOptions::default());
+    /// assert!(!client.is_enabled());
+    ///
+    /// let dsn = "https://public@example.com/1";
+    /// let transport = sentry::test::TestTransport::new();
+    /// let client = sentry::Client::from((dsn, sentry::ClientOptions {
+    /// transport: Some(Arc::new(transport)),
+    /// ..Default::default()}));
+    /// assert!(client.is_enabled());
+    /// ```
     pub fn is_enabled(&self) -> bool {
         self.options.dsn.is_some() && self.transport.read().unwrap().is_some()
     }

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -8,13 +8,10 @@ use std::time::Duration;
 
 use rand::random;
 
-pub use crate::clientoptions::ClientOptions;
 use crate::constants::SDK_INFO;
-use crate::internals::{Dsn, Uuid};
 use crate::protocol::{ClientSdkInfo, Event};
-use crate::scope::Scope;
-use crate::transport::Transport;
-use crate::Integration;
+use crate::types::{Dsn, Uuid};
+use crate::{ClientOptions, Integration, Scope, Transport};
 
 impl<T: Into<ClientOptions>> From<T> for Client {
     fn from(o: T) -> Client {

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -215,9 +215,13 @@ impl Client {
     ///
     /// let dsn = "https://public@example.com/1";
     /// let transport = sentry::test::TestTransport::new();
-    /// let client = sentry::Client::from((dsn, sentry::ClientOptions {
-    /// transport: Some(Arc::new(transport)),
-    /// ..Default::default()}));
+    /// let client = sentry::Client::from((
+    ///     dsn,
+    ///     sentry::ClientOptions {
+    ///         transport: Some(Arc::new(transport)),
+    ///         ..Default::default()
+    ///     },
+    /// ));
     /// assert!(client.is_enabled());
     /// ```
     pub fn is_enabled(&self) -> bool {

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -22,10 +22,10 @@ impl<T: Into<ClientOptions>> From<T> for Client {
 /// The Sentry Client.
 ///
 /// The Client is responsible for event processing and sending events to the
-/// sentry server via the configured [`Transport`].
-/// See the [Unified API] document for more details.
+/// sentry server via the configured [`Transport`]. It can be created from a
+/// [`ClientOptions`].
 ///
-/// A Client can be created from a [`ClientOptions`].
+/// See the [Unified API] document for more details.
 ///
 /// # Examples
 ///
@@ -33,6 +33,7 @@ impl<T: Into<ClientOptions>> From<T> for Client {
 /// sentry::Client::from(sentry::ClientOptions::default());
 /// ```
 ///
+/// [`ClientOptions`]: struct.ClientOptions.html
 /// [`Transport`]: trait.Transport.html
 /// [Unified API]: https://develop.sentry.dev/sdk/unified-api/
 pub struct Client {

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -20,8 +20,8 @@ pub type BeforeCallback<T> = Arc<dyn Fn(T) -> Option<T> + Send + Sync>;
 ///
 /// ```
 /// let _options = sentry::ClientOptions {
-/// debug: true,
-/// ..Default::default()
+///     debug: true,
+///     ..Default::default()
 /// };
 /// ```
 #[derive(Clone)]

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -4,11 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::constants::USER_AGENT;
-use crate::internals::Dsn;
-use crate::intodsn::IntoDsn;
 use crate::protocol::{Breadcrumb, Event};
-use crate::transport::TransportFactory;
-use crate::Integration;
+use crate::types::Dsn;
+use crate::{Integration, IntoDsn, TransportFactory};
 
 /// Type alias for before event/breadcrumb handlers.
 pub type BeforeCallback<T> = Arc<dyn Fn(T) -> Option<T> + Send + Sync>;

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -15,6 +15,15 @@ pub type BeforeCallback<T> = Arc<dyn Fn(T) -> Option<T> + Send + Sync>;
 ///
 /// These options are explained in more detail in the general
 /// [sentry documentation](https://docs.sentry.io/error-reporting/configuration/?platform=rust).
+///
+/// # Examples
+///
+/// ```
+/// let _options = sentry::ClientOptions {
+/// debug: true,
+/// ..Default::default()
+/// };
+/// ```
 #[derive(Clone)]
 pub struct ClientOptions {
     // Common options
@@ -83,7 +92,22 @@ pub struct ClientOptions {
 }
 
 impl ClientOptions {
+    /// Creates new Options.
+    pub fn new() -> Self {
+        Self::default()
+    }
     /// Adds a configured integration to the options.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// struct MyIntegration;
+    ///
+    /// impl sentry::Integration for MyIntegration {}
+    ///
+    /// let options = sentry::ClientOptions::new().add_integration(MyIntegration);
+    /// assert_eq!(options.integrations.len(), 1);
+    /// ```
     pub fn add_integration<I: Integration>(mut self, integration: I) -> Self {
         self.integrations.push(Arc::new(integration));
         self

--- a/sentry-core/src/error.rs
+++ b/sentry-core/src/error.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 
-use sentry_types::Uuid;
-
 use crate::protocol::{Event, Exception, Level};
+use crate::types::Uuid;
 use crate::Hub;
 
 impl Hub {
     /// Capture any `std::error::Error`.
-    pub fn capture_error<E: Error + ?Sized>(&self, error: &E) -> sentry_types::Uuid {
+    #[allow(unused)]
+    pub fn capture_error<E: Error + ?Sized>(&self, error: &E) -> Uuid {
         with_client_impl! {{
             self.inner.with(|stack| {
                 let top = stack.top();
@@ -34,7 +34,7 @@ impl Hub {
 /// sentry::capture_error(&std::io::Error::last_os_error());
 /// ```
 #[allow(unused_variables)]
-pub fn capture_error<E: Error + ?Sized>(error: &E) -> sentry_types::Uuid {
+pub fn capture_error<E: Error + ?Sized>(error: &E) -> Uuid {
     Hub::with_active(|hub| hub.capture_error(error))
 }
 

--- a/sentry-core/src/error.rs
+++ b/sentry-core/src/error.rs
@@ -29,9 +29,17 @@ impl Hub {
 /// described on https://develop.sentry.dev/sdk/event-payloads/exception/.
 ///
 /// # Examples
+///
 /// ```
-/// # use sentry_core as sentry;
-/// sentry::capture_error(&std::io::Error::last_os_error());
+/// let err = "NaN".parse::<usize>().unwrap_err();
+///
+/// # let events = sentry::test::with_captured_events(|| {
+/// sentry::capture_error(&err);
+/// # });
+/// # let captured_event = events.into_iter().next().unwrap();
+///
+/// assert_eq!(captured_event.exception.len(), 1);
+/// assert_eq!(&captured_event.exception[0].ty, "ParseIntError");
 /// ```
 #[allow(unused_variables)]
 pub fn capture_error<E: Error + ?Sized>(error: &E) -> Uuid {
@@ -56,8 +64,8 @@ pub fn capture_error<E: Error + ?Sized>(error: &E) -> Uuid {
 /// #[error("outer")]
 /// struct OuterError(#[from] InnerError);
 ///
-/// let event = sentry_core::event_from_error(&OuterError(InnerError));
-/// assert_eq!(event.level, sentry_core::protocol::Level::Error);
+/// let event = sentry::event_from_error(&OuterError(InnerError));
+/// assert_eq!(event.level, sentry::protocol::Level::Error);
 /// assert_eq!(event.exception.len(), 2);
 /// assert_eq!(&event.exception[0].ty, "InnerError");
 /// assert_eq!(event.exception[0].value, Some("inner".into()));
@@ -95,7 +103,7 @@ fn exception_from_error<E: Error + ?Sized>(err: &E) -> Exception {
 /// # Examples
 ///
 /// ```
-/// use sentry_core::parse_type_from_debug;
+/// use sentry::parse_type_from_debug;
 ///
 /// let err = format!("{:?}", "NaN".parse::<usize>().unwrap_err());
 /// assert_eq!(parse_type_from_debug(&err), "ParseIntError");

--- a/sentry-core/src/error.rs
+++ b/sentry-core/src/error.rs
@@ -6,6 +6,9 @@ use crate::Hub;
 
 impl Hub {
     /// Capture any `std::error::Error`.
+    ///
+    /// See the global [`capture_error`](fn.capture_error.html)
+    /// for more documentation.
     #[allow(unused)]
     pub fn capture_error<E: Error + ?Sized>(&self, error: &E) -> Uuid {
         with_client_impl! {{
@@ -26,7 +29,7 @@ impl Hub {
 ///
 /// Creates an event from the given error and sends it to the current hub.
 /// A chain of errors will be resolved as well, and sorted oldest to newest, as
-/// described on https://develop.sentry.dev/sdk/event-payloads/exception/.
+/// described in the [sentry event payloads].
 ///
 /// # Examples
 ///
@@ -41,6 +44,8 @@ impl Hub {
 /// assert_eq!(captured_event.exception.len(), 1);
 /// assert_eq!(&captured_event.exception[0].ty, "ParseIntError");
 /// ```
+///
+/// [sentry event payloads]: https://develop.sentry.dev/sdk/event-payloads/exception/
 #[allow(unused_variables)]
 pub fn capture_error<E: Error + ?Sized>(error: &E) -> Uuid {
     Hub::with_active(|hub| hub.capture_error(error))
@@ -49,7 +54,7 @@ pub fn capture_error<E: Error + ?Sized>(error: &E) -> Uuid {
 /// Create a sentry `Event` from a `std::error::Error`.
 ///
 /// A chain of errors will be resolved as well, and sorted oldest to newest, as
-/// described on https://develop.sentry.dev/sdk/event-payloads/exception/.
+/// described in the [sentry event payloads].
 ///
 /// # Examples
 ///
@@ -72,6 +77,8 @@ pub fn capture_error<E: Error + ?Sized>(error: &E) -> Uuid {
 /// assert_eq!(&event.exception[1].ty, "OuterError");
 /// assert_eq!(event.exception[1].value, Some("outer".into()));
 /// ```
+///
+/// [sentry event payloads]: https://develop.sentry.dev/sdk/event-payloads/exception/
 pub fn event_from_error<E: Error + ?Sized>(err: &E) -> Event<'static> {
     let mut exceptions = vec![exception_from_error(err)];
 

--- a/sentry-core/src/futures.rs
+++ b/sentry-core/src/futures.rs
@@ -32,7 +32,15 @@ where
         let hub = self.hub.clone();
         // https://doc.rust-lang.org/std/pin/index.html#pinning-is-structural-for-field
         let future = unsafe { self.map_unchecked_mut(|s| &mut s.future) };
-        Hub::run(hub, || future.poll(cx))
+        #[cfg(feature = "client")]
+        {
+            Hub::run(hub, || future.poll(cx))
+        }
+        #[cfg(not(feature = "client"))]
+        {
+            let _ = hub;
+            future.poll(cx)
+        }
     }
 }
 
@@ -54,7 +62,7 @@ pub trait FutureExt: Sized {
 
 impl<F> FutureExt for F where F: Future {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test"))]
 mod tests {
     use crate::test::with_captured_events;
     use crate::{capture_message, configure_scope, FutureExt, Hub, Level};

--- a/sentry-core/src/futures.rs
+++ b/sentry-core/src/futures.rs
@@ -8,7 +8,10 @@ use crate::Hub;
 /// A future that binds a `Hub` to its execution.
 ///
 /// This activates the given hub for the duration of the inner futures `poll`
-/// method.
+/// method. Users usually do not need to construct this type manually, but
+/// rather use the [`FutureExt::bind_hub`] method instead.
+///
+/// [`FutureExt::bind_hub`]: trait.FutureExt.html#method.bind_hub
 #[derive(Debug)]
 pub struct SentryFuture<F> {
     hub: Arc<Hub>,

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -236,8 +236,9 @@ impl Hub {
     /// struct MyIntegration(usize);
     /// impl Integration for MyIntegration {}
     ///
-    /// let client = Arc::new(Client::from(ClientOptions::default()
-    ///     .add_integration(MyIntegration(10))));
+    /// let client = Arc::new(Client::from(
+    ///     ClientOptions::default().add_integration(MyIntegration(10)),
+    /// ));
     /// let hub = Hub::with(|hub| Hub::new_from_top(hub));
     /// hub.bind_client(Some(client));
     ///

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -67,7 +67,7 @@ impl HubImpl {
 ///
 /// In most situations developers do not need to interface with the hub directly.  Instead
 /// toplevel convenience functions are expose that will automatically dispatch
-/// to the thread-local (`Hub::current`) hub.  In some situations this might not be
+/// to the thread-local (`Hub::current()`) hub.  In some situations this might not be
 /// possible in which case it might become necessary to manually work with the
 /// hub.  This is for instance the case when working with async code.
 ///
@@ -269,6 +269,9 @@ impl Hub {
     /// Sends the event to the current client with the current scope.
     ///
     /// In case no client is bound this does nothing instead.
+    ///
+    /// See the global [`capture_event`](fn.capture_event.html)
+    /// for more documentation.
     pub fn capture_event(&self, event: Event<'static>) -> Uuid {
         with_client_impl! {{
             self.inner.with(|stack| {
@@ -285,6 +288,9 @@ impl Hub {
     }
 
     /// Captures an arbitrary message.
+    ///
+    /// See the global [`capture_message`](fn.capture_message.html)
+    /// for more documentation.
     pub fn capture_message(&self, msg: &str, level: Level) -> Uuid {
         with_client_impl! {{
             self.inner.with(|stack| {
@@ -331,7 +337,8 @@ impl Hub {
 
     /// Temporarily pushes a scope for a single call optionally reconfiguring it.
     ///
-    /// This works the same as the global `with_scope` function.
+    /// See the global [`with_scope`](fn.with_scope.html)
+    /// for more documentation.
     pub fn with_scope<C, F, R>(&self, scope_config: C, callback: F) -> R
     where
         C: FnOnce(&mut Scope),
@@ -352,7 +359,8 @@ impl Hub {
 
     /// Invokes a function that can modify the current scope.
     ///
-    /// This works the same as the global `configure_scope` function.
+    /// See the global [`configure_scope`](fn.configure_scope.html)
+    /// for more documentation.
     pub fn configure_scope<F, R>(&self, f: F) -> R
     where
         R: Default,
@@ -371,8 +379,8 @@ impl Hub {
 
     /// Adds a new breadcrumb to the current scope.
     ///
-    /// This is equivalent to the global [`sentry::add_breadcrumb`](fn.add_breadcrumb.html) but
-    /// sends the breadcrumb into the hub instead.
+    /// See the global [`add_breadcrumb`](fn.add_breadcrumb.html)
+    /// for more documentation.
     pub fn add_breadcrumb<B: IntoBreadcrumbs>(&self, breadcrumb: B) {
         with_client_impl! {{
             self.inner.with_mut(|stack| {

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -61,11 +61,13 @@ impl HubImpl {
 ///
 /// This can be used to capture events and manage the scope.  This object is
 /// internally synchronized so it can be used from multiple threads if needed.
-/// The default hub that is available automatically is thread local.
 ///
-/// In most situations developers do not need to interface the hub.  Instead
-/// toplevel convenience functions are expose tht will automatically dispatch
-/// to global (`Hub::current`) hub.  In some situations this might not be
+/// Each thread has its own thread-local (`Hub::current()`) hub, which is
+/// automatically derived from the main hub (`Hub::main()`).
+///
+/// In most situations developers do not need to interface with the hub directly.  Instead
+/// toplevel convenience functions are expose that will automatically dispatch
+/// to the thread-local (`Hub::current`) hub.  In some situations this might not be
 /// possible in which case it might become necessary to manually work with the
 /// hub.  This is for instance the case when working with async code.
 ///

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -8,14 +8,11 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock, TryLockError};
 use std::thread;
 use std::time::Duration;
 
-use crate::breadcrumbs::IntoBreadcrumbs;
-use crate::error::event_from_error;
-use crate::internals::Uuid;
 use crate::protocol::{Breadcrumb, Event, Level};
-use crate::scope::{Scope, ScopeGuard};
-use crate::Integration;
+use crate::types::Uuid;
+use crate::{event_from_error, Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 #[cfg(feature = "client")]
-use crate::{client::Client, scope::Stack};
+use crate::{scope::Stack, Client};
 
 #[cfg(feature = "client")]
 lazy_static::lazy_static! {

--- a/sentry-core/src/integration.rs
+++ b/sentry-core/src/integration.rs
@@ -13,42 +13,44 @@ use crate::ClientOptions;
 /// # Examples
 ///
 /// ```
+/// use sentry::protocol::{Event, Level};
 /// use sentry::ClientOptions;
-/// use sentry::protocol::{Event,Level};
 ///
 /// struct MyProcessorIntegration {
-/// override_environment: &'static str,
-/// override_level: Level,
+///     override_environment: &'static str,
+///     override_level: Level,
 /// }
 ///
 /// impl sentry::Integration for MyProcessorIntegration {
-/// fn setup(&self, options: &mut ClientOptions) {
-/// options.environment = Some(self.override_environment.into());
-/// }
-/// fn process_event(
-/// &self,
-/// mut event: Event<'static>,
-/// _options: &ClientOptions,
-/// ) -> Option<Event<'static>> {
-/// event.level = self.override_level;
-/// Some(event)
-/// }
+///     fn setup(&self, options: &mut ClientOptions) {
+///         options.environment = Some(self.override_environment.into());
+///     }
+///     fn process_event(
+///         &self,
+///         mut event: Event<'static>,
+///         _options: &ClientOptions,
+///     ) -> Option<Event<'static>> {
+///         event.level = self.override_level;
+///         Some(event)
+///     }
 /// }
 ///
 /// let options = ClientOptions::new().add_integration(MyProcessorIntegration {
-/// override_environment: "my_env",
-/// override_level: Level::Error,
+///     override_environment: "my_env",
+///     override_level: Level::Error,
 /// });
 ///
-/// let events = sentry::test::with_captured_events_options(||{
-/// sentry::capture_message("some message", Level::Info);
-/// }, options);
+/// let events = sentry::test::with_captured_events_options(
+///     || {
+///         sentry::capture_message("some message", Level::Info);
+///     },
+///     options,
+/// );
 /// let captured_event = events.into_iter().next().unwrap();
 ///
 /// assert_eq!(captured_event.level, Level::Error);
 /// assert_eq!(captured_event.environment, Some("my_env".into()));
 /// ```
-///
 // NOTE: we need `Any` here so that the `TypeId` machinery works correctly.
 pub trait Integration: Sync + Send + Any + AsAny {
     /// Name of this integration.

--- a/sentry-core/src/intodsn.rs
+++ b/sentry-core/src/intodsn.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 
-use sentry_types::{Dsn, ParseDsnError};
+use crate::types::{Dsn, ParseDsnError};
 
 /// Helper trait to convert a string into an `Option<Dsn>`.
 ///

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -88,13 +88,12 @@
 
 #![warn(missing_docs)]
 
+// macros; these need to be first to be used by other modules
 #[macro_use]
 mod macros;
 
 mod api;
 mod breadcrumbs;
-#[cfg(feature = "client")]
-mod client;
 mod clientoptions;
 mod constants;
 mod error;
@@ -105,38 +104,29 @@ mod intodsn;
 mod scope;
 mod transport;
 
-#[cfg(any(test, feature = "test"))]
-pub mod test;
-
-/// Useful internals.
-///
-/// This module contains types that users of the crate typically do not
-/// have to interface with directly.  These are often returned
-/// from methods on other types.
-pub mod internals {
-    pub use crate::breadcrumbs::IntoBreadcrumbs;
-    pub use crate::scope::ScopeGuard;
-
-    pub use crate::intodsn::IntoDsn;
-    pub use crate::transport::{Transport, TransportFactory};
-
-    pub use sentry_types::{
-        Auth, ChronoParseError, DateTime, DebugId, Dsn, ParseDebugIdError, ParseDsnError,
-        ParseProjectIdError, ProjectId, Scheme, TimeZone, Utc, Uuid, UuidVariant, UuidVersion,
-    };
-}
-
 // public api or exports from this crate
 pub use crate::api::*;
-#[cfg(feature = "client")]
-pub use crate::client::Client;
+pub use crate::breadcrumbs::IntoBreadcrumbs;
 pub use crate::clientoptions::ClientOptions;
 pub use crate::error::{capture_error, event_from_error, parse_type_from_debug};
 pub use crate::futures::{FutureExt, SentryFuture as Future};
 pub use crate::hub::Hub;
 pub use crate::integration::Integration;
-pub use crate::scope::Scope;
+pub use crate::intodsn::IntoDsn;
+pub use crate::scope::{Scope, ScopeGuard};
+pub use crate::transport::{Transport, TransportFactory};
+
+// client feature
+#[cfg(feature = "client")]
+mod client;
+#[cfg(feature = "client")]
+pub use crate::client::Client;
+
+// test utilities
+#[cfg(feature = "test")]
+pub mod test;
 
 // public api from other crates
+pub use sentry_types as types;
 pub use sentry_types::protocol::v7 as protocol;
 pub use sentry_types::protocol::v7::{Breadcrumb, Level, User};

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -92,6 +92,7 @@ pub use crate::client::Client;
 pub mod test;
 
 // public api from other crates
+#[doc(inline)]
 pub use sentry_types as types;
 pub use sentry_types::protocol::v7 as protocol;
 pub use sentry_types::protocol::v7::{Breadcrumb, Level, User};

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -17,10 +17,9 @@
 //! # Core Concepts
 //!
 //! This crate follows the [Unified API] guidelines and is centered around
-//! the concepts of [`Client`], [`Hub`] and [`Scope`]. See the corresponding
-//! type for more documentation, as well as the [Unified API] specification.
-//! See the [`Integration`] trait for documentation on how to write
-//! integrations, and the [`Transport`] trait on how to write transports.
+//! the concepts of [`Client`], [`Hub`] and [`Scope`], as well as the extension
+//! points via the [`Integration`], [`Transport`] and [`TransportFactory`] traits.
+//!
 //!
 //! # Minimal API
 //!
@@ -50,6 +49,7 @@
 //! [`Scope`]: struct.Scope.html
 //! [`Integration`]: trait.Integration.html
 //! [`Transport`]: trait.Transport.html
+//! [`TransportFactory`]: trait.TransportFactory.html
 
 #![warn(missing_docs)]
 

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -4,87 +4,52 @@
 //!     style="width: 260px"></a>
 //! </p>
 //!
-//! This crate provides support for logging events and errors / panics to the
-//! [Sentry](https://sentry.io/) error logging service.  It integrates with the standard panic
-//! system in Rust as well as a few popular error handling setups.
+//! This crate provides the core of the [Sentry](https://sentry.io/) SDK, which
+//! can be used to log events and errors.
 //!
-//! # Quickstart
+//! This crate is meant for integration authors and third party library authors
+//! that want to instrument their code for sentry.
 //!
-//! To use the crate you need to create a client first.  When a client is created it's typically
-//! bound to the current thread by calling `bind_client`.  By default this happens by using the
-//! `sentry::init` convenience function.  When the client is bound to the main thread it also
-//! becomes the default client for future threads created but it is always possible to override the
-//! client for a thread later by explicitly binding it.
+//! Regular users who wish to integrate sentry into their applications should
+//! rather use the [`sentry`] crate, which comes with a default transport, and
+//! a large set of integrations for various third-party libraries.
 //!
-//! The `sentry::init` function returns a guard that when dropped will flush Events that were not
-//! yet sent to the sentry service.  It has a two second deadline for this so shutdown of
-//! applications might slightly delay as a result of this.  Keep the guard around or sending events
-//! will not work.
+//! # Core Concepts
 //!
-//! ```ignore
-//! # use sentry_core as sentry;
-//! let _guard = sentry::init("https://key@sentry.io/42");
-//! sentry::capture_message("Hello World!", sentry::Level::Info);
-//! // when the guard goes out of scope here, the client will wait up to two
-//! // seconds to send remaining events to the service.
-//! ```
-//!
-//! # Integrations
-//!
-//! What makes this crate useful are the various integrations that exist.  Some of them are enabled
-//! by default, some uncommon ones or for deprecated parts of the ecosystem a feature flag needs to
-//! be enabled.  For the available integrations and how to use them see
-//! [integrations](integrations/index.html).
-//!
-//! # Scopes, Threads and Hubs
-//!
-//! Data is typically bound to a [`Scope`](struct.Scope.html).  Scopes are stored in a hidden stack
-//! on a [`Hub`](struct.Hub.html).  Once the library has been initialized a hub is automatically
-//! available.  In the default config a new hub is created for each thread and they act
-//! independently.
-//!
-//! The thread that calls `sentry::init` initializes the first hub which then automatically becomes
-//! the base of new hubs (You can get that hub by calling `Hub::main()`).  If a new thread is
-//! spawned it gets a new hub based on that one (the thread calls `Hub::new_from_top(Hub::main())`).
-//! The current thread's hub is returned from `Hub::current()`.  Any hub that is wrapped in an `Arc`
-//! can be temporarily bound to a thread with `Hub::run`.  For more information see
-//! [`Hub`](struct.Hub.html).
-//!
-//! Users are expected to reconfigure the scope with [`configure_scope`](fn.configure_scope.html).
-//! For more elaborate scope management the hub needs to be interfaced with directly.
-//!
-//! In some situations (particularly in async code) it's often not possible to use the thread local
-//! hub.  In that case a hub can be explicitly created and passed around.  However due to the nature
-//! of some integrations some functionality like automatic breadcrumb recording depends on the
-//! thread local hub being correctly configured.
+//! This crate follows the [Unified API] guidelines and is centered around
+//! the concepts of [`Client`], [`Hub`] and [`Scope`]. See the corresponding
+//! type for more documentation, as well as the [Unified API] specification.
+//! See the [`Integration`] trait for documentation on how to write
+//! integrations, and the [`Transport`] trait on how to write transports.
 //!
 //! # Minimal API
 //!
-//! This crate can also be used in "minimal" mode.  This is enabled by disabling all default
-//! features of the crate.  In that mode a minimal API set is retained that can be used to
-//! instrument code for Sentry without actually using Sentry.  The minimal API is a small set of
-//! APIs that dispatch to the underlying implementations on the configured Sentry client.  If the
-//! client is not there the minimal API will blackhole a lot of operations.
+//! By default, this crate comes with a so-called "minimal" mode. This mode will
+//! provide all the APIs needed to instrument code with sentry, and to write
+//! sentry integrations, but it will blackhole a lot of operations.
 //!
-//! Only if a user then also uses and configures Sentry this code becomes used.
-//!
-//! In minimal mode some types are restricted in functionality.  For instance the `Client` is not
-//! available and the `Hub` does not retain all API functionality. To see what the APIs in mnimal
-//! mode look like you can build the docs for this crate without any features enabled.
+//! In minimal mode some types are restricted in functionality. For instance
+//! the [`Client`] is not available and the [`Hub`] does not retain all API
+//! functionality.
 //!
 //! # Features
 //!
-//! Functionality of the crate can be turned on and off by feature flags.  This is the current list
-//! of feature flags:
+//! * `feature = "client"`: Activates the [`Client`] type and certain
+//!   [`Hub`] functionality.
+//! * `feature = "test"`: Activates the [`test`] module, which can be used to
+//!   write integration tests. It comes with a test transport which can capture
+//!   all sent events for inspection.
+//! * `feature = "debug-logs"`: Uses the `log` crate for debug output, instead
+//!   of printing to `stderr`. This feature is **deprecated** and will be
+//!   replaced by a dedicated log callback in the future.
 //!
-//! Default features:
-//!
-//! * `client`: Turns on the real client implementation.
-//!
-//! Additional features:
-//!
-//! * `log`: When enabled sentry will debug log to `log` at all times.
-//! * `test`: Enables the test support module.
+//! [`sentry`]: https://crates.io/crates/sentry
+//! [Unified API]: https://develop.sentry.dev/sdk/unified-api/
+//! [`Client`]: struct.Client.html
+//! [`Hub`]: struct.Hub.html
+//! [`Scope`]: struct.Scope.html
+//! [`Integration`]: trait.Integration.html
+//! [`Transport`]: trait.Transport.html
 
 #![warn(missing_docs)]
 

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -2,6 +2,18 @@
 ///
 /// This can be used with `ClientOptions` to set the release name.  It uses
 /// the information supplied by cargo to calculate a release.
+///
+/// # Examples
+///
+/// ```
+/// # #[macro_use] extern crate sentry;
+/// # fn main() {
+/// let _sentry = sentry::init(sentry::ClientOptions {
+///            release: sentry::release_name!(),
+///            ..Default::default()
+///        });
+/// # }
+/// ```
 #[macro_export]
 macro_rules! release_name {
     () => {{

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -9,9 +9,9 @@
 /// # #[macro_use] extern crate sentry;
 /// # fn main() {
 /// let _sentry = sentry::init(sentry::ClientOptions {
-///            release: sentry::release_name!(),
-///            ..Default::default()
-///        });
+///     release: sentry::release_name!(),
+///     ..Default::default()
+/// });
 /// # }
 /// ```
 #[macro_export]

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -14,19 +14,22 @@ pub type EventProcessor = Box<dyn Fn(Event<'static>) -> Option<Event<'static>> +
 
 /// Holds contextual data for the current scope.
 ///
-/// The scope is an object that can cloned efficiently and stores data that
+/// The scope is an object that can be cloned efficiently and stores data that
 /// is locally relevant to an event.  For instance the scope will hold recorded
 /// breadcrumbs and similar information.
 ///
 /// The scope can be interacted with in two ways:
 ///
 /// 1. the scope is routinely updated with information by functions such as
-///    `add_breadcrumb` which will modify the currently top-most scope.
-/// 2. the topmost scope can also be configured through the `configure_scope`
+///    [`add_breadcrumb`] which will modify the currently top-most scope.
+/// 2. the topmost scope can also be configured through the [`configure_scope`]
 ///    method.
 ///
 /// Note that the scope can only be modified but not inspected.  Only the
 /// client can use the scope to extract information currently.
+///
+/// [`add_breadcrumb`]: fn.add_breadcrumb.html
+/// [`configure_scope`]: fn.configure_scope.html
 #[derive(Clone)]
 pub struct Scope {
     pub(crate) level: Option<Level>,

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::fmt;
 use std::sync::{Arc, PoisonError, RwLock};
 
-use crate::client::Client;
 use crate::protocol::{Breadcrumb, Context, Event, Level, User, Value};
+use crate::Client;
 
 #[derive(Debug)]
 pub struct Stack {

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -115,6 +115,11 @@ impl Stack {
 }
 
 /// A scope guard.
+///
+/// This is returned from [`Hub::push_scope`] and will automatically pop the
+/// scope on drop.
+///
+/// [`Hub::push_scope`]: struct.Hub.html#method.with_scope
 #[derive(Default)]
 pub struct ScopeGuard(pub(crate) Option<(Arc<RwLock<Stack>>, usize)>);
 

--- a/sentry-core/src/test.rs
+++ b/sentry-core/src/test.rs
@@ -9,7 +9,6 @@
 //! # Example usage
 //!
 //! ```
-//! # use sentry_core as sentry;
 //! use sentry::{capture_message, Level};
 //! use sentry::test::with_captured_events;
 //!
@@ -32,10 +31,9 @@ lazy_static::lazy_static! {
 
 /// Collects events instead of sending them.
 ///
-/// Example usage:
+/// # Examples
 ///
 /// ```
-/// # use sentry_core as sentry;
 /// use std::sync::Arc;
 /// use sentry::{Hub, ClientOptions};
 /// use sentry::test::TestTransport;

--- a/sentry-core/src/test.rs
+++ b/sentry-core/src/test.rs
@@ -9,8 +9,8 @@
 //! # Example usage
 //!
 //! ```
-//! use sentry::{capture_message, Level};
 //! use sentry::test::with_captured_events;
+//! use sentry::{capture_message, Level};
 //!
 //! let events = with_captured_events(|| {
 //!     capture_message("Hello World!", Level::Warning);
@@ -34,9 +34,9 @@ lazy_static::lazy_static! {
 /// # Examples
 ///
 /// ```
-/// use std::sync::Arc;
-/// use sentry::{Hub, ClientOptions};
 /// use sentry::test::TestTransport;
+/// use sentry::{ClientOptions, Hub};
+/// use std::sync::Arc;
 ///
 /// let transport = TestTransport::new();
 /// let options = ClientOptions {

--- a/sentry-core/src/test.rs
+++ b/sentry-core/src/test.rs
@@ -19,13 +19,12 @@
 //! assert_eq!(events.len(), 1);
 //! assert_eq!(events[0].message.as_ref().unwrap(), "Hello World!");
 //! ```
+
 use std::sync::{Arc, Mutex};
 
-use crate::client::ClientOptions;
-use crate::hub::Hub;
-use crate::internals::Dsn;
 use crate::protocol::Event;
-use crate::transport::Transport;
+use crate::types::Dsn;
+use crate::{ClientOptions, Hub, Transport};
 
 lazy_static::lazy_static! {
     static ref TEST_DSN: Dsn = "https://public@sentry.invalid/1".parse().unwrap();

--- a/sentry-debug-images/src/unix.rs
+++ b/sentry-debug-images/src/unix.rs
@@ -1,9 +1,9 @@
 use std::env;
 
 use findshlibs::{Segment, SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
-use sentry_core::internals::Uuid;
 use sentry_core::protocol::debugid::DebugId;
 use sentry_core::protocol::{DebugImage, SymbolicDebugImage};
+use sentry_core::types::Uuid;
 
 pub fn debug_images() -> Vec<DebugImage> {
     let mut images = vec![];

--- a/sentry-error-chain/src/lib.rs
+++ b/sentry-error-chain/src/lib.rs
@@ -30,9 +30,9 @@ use std::fmt::{Debug, Display};
 
 use error_chain::ChainedError;
 use sentry_backtrace::backtrace_to_stacktrace;
-use sentry_core::internals::Uuid;
 use sentry_core::parse_type_from_debug;
 use sentry_core::protocol::{Event, Exception, Level};
+use sentry_core::types::Uuid;
 use sentry_core::{ClientOptions, Hub, Integration};
 
 fn exceptions_from_error_chain<T>(error: &T) -> Vec<Exception>

--- a/sentry-failure/src/lib.rs
+++ b/sentry-failure/src/lib.rs
@@ -32,9 +32,9 @@ use std::panic::PanicInfo;
 
 use failure::{Error, Fail};
 use sentry_backtrace::parse_stacktrace;
-use sentry_core::internals::Uuid;
 use sentry_core::parse_type_from_debug;
 use sentry_core::protocol::{Event, Exception, Level};
+use sentry_core::types::Uuid;
 use sentry_core::{ClientOptions, Hub, Integration};
 
 /// The Sentry Failure Integration.

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -2,8 +2,7 @@ use std::env;
 use std::{borrow::Cow, sync::Arc};
 
 use crate::transports::DefaultTransportFactory;
-
-use crate::internals::Dsn;
+use crate::types::Dsn;
 use crate::{ClientOptions, Integration};
 
 /// Apply default client options.
@@ -21,7 +20,7 @@ use crate::{ClientOptions, Integration};
 /// assert_eq!(options.release, None);
 /// assert!(options.transport.is_none());
 ///
-/// let options = sentry::internals::apply_defaults(options);
+/// let options = sentry::apply_defaults(options);
 /// assert_eq!(options.release, Some("release-from-env".into()));
 /// assert!(options.transport.is_some());
 /// ```

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -99,14 +99,20 @@
 //! Testing:
 //!
 //! * `with_test_support`: Enables the test support module.
+
 #![warn(missing_docs)]
 
 mod defaults;
 mod init;
 mod transport;
 
+// re-export from core
 #[doc(inline)]
 pub use sentry_core::*;
+
+// added public API
+pub use crate::defaults::apply_defaults;
+pub use crate::init::{init, ClientInitGuard};
 
 /// Available Sentry Integrations.
 pub mod integrations {
@@ -144,10 +150,11 @@ pub mod integrations {
 /// This module contains types that users of the crate typically do not
 /// have to interface with directly.  These are often returned
 /// from methods on other types.
+#[deprecated = "These exports have been moved to the root or the `types` mod."]
 pub mod internals {
     pub use crate::defaults::apply_defaults;
     pub use crate::init::ClientInitGuard;
-    pub use sentry_core::internals::*;
+    pub use sentry_core::types::*;
 }
 
 /// The provided transports.
@@ -174,5 +181,3 @@ pub mod transports {
     ))]
     pub use crate::transport::HttpTransport;
 }
-
-pub use crate::init::init;

--- a/sentry/src/transport.rs
+++ b/sentry/src/transport.rs
@@ -16,7 +16,7 @@ use httpdate::parse_http_date;
 #[cfg(feature = "with_curl_transport")]
 use std::io::Cursor;
 #[cfg(feature = "with_curl_transport")]
-use {crate::internals::Scheme, curl, std::io::Read};
+use {crate::types::Scheme, curl, std::io::Read};
 
 #[cfg(feature = "with_reqwest_transport")]
 use reqwest::{blocking::Client as ReqwestClient, header::RETRY_AFTER, Proxy};
@@ -30,9 +30,9 @@ use surf::Client as SurfClient;
 
 use sentry_core::sentry_debug;
 
-use crate::internals::{Transport, TransportFactory};
 use crate::protocol::Event;
-use crate::ClientOptions;
+use crate::{ClientOptions, Transport, TransportFactory};
+
 /// Creates the default HTTP transport.
 ///
 /// This is the default value for `transport` on the client options.  It

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -80,7 +80,7 @@ fn test_breadcrumbs() {
 fn test_factory() {
     struct TestTransport(Arc<AtomicUsize>);
 
-    impl sentry::types::Transport for TestTransport {
+    impl sentry::Transport for TestTransport {
         fn send_event(&self, event: sentry::protocol::Event<'static>) {
             assert_eq!(event.message.unwrap(), "test");
             self.0.fetch_add(1, Ordering::SeqCst);

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -3,7 +3,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use sentry::internals::Uuid;
+use sentry::types::Uuid;
 
 #[test]
 fn test_basic_capture_message() {
@@ -80,7 +80,7 @@ fn test_breadcrumbs() {
 fn test_factory() {
     struct TestTransport(Arc<AtomicUsize>);
 
-    impl sentry::internals::Transport for TestTransport {
+    impl sentry::types::Transport for TestTransport {
         fn send_event(&self, event: sentry::protocol::Event<'static>) {
             assert_eq!(event.message.unwrap(), "test");
             self.0.fetch_add(1, Ordering::SeqCst);
@@ -93,7 +93,7 @@ fn test_factory() {
     let options = sentry::ClientOptions {
         dsn: "http://foo@example.com/42".parse().ok(),
         transport: Some(Arc::new(
-            move |opts: &sentry::ClientOptions| -> Arc<dyn sentry::internals::Transport> {
+            move |opts: &sentry::ClientOptions| -> Arc<dyn sentry::Transport> {
                 assert_eq!(opts.dsn.as_ref().unwrap().host(), "example.com");
                 Arc::new(TestTransport(events_for_options.clone()))
             },

--- a/sentry/tests/test_client.rs
+++ b/sentry/tests/test_client.rs
@@ -10,7 +10,7 @@ fn test_into_client() {
         let dsn = c.dsn().unwrap();
         assert_eq!(dsn.public_key(), "public");
         assert_eq!(dsn.host(), "example.com");
-        assert_eq!(dsn.scheme(), sentry::internals::Scheme::Https);
+        assert_eq!(dsn.scheme(), sentry::types::Scheme::Https);
         assert_eq!(dsn.project_id().value(), 42);
     }
 
@@ -25,7 +25,7 @@ fn test_into_client() {
         let dsn = c.dsn().unwrap();
         assert_eq!(dsn.public_key(), "public");
         assert_eq!(dsn.host(), "example.com");
-        assert_eq!(dsn.scheme(), sentry::internals::Scheme::Https);
+        assert_eq!(dsn.scheme(), sentry::types::Scheme::Https);
         assert_eq!(dsn.project_id().value(), 42);
         assert_eq!(&c.options().release.as_ref().unwrap(), &"foo@1.0");
     }


### PR DESCRIPTION
The `sentry-core` exports have been a bit restructured, other things in
`sentry` have been marked as deprecated.