### PR TITLE
fix(debug-images): Compute correct DebugId for ELF images

### DIFF
--- a/sentry-debug-images/src/unix.rs
+++ b/sentry-debug-images/src/unix.rs
@@ -1,9 +1,37 @@
 use std::env;
 
-use findshlibs::{Segment, SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
 use sentry_core::protocol::debugid::DebugId;
 use sentry_core::protocol::{DebugImage, SymbolicDebugImage};
 use sentry_core::types::Uuid;
+
+use findshlibs::{Segment, SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
+
+const UUID_SIZE: usize = 16;
+
+/// Converts an ELF object identifier into a `DebugId`.
+///
+/// The identifier data is first truncated or extended to match 16 byte size of
+/// Uuids. If the data is declared in little endian, the first three Uuid fields
+/// are flipped to match the big endian expected by the breakpad processor.
+///
+/// The `DebugId::appendix` field is always `0` for ELF.
+fn debug_id_from_build_id(build_id: &[u8]) -> Option<DebugId> {
+    let mut data = [0 as u8; UUID_SIZE];
+    let len = build_id.len().min(UUID_SIZE);
+    data[0..len].copy_from_slice(&build_id[0..len]);
+
+    #[cfg(target_endian = "little")]
+    {
+        // The ELF file targets a little endian architecture. Convert to
+        // network byte order (big endian) to match the Breakpad processor's
+        // expectations. For big endian object files, this is not needed.
+        data[0..4].reverse(); // uuid field 1
+        data[4..6].reverse(); // uuid field 2
+        data[6..8].reverse(); // uuid field 3
+    }
+
+    Uuid::from_slice(&data).map(DebugId::from_uuid).ok()
+}
 
 pub fn debug_images() -> Vec<DebugImage> {
     let mut images = vec![];
@@ -14,7 +42,7 @@ pub fn debug_images() -> Vec<DebugImage> {
     TargetSharedLibrary::each(|shlib| {
         let maybe_debug_id = shlib.id().and_then(|id| match id {
             SharedLibraryId::Uuid(bytes) => Some(DebugId::from_uuid(Uuid::from_bytes(bytes))),
-            SharedLibraryId::GnuBuildId(ref id) => DebugId::from_guid_age(&id[..16], 0).ok(),
+            SharedLibraryId::GnuBuildId(ref id) => debug_id_from_build_id(id),
         });
 
         let debug_id = match maybe_debug_id {


### PR DESCRIPTION
This ports over the logic from [`symbolic`](https://github.com/getsentry/symbolic/blob/4d509d112f385daa1ec11a78e4b815e54b0dd3b6/debuginfo/src/elf.rs#L383) to compute `DebugId` from the GNU build identifier. This fixes two distinct bugs:

 1. A panic if the identifier is smaller than 16 bytes (Fixes https://github.com/getsentry/sentry-rust/issues/220)
 2. Incorrect endianness on big-endian targets.
