### PR TITLE
Removed not existing feature from log crate that made methods not accessible

### DIFF
--- a/sentry-log/src/integration.rs
+++ b/sentry-log/src/integration.rs
@@ -62,7 +62,6 @@ impl Default for LogIntegration {
 
 impl LogIntegration {
     /// Initializes an env logger as destination target.
-    #[cfg(feature = "env_logger")]
     pub fn with_env_logger_dest(mut self, logger: Option<env_logger::Logger>) -> Self {
         let logger = logger
             .unwrap_or_else(|| env_logger::Builder::from_env(env_logger::Env::default()).build());


### PR DESCRIPTION
The method `with_env_logger_dest` is not accessible by public API because is behind a not existing feature.