### PR TITLE
feat: Add support for surf HTTP client

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -20,6 +20,7 @@ all-features = true
 default = ["with_client_implementation", "with_default_transport", "with_panic", "with_failure"]
 with_reqwest_transport = ["reqwest", "httpdate", "with_client_implementation"]
 with_curl_transport = ["curl", "httpdate", "serde_json", "with_client_implementation"]
+with_surf_transport = ["surf", "httpdate", "http-client", "futures", "with_client_implementation"]
 with_default_transport = ["with_reqwest_transport", "with_native_tls"]
 with_client_implementation = ["sentry-core/with_client_implementation"]
 with_backtrace = ["sentry-backtrace"]
@@ -39,6 +40,9 @@ sentry-contexts = { version = "0.18.0", path = "../sentry-contexts" }
 log = { version = "0.4.8", optional = true, features = ["std"] }
 reqwest = { version = "0.10.1", optional = true, features = ["blocking", "json"], default-features = false }
 curl = { version = "0.4.25", optional = true }
+surf = { version = "2.0.0-alpha.2", optional = true }
+http-client = { version = "2.0", optional = true }
+futures = { version = "0.3", optional = true }
 httpdate = { version = "0.3.2", optional = true }
 serde_json = { version = "1.0.48", optional = true }
 

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -92,6 +92,7 @@
 //! * `with_reqwest_transport`: Enables the reqwest transport explicitly.  This is currently the
 //!   default transport.
 //! * `with_curl_transport`: Enables the curl transport.
+//! * `with_surf_transport`: Enables the surf transport.
 //! * `with_rustls`: Enables the `rustls` TLS implementation.  This is currently the default when
 //!   using the `with_reqwest_transport` feature.
 //! * `with_native_tls`: Enables the `default-tls` feature of the `reqwest` library.
@@ -129,10 +130,14 @@ pub mod internals {
 /// The provided transports.
 ///
 /// This module exposes all transports that are compiled into the sentry
-/// library.  The `with_reqwest_transport` and `with_curl_transport` flags
+/// library.  The `with_reqwest_transport`, `with_curl_transport` and `with_surf_transport` flags
 /// turn on these transports.
 pub mod transports {
-    #[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+    #[cfg(any(
+        feature = "with_reqwest_transport",
+        feature = "with_curl_transport",
+        feature = "with_surf_transport"
+    ))]
     pub use crate::transport::{DefaultTransportFactory, HttpTransport};
 
     #[cfg(feature = "with_reqwest_transport")]
@@ -140,6 +145,9 @@ pub mod transports {
 
     #[cfg(feature = "with_curl_transport")]
     pub use crate::transport::CurlHttpTransport;
+
+    #[cfg(feature = "with_surf_transport")]
+    pub use crate::transport::SurfHttpTransport;
 }
 
 #[cfg(feature = "with_client_implementation")]

--- a/sentry/src/transport.rs
+++ b/sentry/src/transport.rs
@@ -4,7 +4,11 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime};
 
-#[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+#[cfg(any(
+    feature = "with_reqwest_transport",
+    feature = "with_curl_transport",
+    feature = "with_surf_transport"
+))]
 use httpdate::parse_http_date;
 
 #[cfg(feature = "with_curl_transport")]
@@ -13,7 +17,14 @@ use std::io::Cursor;
 use {crate::internals::Scheme, curl, std::io::Read};
 
 #[cfg(feature = "with_reqwest_transport")]
-use reqwest::{blocking::Client, header::RETRY_AFTER, Proxy};
+use reqwest::{blocking::Client as ReqwestClient, header::RETRY_AFTER, Proxy};
+
+#[cfg(feature = "with_surf_transport")]
+use futures::executor;
+#[cfg(feature = "with_surf_transport")]
+use http_client::native::NativeClient;
+#[cfg(feature = "with_surf_transport")]
+use surf::Client as SurfClient;
 
 use sentry_core::sentry_debug;
 
@@ -30,18 +41,30 @@ pub struct DefaultTransportFactory;
 
 impl TransportFactory for DefaultTransportFactory {
     fn create_transport(&self, options: &ClientOptions) -> Arc<dyn Transport> {
-        #[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+        #[cfg(any(
+            feature = "with_reqwest_transport",
+            feature = "with_curl_transport",
+            feature = "with_surf_transport"
+        ))]
         {
             Arc::new(HttpTransport::new(options))
         }
-        #[cfg(not(any(feature = "with_reqwest_transport", feature = "with_curl_transport")))]
+        #[cfg(not(any(
+            feature = "with_reqwest_transport",
+            feature = "with_curl_transport",
+            feature = "with_surf_transport"
+        )))]
         {
             panic!("sentry crate was compiled without transport")
         }
     }
 }
 
