### PR TITLE
meta: Streamline Cargo.toml and README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,38 +8,100 @@
 # Sentry Rust
 
 [![Build Status](https://travis-ci.com/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.com/getsentry/sentry-rust)
-[![Crates.io](https://img.shields.io/crates/v/sentry.svg?style=flat)](https://crates.io/crates/sentry)
 
-This workspace contains various crates that provide support for logging events
-and errors / panics to the [Sentry](https://sentry.io/) error logging service.
+This workspace contains various crates that provide support for logging events and errors / panics to the
+[Sentry](https://sentry.io/) error logging service.
 
-- [sentry](./sentry) The main `sentry` crate aimed at application users that
-  want to log events to sentry.
-- [sentry-actix](./sentry-actix) An integration for the `actix-web (0.7)`
-  framework.
-- [sentry-core](./sentry-core) The core of `sentry`, which can be used to
-  instrument code, and to write integrations that generate events or hook into
-  event processing.
-- [sentry-types](./sentry-types) Contains types for the Sentry v7 protocol as
-  well as other common types.
+- [sentry](./sentry) [![crates.io](https://img.shields.io/crates/v/sentry.svg)](https://crates.io/crates/sentry)
+  [![docs.rs](https://docs.rs/sentry/badge.svg)](https://docs.rs/sentry)
 
-**Note**: Until the _1.0_ release, the crates in this repository are considered work in
-progress and do not follow semver semantics. Between minor releases, we might
-occasionally introduce breaking changes while we are exploring the best API and
-adding new features.
+  The main `sentry` crate aimed at application users that want to log events to sentry.
+
+- [sentry-actix](./sentry-actix)
+  [![crates.io](https://img.shields.io/crates/v/sentry-actix.svg)](https://crates.io/crates/sentry-actix)
+  [![docs.rs](https://docs.rs/sentry-actix/badge.svg)](https://docs.rs/sentry-actix)
+
+  An integration for the `actix-web (0.7)` framework.
+
+- [sentry-anyhow](./sentry-anyhow)
+  [![crates.io](https://img.shields.io/crates/v/sentry-anyhow.svg)](https://crates.io/crates/sentry-anyhow)
+  [![docs.rs](https://docs.rs/sentry-anyhow/badge.svg)](https://docs.rs/sentry-anyhow)
+
+  An integration for `anyhow` errors.
+
+- [sentry-backtrace](./sentry-backtrace)
+  [![crates.io](https://img.shields.io/crates/v/sentry-backtrace.svg)](https://crates.io/crates/sentry-backtrace)
+  [![docs.rs](https://docs.rs/sentry-backtrace/badge.svg)](https://docs.rs/sentry-backtrace)
+
+  A utility crate that creates and processes backtraces.
+
+- [sentry-contexts](./sentry-contexts)
+  [![crates.io](https://img.shields.io/crates/v/sentry-contexts.svg)](https://crates.io/crates/sentry-contexts)
+  [![docs.rs](https://docs.rs/sentry-contexts/badge.svg)](https://docs.rs/sentry-contexts)
+
+  An integration that provides `os`, `device` and `rust` contexts.
+
+- [sentry-core](./sentry-core)
+  [![crates.io](https://img.shields.io/crates/v/sentry-core.svg)](https://crates.io/crates/sentry-core)
+  [![docs.rs](https://docs.rs/sentry-core/badge.svg)](https://docs.rs/sentry-core)
+
+  The core of `sentry`, which can be used to instrument code, and to write integrations that generate events or hook
+  into event processing.
+
+- [sentry-debug-images](./sentry-debug-images)
+  [![crates.io](https://img.shields.io/crates/v/sentry-debug-images.svg)](https://crates.io/crates/sentry-debug-images)
+  [![docs.rs](https://docs.rs/sentry-debug-images/badge.svg)](https://docs.rs/sentry-debug-images)
+
+  An integration that adds a list of loaded libraries to events.
+
+- [sentry-error-chain](./sentry-error-chain)
+  [![crates.io](https://img.shields.io/crates/v/sentry-error-chain.svg)](https://crates.io/crates/sentry-error-chain)
+  [![docs.rs](https://docs.rs/sentry-error-chain/badge.svg)](https://docs.rs/sentry-error-chain)
+
+  An integration for the `error-chain` crate. This is _deprecated_ and may be completely removed in the future.
+
+- [sentry-failure](./sentry-failure)
+  [![crates.io](https://img.shields.io/crates/v/sentry-failure.svg)](https://crates.io/crates/sentry-failure)
+  [![docs.rs](https://docs.rs/sentry-failure/badge.svg)](https://docs.rs/sentry-failure)
+
+  An integration for the `failure` crate.
+
+- [sentry-log](./sentry-log)
+  [![crates.io](https://img.shields.io/crates/v/sentry-log.svg)](https://crates.io/crates/sentry-log)
+  [![docs.rs](https://docs.rs/sentry-log/badge.svg)](https://docs.rs/sentry-log)
+
+  An integration for the `log` and `env_logger` crate.
+
+- [sentry-panic](./sentry-panic)
+  [![crates.io](https://img.shields.io/crates/v/sentry-panic.svg)](https://crates.io/crates/sentry-panic)
+  [![docs.rs](https://docs.rs/sentry-panic/badge.svg)](https://docs.rs/sentry-panic)
+
+  An integration for capturing and logging panics.
+
+- [sentry-slog](./sentry-slog)
+  [![crates.io](https://img.shields.io/crates/v/sentry-slog.svg)](https://crates.io/crates/sentry-slog)
+  [![docs.rs](https://docs.rs/sentry-slog/badge.svg)](https://docs.rs/sentry-slog)
+
+  An integration for the `slog` crate.
+
+- [sentry-types](./sentry-types)
+  [![crates.io](https://img.shields.io/crates/v/sentry-types.svg)](https://crates.io/crates/sentry-types)
+  [![docs.rs](https://docs.rs/sentry-types/badge.svg)](https://docs.rs/sentry-types)
+
+  Contains types for the Sentry v7 protocol as well as other common types.
+
+**Note**: Until the _1.0_ release, the crates in this repository are considered work in progress and do not follow
+semver semantics. Between minor releases, we might occasionally introduce breaking changes while we are exploring the
+best API and adding new features.
 
 ## Requirements
 
-We currently only verify this crate against a recent version of Sentry hosted on
-[sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
-8.20 and later.
+We currently only verify this crate against a recent version of Sentry hosted on [sentry.io](https://sentry.io/) but it
+should work with on-prem Sentry versions 8.20 and later.
 
 Additionally, the lowest Rust version we target is _1.40.0_.
 
 ## Resources
 
-- [crates.io](https://crates.io/crates/sentry)
-- [Documentation](https://getsentry.github.io/sentry-rust)
-- [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
 - [Discord](https://discord.gg/ez5KZN7) server for project discussions.
 - Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br />
 </p>
 
-# Sentry Rust
+# Sentry SDK for Rust
 
 [![Build Status](https://travis-ci.com/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.com/getsentry/sentry-rust)
 

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://docs.rs/sentry-actix"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry client extension for actix-web
+Sentry client extension for actix-web 0.7.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [features]
 default = ["with_sentry_default"]

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -5,25 +5,6 @@
   <br />
 </p>
 
-# Sentry-Actix
+# Sentry SDK Integration for actix-web 0.7
 
-[![Build Status](https://travis-ci.org/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.org/getsentry/sentry-rust)
-[![Crates.io](https://img.shields.io/crates/v/sentry-actix.svg?style=flat)](https://crates.io/crates/sentry-actix)
-
-This is an actix-web integration for the Sentry crate.
-
-## Requirements
-
-We currently only verify this crate against a recent version of Sentry hosted on
-[sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
-8.20 and later.
-
-Additionally, the lowest Rust version we target is _1.40.0_.
-
-## Resources
-
-- [crates.io](https://crates.io/crates/sentry-actix)
-- [Documentation](https://docs.rs/sentry)
-- [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
-- [IRC](irc://chat.freenode.net/sentry) (chat.freenode.net, #sentry)
-- Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates
+This is a Sentry extension for the `actix-web 0.7` framework.

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -9,7 +9,7 @@ fn failing(_req: &HttpRequest) -> Result<String, Error> {
 }
 
 fn main() {
-    let _guard = sentry::init("https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156");
+    let _guard = sentry::init(());
     env::set_var("RUST_BACKTRACE", "1");
 
     server::new(|| {

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -28,9 +28,10 @@
 //!         App::new()
 //!             .middleware(SentryMiddleware::new())
 //!             .resource("/", |r| r.f(failing))
-//!     }).bind("127.0.0.1:3001")
-//!         .unwrap()
-//!         .run();
+//!     })
+//!     .bind("127.0.0.1:3001")
+//!     .unwrap()
+//!     .run();
 //! }
 //! ```
 //!

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for anyhow.
+Sentry integration for anyhow.
 """
 edition = "2018"
 

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -5,13 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for any errors.
+Sentry Integration for anyhow.
 """
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-anyhow/README.md
+++ b/sentry-anyhow/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK Integration for anyhow
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+This is a Sentry integration for the `anyhow` crate.

--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry integration and utilities for dealing with stacktraces
+Sentry integration and utilities for dealing with stacktraces.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-backtrace/README.md
+++ b/sentry-backtrace/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK backtrace integration and utilities
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration and utilities for dealing with stacktraces.

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -29,4 +29,4 @@ uname = "0.1.1"
 rustc_version = "0.2.3"
 
 [dev-dependencies]
-sentry = { version = "0.18.0", path = "../sentry" }
+sentry = { version = "0.18.0", path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -5,13 +5,15 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry integration for rust and device contexts
+Sentry integration for os, device, and rust contexts.
 """
 build = "build.rs"
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-contexts/README.md
+++ b/sentry-contexts/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK contexts integration
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration for os, device, and rust contexts.

--- a/sentry-contexts/src/lib.rs
+++ b/sentry-contexts/src/lib.rs
@@ -13,8 +13,7 @@
 //!     add_os: false,
 //!     ..Default::default()
 //! };
-//! let _sentry = sentry::init(sentry::ClientOptions::default()
-//!     .add_integration(integration));
+//! let _sentry = sentry::init(sentry::ClientOptions::default().add_integration(integration));
 //! ```
 
 #![deny(missing_docs)]

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
 Core sentry library used for instrumentation and integration development.
 """
@@ -24,7 +23,7 @@ debug-logs = ["log_"]
 test = ["client"]
 
 [dependencies]
-sentry-types = { version = "0.15.0", path = "../sentry-types" }
+sentry-types = { version = "0.18.0", path = "../sentry-types" }
 lazy_static = "1.4.0"
 im = { version = "14.2.0", optional = true }
 rand = { version = "0.7.3", optional = true }

--- a/sentry-core/README.md
+++ b/sentry-core/README.md
@@ -5,31 +5,7 @@
   <br />
 </p>
 
-# Sentry-Core
+# Sentry SDK Core
 
-[![Build Status](https://travis-ci.com/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.com/getsentry/sentry-rust)
-[![Crates.io](https://img.shields.io/crates/v/sentry-core.svg?style=flat)](https://crates.io/crates/sentry-core)
-
-The core of `sentry`, which can be used to instrument code, and to write
-integrations that generate events or hook into event processing.
-
-**Note**: Until the _1.0_ release, the `sentry` crate is considered work in
-progress and does not follow semver semantics. Between minor releases, we might
-occasionally introduce breaking changes while we are exploring the best API and
-adding new features.
-
-## Requirements
-
-We currently only verify this crate against a recent version of Sentry hosted on
-[sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
-8.20 and later.
-
-Additionally, the lowest Rust version we target is _1.40.0_.
-
-## Resources
-
-- [crates.io](https://crates.io/crates/sentry-core)
-- [Documentation](https://getsentry.github.io/sentry-rust)
-- [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
-- [Discord](https://discord.gg/ez5KZN7) server for project discussions.
-- Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates
+The core of `sentry`, which can be used to instrument code, and to write integrations that generate events or hook into
+event processing.

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration that adds the list of loaded libraries to events.
+Sentry integration that adds the list of loaded libraries to events.
 """
 edition = "2018"
 

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for debug images
+Sentry Integration that adds the list of loaded libraries to events.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-debug-images/README.md
+++ b/sentry-debug-images/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK debug-images integration
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration that adds the list of loaded libraries to events.

--- a/sentry-error-chain/Cargo.toml
+++ b/sentry-error-chain/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "sentry-error-chain"
-version = "0.1.0"
+version = "0.18.0"
 authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry integration that allows capturing error-chain errors
+Sentry integration that allows capturing error-chain errors.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-error-chain/Cargo.toml
+++ b/sentry-error-chain/Cargo.toml
@@ -20,4 +20,4 @@ sentry-backtrace = { version = "0.18.0", path = "../sentry-backtrace" }
 error-chain = "0.12.1"
 
 [dev-dependencies]
-sentry = { version = "0.18.0", path = "../sentry" }
+sentry = { version = "0.18.0", path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-error-chain/README.md
+++ b/sentry-error-chain/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK error-chain integration
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration that allows capturing `error-chain` errors.

--- a/sentry-error-chain/src/lib.rs
+++ b/sentry-error-chain/src/lib.rs
@@ -11,8 +11,8 @@
 //! use sentry_error_chain::{capture_error_chain, ErrorChainIntegration};
 //! # fn function_that_might_fail() -> Result<()> { Ok(()) }
 //! # fn test() -> Result<()> {
-//! let _sentry = sentry::init(sentry::ClientOptions::default()
-//!     .add_integration(ErrorChainIntegration));
+//! let _sentry =
+//!     sentry::init(sentry::ClientOptions::default().add_integration(ErrorChainIntegration));
 //! let result = match function_that_might_fail() {
 //!     Ok(result) => result,
 //!     Err(err) => {

--- a/sentry-failure/Cargo.toml
+++ b/sentry-failure/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for failure crate.
+Sentry integration for failure crate.
 """
 edition = "2018"
 

--- a/sentry-failure/Cargo.toml
+++ b/sentry-failure/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for failure crate
+Sentry Integration for failure crate.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-failure/Cargo.toml
+++ b/sentry-failure/Cargo.toml
@@ -20,5 +20,5 @@ sentry-backtrace = { version = "0.18.0", path = "../sentry-backtrace" }
 failure = "0.1.6"
 
 [dev-dependencies]
-sentry = { version = "0.18.0", path = "../sentry" }
+sentry = { version = "0.18.0", path = "../sentry", default-features = false, features = ["test"] }
 sentry-panic = { version = "0.18.0", path = "../sentry-panic" }

--- a/sentry-failure/README.md
+++ b/sentry-failure/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK failure integration
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration that allows capturing `failure` errors.

--- a/sentry-failure/src/lib.rs
+++ b/sentry-failure/src/lib.rs
@@ -73,8 +73,8 @@ impl Integration for FailureIntegration {
 /// # Examples
 ///
 /// ```
-/// let panic_integration = sentry_panic::PanicIntegration::new()
-///     .add_extractor(sentry_failure::panic_extractor);
+/// let panic_integration =
+///     sentry_panic::PanicIntegration::new().add_extractor(sentry_failure::panic_extractor);
 /// ```
 pub fn panic_extractor(info: &PanicInfo<'_>) -> Option<Event<'static>> {
     let error = info.payload().downcast_ref::<Error>()?;

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for log and env_logger crates
+Sentry Integration for log and env_logger crates.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -21,6 +21,6 @@ log = { version = "0.4.8", features = ["std"] }
 env_logger = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
-sentry = { version = "0.18.0", path = "../sentry" }
+sentry = { version = "0.18.0", path = "../sentry", default-features = false, features = ["test"] }
 pretty_env_logger = "0.4.0"
 env_logger = "0.7.1"

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for log and env_logger crates.
+Sentry integration for log and env_logger crates.
 """
 edition = "2018"
 

--- a/sentry-log/README.md
+++ b/sentry-log/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK log integration
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration that allows capturing breadcrumbs and events from `log` Records.

--- a/sentry-log/src/lib.rs
+++ b/sentry-log/src/lib.rs
@@ -9,8 +9,7 @@
 //!
 //! ```
 //! let log_integration = sentry_log::LogIntegration::default();
-//! let _setry = sentry::init(sentry::ClientOptions::default()
-//!     .add_integration(log_integration));
+//! let _setry = sentry::init(sentry::ClientOptions::default().add_integration(log_integration));
 //!
 //! log::info!("Generates a breadcrumb");
 //! ```
@@ -20,10 +19,9 @@
 //! ```
 //! let mut log_builder = pretty_env_logger::formatted_builder();
 //! log_builder.parse_filters("info");
-//! let log_integration = sentry_log::LogIntegration::default()
-//!     .with_env_logger_dest(Some(log_builder.build()));
-//! let _setry = sentry::init(sentry::ClientOptions::default()
-//!     .add_integration(log_integration));
+//! let log_integration =
+//!     sentry_log::LogIntegration::default().with_env_logger_dest(Some(log_builder.build()));
+//! let _setry = sentry::init(sentry::ClientOptions::default().add_integration(log_integration));
 //!
 //! log::error!("Generates an event");
 //! ```

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -19,4 +19,4 @@ sentry-core = { version = "0.18.0", path = "../sentry-core" }
 sentry-backtrace = { version = "0.18.0", path = "../sentry-backtrace" }
 
 [dev-dependencies]
-sentry = { version = "0.18.0", path = "../sentry" }
+sentry = { version = "0.18.0", path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for capturing panics.
+Sentry integration for capturing panics.
 """
 edition = "2018"
 

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for panics
+Sentry Integration for capturing panics.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-panic/README.md
+++ b/sentry-panic/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK panic integration
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration for capturing panics.

--- a/sentry-panic/src/lib.rs
+++ b/sentry-panic/src/lib.rs
@@ -11,8 +11,7 @@
 //! might optionally create a sentry `Event` out of a `PanicInfo`.
 //!
 //! ```
-//! let integration = sentry_panic::PanicIntegration::default()
-//!     .add_extractor(|info| None);
+//! let integration = sentry_panic::PanicIntegration::default().add_extractor(|info| None);
 //! ```
 
 #![deny(missing_docs)]

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -19,4 +19,4 @@ sentry-core = { version = "0.18.0", path = "../sentry-core" }
 slog = "2.5.2"
 
 [dev-dependencies]
-sentry = { version = "0.18.0", path = "../sentry", features = ["with_test_support"] }
+sentry = { version = "0.18.0", path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for the slog crate.
+Sentry integration for the slog crate.
 """
 edition = "2018"
 

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -5,12 +5,14 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
-Sentry Integration for slog
+Sentry Integration for the slog crate.
 """
 edition = "2018"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 sentry-core = { version = "0.18.0", path = "../sentry-core" }

--- a/sentry-slog/README.md
+++ b/sentry-slog/README.md
@@ -5,7 +5,6 @@
   <br />
 </p>
 
-# Sentry Types
+# Sentry SDK slog integration
 
-This library implements Rust types for the Sentry v7 protocol as well as some other common types that are useful when
-working with Sentry (like DSNs and so forth).
+Sentry integration that allows capturing breadcrumbs and events from `slog` Records.

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "sentry-types"
-version = "0.15.0"
-license = "Apache-2.0"
-description = "Common reusable types for implementing the sentry.io protocol."
-homepage = "https://sentry.io/"
-repository = "https://github.com/getsentry/sentry-rust"
-documentation = "https://docs.rs/sentry-types"
-keywords = ["sentry", "protocol"]
-readme = "README.md"
+version = "0.18.0"
 authors = ["Sentry <hello@sentry.io>"]
-exclude = [
-    ".vscode/**/*",
-    "scripts/**/*"
-]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/getsentry/sentry-rust"
+homepage = "https://sentry.io/welcome/"
+description = """
+Common reusable types for implementing the sentry.io protocol.
+"""
+keywords = ["sentry", "protocol"]
 edition = "2018"
 
-[features]
-default = ["with_protocol"]
-with_protocol = []
+[package.metadata.docs.rs]
+all-features = true
 
-[badges]
-travis-ci = { repository = "getsentry/sentry-rust" }
+[features]
+default = ["protocol"]
+protocol = []
+# for backwards compatibility:
+with_protocol = ["protocol"]
+
 
 [dependencies]
 thiserror = "1.0.15"

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -21,7 +21,6 @@ protocol = []
 # for backwards compatibility:
 with_protocol = ["protocol"]
 
-
 [dependencies]
 thiserror = "1.0.15"
 serde = { version = "1.0.104", features = ["derive"] }

--- a/sentry-types/src/macros.rs
+++ b/sentry-types/src/macros.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "with_protocol"), allow(unused))]
+#![cfg_attr(not(feature = "protocol"), allow(unused))]
 
 /// Helper macro to implement string based serialization.
 ///

--- a/sentry-types/src/protocol/mod.rs
+++ b/sentry-types/src/protocol/mod.rs
@@ -1,13 +1,13 @@
 //! This module exposes the types for the Sentry protocol in different versions.
 
-#[cfg(feature = "with_protocol")]
+#[cfg(feature = "protocol")]
 pub mod v7;
 
 /// The latest version of the protocol.
 pub const LATEST: u16 = 7;
 
-/// the always latest sentry protocol version
-#[cfg(feature = "with_protocol")]
+/// The always latest sentry protocol version.
+#[cfg(feature = "protocol")]
 pub mod latest {
     pub use super::v7::*;
 }

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "with_protocol"), allow(unused))]
+#![cfg_attr(not(feature = "protocol"), allow(unused))]
 use chrono::{DateTime, LocalResult, TimeZone, Utc};
 
 /// Converts a datetime object into a float timestamp.

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Sentry <hello@sentry.io>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://github.com/getsentry/sentry-rust"
-documentation = "https://getsentry.github.io/sentry-rust"
+homepage = "https://sentry.io/welcome/"
 description = """
 Sentry (getsentry.com) client for rust ;)
 """
@@ -66,7 +65,7 @@ sentry-anyhow = { version = "0.18.0", path = "../sentry-anyhow", optional = true
 sentry-backtrace = { version = "0.18.0", path = "../sentry-backtrace", optional = true }
 sentry-contexts = { version = "0.18.0", path = "../sentry-contexts", optional = true }
 sentry-debug-images = { version = "0.18.0", path = "../sentry-debug-images", optional = true }
-sentry-error-chain = { version = "0.1.0", path = "../sentry-error-chain", optional = true }
+sentry-error-chain = { version = "0.18.0", path = "../sentry-error-chain", optional = true }
 sentry-failure = { version = "0.18.0", path = "../sentry-failure", optional = true }
 sentry-log = { version = "0.18.0", path = "../sentry-log", optional = true }
 sentry-panic = { version = "0.18.0", path = "../sentry-panic", optional = true }
@@ -81,6 +80,8 @@ httpdate = { version = "0.3.2", optional = true }
 serde_json = { version = "1.0.48", optional = true }
 
 [dev-dependencies]
+sentry-anyhow = { version = "0.18.0", path = "../sentry-anyhow" }
+sentry-error-chain = { version = "0.18.0", path = "../sentry-error-chain" }
 sentry-log = { version = "0.18.0", path = "../sentry-log", features = ["env_logger"] }
 log_ = { package = "log", version = "0.4.8", features = ["std"] }
 failure_derive = "0.1.6"
@@ -89,6 +90,4 @@ tokio = { version = "0.2", features = ["macros"] }
 failure_ = { package = "failure", version = "0.1.6" }
 pretty_env_logger = "0.4.0"
 error-chain_ = { package = "error-chain", version = "0.12.1" }
-sentry-error-chain = { version = "0.1.0", path = "../sentry-error-chain" }
-sentry-anyhow = { version = "0.18.0", path = "../sentry-anyhow" }
 anyhow_ = { package = "anyhow", version = "1.0.30" }

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -5,32 +5,7 @@
   <br />
 </p>
 
-# Sentry Rust
+# Sentry SDK for Rust
 
-[![Build Status](https://travis-ci.com/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.com/getsentry/sentry-rust)
-[![Crates.io](https://img.shields.io/crates/v/sentry.svg?style=flat)](https://crates.io/crates/sentry)
-
-This crate provides support for logging events and errors / panics to the
-[Sentry](https://sentry.io/) error logging service. It integrates with the
-standard panic system in Rust as well as a few popular error handling setups.
-
-**Note**: Until the _1.0_ release, the `sentry` crate is considered work in
-progress and does not follow semver semantics. Between minor releases, we might
-occasionally introduce breaking changes while we are exploring the best API and
-adding new features.
-
-## Requirements
-
-We currently only verify this crate against a recent version of Sentry hosted on
-[sentry.io](https://sentry.io/) but it should work with on-prem Sentry versions
-8.20 and later.
-
-Additionally, the lowest Rust version we target is _1.40.0_.
-
-## Resources
-
-- [crates.io](https://crates.io/crates/sentry)
-- [Documentation](https://getsentry.github.io/sentry-rust)
-- [Bug Tracker](https://github.com/getsentry/sentry-rust/issues)
-- [Discord](https://discord.gg/ez5KZN7) server for project discussions.
-- Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates
+This crate provides support for logging events and errors / panics to the [Sentry](https://sentry.io/) error logging
+service. It offers integrations for the standard panic system in Rust as well as a few popular error handling setups.

--- a/sentry/examples/anyhow-demo.rs
+++ b/sentry/examples/anyhow-demo.rs
@@ -6,13 +6,10 @@ fn execute() -> anyhow::Result<usize> {
 }
 
 fn main() {
-    let _sentry = sentry::init((
-        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            ..Default::default()
-        },
-    ));
+    let _sentry = sentry::init(sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    });
 
     if let Err(err) = execute() {
         println!("error: {}", err);

--- a/sentry/examples/before-send.rs
+++ b/sentry/examples/before-send.rs
@@ -2,9 +2,6 @@ use std::sync::Arc;
 
 fn main() {
     let _sentry = sentry::init(sentry::ClientOptions {
-        dsn: "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156"
-            .parse()
-            .ok(),
         before_send: Some(Arc::new(|mut event| {
             event.request = Some(sentry::protocol::Request {
                 url: Some("https://example.com/".parse().unwrap()),

--- a/sentry/examples/error-chain-demo.rs
+++ b/sentry/examples/error-chain-demo.rs
@@ -17,14 +17,13 @@ fn execute() -> Result<()> {
 }
 
 fn main() {
-    let _sentry = sentry::init((
-        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
+    let _sentry = sentry::init(
         sentry::ClientOptions {
             release: sentry::release_name!(),
             ..Default::default()
         }
         .add_integration(ErrorChainIntegration),
-    ));
+    );
 
     if let Err(err) = execute() {
         println!("error: {}", err);

--- a/sentry/examples/event-processors.rs
+++ b/sentry/examples/event-processors.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let _sentry = sentry::init("https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156");
+    let _sentry = sentry::init(());
 
     sentry::configure_scope(|scope| {
         scope.add_event_processor(Box::new(move |mut event| {

--- a/sentry/examples/failure-demo.rs
+++ b/sentry/examples/failure-demo.rs
@@ -18,13 +18,10 @@ fn execute() -> Result<(), failure::Error> {
 }
 
 fn main() {
-    let _sentry = sentry::init((
-        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            ..Default::default()
-        },
-    ));
+    let _sentry = sentry::init(sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    });
 
     if let Err(err) = execute() {
         println!("error: {}", err);

--- a/sentry/examples/log-demo.rs
+++ b/sentry/examples/log-demo.rs
@@ -6,14 +6,13 @@ fn main() {
     let log_integration =
         sentry_log::LogIntegration::default().with_env_logger_dest(Some(log_builder.build()));
 
-    let _sentry = sentry::init((
-        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
+    let _sentry = sentry::init(
         sentry::ClientOptions {
             release: sentry::release_name!(),
             ..Default::default()
         }
         .add_integration(log_integration),
-    ));
+    );
 
     debug!("System is booting");
     info!("System is booting");

--- a/sentry/examples/message-demo.rs
+++ b/sentry/examples/message-demo.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let _sentry = sentry::init("https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156");
+    let _sentry = sentry::init(());
     sentry::configure_scope(|scope| {
         scope.set_fingerprint(Some(["a-message"].as_ref()));
         scope.set_tag("foo", "bar");

--- a/sentry/examples/panic-demo.rs
+++ b/sentry/examples/panic-demo.rs
@@ -1,11 +1,8 @@
 fn main() {
-    let _sentry = sentry::init((
-        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            ..Default::default()
-        },
-    ));
+    let _sentry = sentry::init(sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    });
 
     {
         let _guard = sentry::Hub::current().push_scope();

--- a/sentry/examples/send-with-extra.rs
+++ b/sentry/examples/send-with-extra.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let _sentry = sentry::init("https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156");
+    let _sentry = sentry::init(());
 
     sentry::with_scope(
         |scope| {

--- a/sentry/examples/thread-demo.rs
+++ b/sentry/examples/thread-demo.rs
@@ -13,14 +13,13 @@ fn main() {
     // this initializes sentry.  It also gives the thread that calls this some
     // special behavior in that all other threads spawned will get a hub based on
     // the hub from here.
-    let _sentry = sentry::init((
-        "https://a94ae32be2584e0bbd7a4cbb95971fee@sentry.io/1041156",
+    let _sentry = sentry::init(
         sentry::ClientOptions {
             release: sentry::release_name!(),
             ..Default::default()
         }
         .add_integration(log_integration),
-    ));
+    );
 
     // the log integration sends to Hub::current()
     log::info!("Spawning thread");


### PR DESCRIPTION
* All the `Cargo.toml` files should have the same structure.
* README files should have the same structure.
* Streamline versions and dev-dependencies.
* Remove the DSN from the examples.