### PR TITLE
build(craft): Strip dev dependencies before publishing

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,6 +6,7 @@ changelogPolicy: auto
 
 targets:
   - name: crates
+    noDevDeps: true
   - name: gh-pages
   - name: github
   - name: registry

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: "0.10.0"
+minVersion: "0.10.1"
 github:
   owner: getsentry
   repo: sentry-rust


### PR DESCRIPTION
Configure craft to remove circular dev-dependencies before publishing the crate. This requires `cargo-hack` on the publishing system. 

Requires https://github.com/getsentry/craft/pull/112