-#[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+#[cfg(any(
+    feature = "with_reqwest_transport",
+    feature = "with_curl_transport",
+    feature = "with_surf_transport"
+))]
 fn parse_retry_after(s: &str) -> Option<SystemTime> {
     if let Ok(value) = s.parse::<f64>() {
         Some(SystemTime::now() + Duration::from_secs(value.ceil() as u64))
@@ -161,7 +184,7 @@ implement_http_transport! {
         signal: Arc<Condvar>,
         shutdown_immediately: Arc<AtomicBool>,
         queue_size: Arc<Mutex<usize>>,
-        http_client: Option<Client>,
+        http_client: Option<ReqwestClient>,
     ) {
         let dsn = options.dsn.clone().unwrap();
         let user_agent = options.user_agent.to_string();
@@ -175,7 +198,7 @@ implement_http_transport! {
             .spawn(move || {
                 sentry_debug!("spawning reqwest transport");
                 let http_client = http_client.unwrap_or_else(|| {
-                    let mut builder = Client::builder();
+                    let mut builder = ReqwestClient::builder();
                     if let Some(url) = http_proxy {
                         builder = builder.proxy(Proxy::http(&url).unwrap());
                     };
@@ -241,7 +264,10 @@ implement_http_transport! {
             }).unwrap()
     }
 
-    fn http_client(_options: &ClientOptions, client: Option<Client>) -> Option<Client> {
+    fn http_client(
+        _options: &ClientOptions,
+        client: Option<ReqwestClient>
+    ) -> Option<ReqwestClient> {
         client
     }
 }
@@ -376,15 +402,130 @@ implement_http_transport! {
     }
 }
 
+#[cfg(feature = "with_surf_transport")]
+implement_http_transport! {
+    /// A transport can send events via HTTP to sentry via `surf`.
+    ///
+    /// This is enabled by the `with_surf_transport` flag.
+    pub struct SurfHttpTransport;
+
+    fn spawn(
+        options: &ClientOptions,
+        receiver: Receiver<Option<Event<'static>>>,
+        signal: Arc<Condvar>,
+        shutdown_immediately: Arc<AtomicBool>,
+        queue_size: Arc<Mutex<usize>>,
+        http_client: SurfClient<NativeClient>,
+    ) {
+        let dsn = options.dsn.clone().unwrap();
+        let user_agent = options.user_agent.to_string();
+        let mut disabled = None::<SystemTime>;
+
+        thread::Builder::new()
+            .name("sentry-transport".to_string())
+            .spawn(move || {
+                sentry_debug!("spawning surf transport");
+                let http_client = http_client;
+                let url = dsn.store_api_url().to_string();
+
+                while let Some(event) = receiver.recv().unwrap_or(None) {
+                    // on drop we want to not continue processing the queue.
+                    if shutdown_immediately.load(Ordering::SeqCst) {
+                        let mut size = queue_size.lock().unwrap();
+                        *size = 0;
+                        signal.notify_all();
+                        break;
+                    }
+
+                    // while we are disabled due to rate limits, skip
+                    if let Some(ts) = disabled {
+                        if let Ok(time_left) = ts.duration_since(SystemTime::now()) {
+                            sentry_debug!(
+                                "Skipping event send because we're disabled due to rate limits for {}s",
+                                time_left.as_secs()
+                            );
+                            continue;
+                        } else {
+                            disabled = None;
+                        }
+                    }
+
+                    let req_result = http_client
+                        .post(url.as_str())
+                        .set_header(
+                            "X-Sentry-Auth".parse().unwrap(),
+                            dsn.to_auth(Some(&user_agent)).to_string()
+                        )
+                        .body_json(&event);
+
+                    let fut = match req_result {
+                        Ok(fut) => fut,
+                        Err(err) => {
+                            sentry_debug!(
+                                "Skipping event send because JSON serialization failed: {}",
+                                err
+                            );
+
+                            continue;
+                        }
+                    };
+
+                    match executor::block_on(fut) {
+                        Ok(resp) => {
+                            if resp.status() == 429 {
+                                if let Some(retry_after) = resp
+                                    .header(&"Retry-After".parse().unwrap())
+                                    .and_then(|x| x.first())
+                                    .map(|x| x.as_str())
+                                    .and_then(parse_retry_after)
+                                {
+                                    disabled = Some(retry_after);
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            sentry_debug!("Failed to send event: {}", err);
+                        }
+                    }
+
+                    let mut size = queue_size.lock().unwrap();
+                    *size -= 1;
+                    if *size == 0 {
+                        signal.notify_all();
+                    }
+                }
+            }).unwrap()
+    }
+
+    fn http_client(
+        _options: &ClientOptions,
+        client: Option<SurfClient<NativeClient>>
+    ) -> SurfClient<NativeClient> {
+        client.unwrap_or_else(SurfClient::new)
+    }
+}
+
 #[cfg(feature = "with_reqwest_transport")]
 type DefaultTransport = ReqwestHttpTransport;
 
 #[cfg(all(
     feature = "with_curl_transport",
-    not(feature = "with_reqwest_transport")
+    not(feature = "with_reqwest_transport"),
+    not(feature = "with_surf_transport")
 ))]
 type DefaultTransport = CurlHttpTransport;
 
+#[cfg(all(
+    feature = "with_surf_transport",
+    not(feature = "with_reqwest_transport"),
+    not(feature = "with_curl_transport")
+))]
+type DefaultTransport = SurfHttpTransport;
+
 /// The default http transport.
-#[cfg(any(feature = "with_reqwest_transport", feature = "with_curl_transport"))]
+#[cfg(any(
+    feature = "with_reqwest_transport",
+    feature = "with_curl_transport",
+    feature = "with_surf_transport"
+))]
 pub type HttpTransport = DefaultTransport;


### PR DESCRIPTION
This PR provides support of [surf](https://github.com/http-rs/surf) HTTP client as an alternative to reqwest and curl.