### PR TITLE
feat: Add basic session support

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -24,6 +24,7 @@ test = ["client"]
 
 [dependencies]
 sentry-types = { version = "0.19.1", path = "../sentry-types" }
+serde = { version = "1.0.104", features = ["derive"] }
 lazy_static = "1.4.0"
 im = { version = "14.2.0", optional = true }
 rand = { version = "0.7.3", optional = true }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -1,6 +1,6 @@
 use crate::protocol::{Event, Level};
 use crate::types::Uuid;
-use crate::{Hub, Integration, IntoBreadcrumbs, Scope, SessionGuard};
+use crate::{Hub, Integration, IntoBreadcrumbs, Scope};
 
 /// Captures an event on the currently active client if any.
 ///
@@ -264,18 +264,21 @@ pub fn last_event_id() -> Option<Uuid> {
 
 /// Start a new session for Release Health.
 ///
-/// Returns a guard that ends the session on drop and thus determines the
-/// lifetime of the session.
-///
 /// # Examples
 ///
 /// ```
-/// let session = sentry::start_session();
+/// sentry::start_session();
 ///
-/// // capturing any event / error here will update the sessions `errors` count.
+/// // capturing any event / error here will update the sessions `errors` count,
+/// // up until we call `sentry::end_session`.
 ///
-/// drop(session);
+/// sentry::end_session();
 /// ```
-pub fn start_session() -> SessionGuard {
+pub fn start_session() {
     Hub::with_active(|hub| hub.start_session())
+}
+
+/// End the current Release Health Session.
+pub fn end_session() {
+    Hub::with_active(|hub| hub.end_session())
 }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -1,6 +1,6 @@
 use crate::protocol::{Event, Level};
 use crate::types::Uuid;
-use crate::{Hub, Integration, IntoBreadcrumbs, Scope};
+use crate::{Hub, Integration, IntoBreadcrumbs, Scope, SessionGuard};
 
 /// Captures an event on the currently active client if any.
 ///
@@ -264,15 +264,18 @@ pub fn last_event_id() -> Option<Uuid> {
 
 /// Start a new session for Release Health.
 ///
-/// This implicitly closes any previous session and starts recording a new
-/// session.
-pub fn start_session() {
-    Hub::with_active(|hub| hub.start_session())
-}
-
-/// Stop the current Release Health session.
+/// Returns a guard that ends the session on drop and thus determines the
+/// lifetime of the session.
 ///
-/// See [`start_session`](fn.start_session.html) for examples.
-pub fn end_session() {
-    Hub::with_active(|hub| hub.end_session())
+/// # Examples
+///
+/// ```
+/// let session = sentry::start_session();
+///
+/// // capturing any event / error here will update the sessions `errors` count.
+///
+/// drop(session);
+/// ```
+pub fn start_session() -> SessionGuard {
+    Hub::with_active(|hub| hub.start_session())
 }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -261,3 +261,18 @@ pub fn last_event_id() -> Option<Uuid> {
         Hub::with(|hub| hub.last_event_id())
     }}
 }
+
+/// Start a new session for Release Health.
+///
+/// This implicitly closes any previous session and starts recording a new
+/// session.
+pub fn start_session() {
+    Hub::with_active(|hub| hub.start_session())
+}
+
+/// Stop the current Release Health session.
+///
+/// See [`start_session`](fn.start_session.html) for examples.
+pub fn end_session() {
+    Hub::with_active(|hub| hub.end_session())
+}

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -264,6 +264,9 @@ pub fn last_event_id() -> Option<Uuid> {
 
 /// Start a new session for Release Health.
 ///
+/// This is still **experimental** for the moment and is not recommended to be
+/// used with a very high volume of sessions (_request-mode_ sessions).
+///
 /// # Examples
 ///
 /// ```

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -253,7 +253,7 @@ impl Client {
                         .lock()
                         .unwrap()
                         .as_mut()
-                        .and_then(|session| session.to_envelope_item())
+                        .and_then(|session| session.into_envelope_item())
                 });
                 if let Some(session_item) = session_item {
                     envelope.add(session_item);

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -253,7 +253,7 @@ impl Client {
                         .lock()
                         .unwrap()
                         .as_mut()
-                        .and_then(|session| session.into_envelope_item())
+                        .and_then(|session| session.create_envelope_item())
                 });
                 if let Some(session_item) = session_item {
                     envelope.add(session_item);

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -251,7 +251,7 @@ impl Client {
                     });
                     let mut envelope: Envelope = event.into();
                     if let Some(session) = session {
-                        envelope.add(session.into());
+                        envelope.add(session);
                     }
                     transport.send_envelope(envelope);
                     return event_id;

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -253,7 +253,6 @@ impl Client {
                     if let Some(session) = session {
                         envelope.add(session.into());
                     }
-                    //sentry_debug!("sending envelope {:#?}", envelope);
                     transport.send_envelope(envelope);
                     return event_id;
                 }

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -82,6 +82,12 @@ pub struct ClientOptions {
     /// The timeout on client drop for draining events on shutdown.
     pub shutdown_timeout: Duration,
     // Other options not documented in Unified API
+    /// Enable Release Health Session tracking.
+    ///
+    /// When automatic session tracking is enabled, as is the default, a new
+    /// "user-mode" session is started at the time of `sentry::init`, and will
+    /// persist for the application lifetime.
+    pub auto_session_tracking: bool,
     /// Border frames which indicate a border from a backtrace to
     /// useless internals. Some are automatically included.
     pub extra_border_frames: Vec<&'static str>,
@@ -147,6 +153,7 @@ impl fmt::Debug for ClientOptions {
             .field("http_proxy", &self.http_proxy)
             .field("https_proxy", &self.https_proxy)
             .field("shutdown_timeout", &self.shutdown_timeout)
+            .field("auto_session_tracking", &self.auto_session_tracking)
             .field("extra_border_frames", &self.extra_border_frames)
             .field("trim_backtraces", &self.trim_backtraces)
             .field("user_agent", &self.user_agent)
@@ -176,6 +183,7 @@ impl Default for ClientOptions {
             http_proxy: None,
             https_proxy: None,
             shutdown_timeout: Duration::from_secs(2),
+            auto_session_tracking: true,
             extra_border_frames: vec![],
             trim_backtraces: true,
             user_agent: Cow::Borrowed(&USER_AGENT),

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -84,9 +84,9 @@ pub struct ClientOptions {
     // Other options not documented in Unified API
     /// Enable Release Health Session tracking.
     ///
-    /// When automatic session tracking is enabled, as is the default, a new
-    /// "user-mode" session is started at the time of `sentry::init`, and will
-    /// persist for the application lifetime.
+    /// When automatic session tracking is enabled, a new "user-mode" session
+    /// is started at the time of `sentry::init`, and will persist for the
+    /// application lifetime.
     pub auto_session_tracking: bool,
     /// Border frames which indicate a border from a backtrace to
     /// useless internals. Some are automatically included.
@@ -183,7 +183,7 @@ impl Default for ClientOptions {
             http_proxy: None,
             https_proxy: None,
             shutdown_timeout: Duration::from_secs(2),
-            auto_session_tracking: true,
+            auto_session_tracking: false,
             extra_border_frames: vec![],
             trim_backtraces: true,
             user_agent: Cow::Borrowed(&USER_AGENT),

--- a/sentry-core/src/envelope.rs
+++ b/sentry-core/src/envelope.rs
@@ -46,8 +46,11 @@ impl Envelope {
         Default::default()
     }
 
-    pub(crate) fn add(&mut self, item: EnvelopeItem) {
-        self.items.push(item);
+    pub(crate) fn add<I>(&mut self, item: I)
+    where
+        I: Into<EnvelopeItem>,
+    {
+        self.items.push(item.into());
     }
 
     /// Returns the Envelopes Uuid, if any.

--- a/sentry-core/src/envelope.rs
+++ b/sentry-core/src/envelope.rs
@@ -20,12 +20,6 @@ impl From<Event<'static>> for EnvelopeItem {
     }
 }
 
-impl From<Session> for EnvelopeItem {
-    fn from(session: Session) -> Self {
-        EnvelopeItem::Session(session)
-    }
-}
-
 /// A Sentry Envelope.
 ///
 /// An Envelope is the data format that Sentry uses for Ingestion. It can contain

--- a/sentry-core/src/envelope.rs
+++ b/sentry-core/src/envelope.rs
@@ -1,14 +1,15 @@
 use std::io::Write;
 
 use crate::protocol::Event;
+use crate::session::Session;
 use crate::types::Uuid;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
-enum EnvelopeItem {
+pub(crate) enum EnvelopeItem {
     Event(Event<'static>),
+    Session(Session),
     // TODO:
-    // * Session,
     // * Attachment,
     // etc…
 }
@@ -16,6 +17,12 @@ enum EnvelopeItem {
 impl From<Event<'static>> for EnvelopeItem {
     fn from(event: Event<'static>) -> Self {
         EnvelopeItem::Event(event)
+    }
+}
+
+impl From<Session> for EnvelopeItem {
+    fn from(session: Session) -> Self {
+        EnvelopeItem::Session(session)
     }
 }
 
@@ -27,7 +34,7 @@ impl From<Event<'static>> for EnvelopeItem {
 ///
 /// See the [documentation on Envelopes](https://develop.sentry.dev/sdk/envelopes/)
 /// for more details.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug)]
 pub struct Envelope {
     event_id: Option<Uuid>,
     items: Vec<EnvelopeItem>,
@@ -39,6 +46,10 @@ impl Envelope {
         Default::default()
     }
 
+    pub(crate) fn add(&mut self, item: EnvelopeItem) {
+        self.items.push(item);
+    }
+
     /// Returns the Envelopes Uuid, if any.
     pub fn uuid(&self) -> Option<&Uuid> {
         self.event_id.as_ref()
@@ -48,12 +59,11 @@ impl Envelope {
     ///
     /// [`Event`]: protocol/struct.Event.html
     pub fn event(&self) -> Option<&Event<'static>> {
-        // until we actually add more items:
-        #[allow(clippy::unnecessary_filter_map)]
         self.items
             .iter()
             .filter_map(|item| match item {
                 EnvelopeItem::Event(event) => Some(event),
+                _ => None,
             })
             .next()
     }
@@ -77,14 +87,13 @@ impl Envelope {
         // write each item:
         for item in &self.items {
             // we write them to a temporary buffer first, since we need their length
-            serde_json::to_writer(
-                &mut item_buf,
-                match item {
-                    EnvelopeItem::Event(event) => event,
-                },
-            )?;
+            match item {
+                EnvelopeItem::Event(event) => serde_json::to_writer(&mut item_buf, event)?,
+                EnvelopeItem::Session(session) => serde_json::to_writer(&mut item_buf, session)?,
+            }
             let item_type = match item {
                 EnvelopeItem::Event(_) => "event",
+                EnvelopeItem::Session(_) => "session",
             };
             writeln!(
                 writer,
@@ -113,6 +122,7 @@ impl From<Event<'static>> for Envelope {
 #[cfg(test)]
 mod test {
     use super::*;
+
     fn to_buf(envelope: Envelope) -> Vec<u8> {
         let mut vec = Vec::new();
         envelope.to_writer(&mut vec).unwrap();

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -340,7 +340,7 @@ impl Hub {
                 let top = stack.top_mut();
                 if let Some(mut session) = top.scope.session.lock().unwrap().take() {
                     session.close();
-                    if let Some(item) = session.into_envelope_item() {
+                    if let Some(item) = session.create_envelope_item() {
                         let mut envelope = Envelope::new();
                         envelope.add(item);
                         if let Some(ref client) = top.client {

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -64,6 +64,7 @@ mod hub;
 mod integration;
 mod intodsn;
 mod scope;
+mod session;
 mod transport;
 
 // public api or exports from this crate

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -77,7 +77,7 @@ pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
-pub use crate::scope::{Scope, ScopeGuard, SessionGuard};
+pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 
 // deprecated exports

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -77,7 +77,7 @@ pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
-pub use crate::scope::{Scope, ScopeGuard};
+pub use crate::scope::{Scope, ScopeGuard, SessionGuard};
 pub use crate::transport::{Transport, TransportFactory};
 
 // deprecated exports

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -2,19 +2,6 @@ use std::fmt;
 
 use crate::protocol::{Context, Event, Level, User, Value};
 
-/// A minimal API session guard.
-///
-/// Doesn't do anything but can be debug formatted.
-#[derive(Default)]
-#[must_use = "The duration of the Session from start to end is defined by the lifetime of this guard."]
-pub struct SessionGuard;
-
-impl fmt::Debug for SessionGuard {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SessionGuard")
-    }
-}
-
 /// A minimal API scope guard.
 ///
 /// Doesn't do anything but can be debug formatted.

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -2,12 +2,18 @@ use std::fmt;
 
 use crate::protocol::{Context, Event, Level, User, Value};
 
-/// The minimal scope.
+/// A minimal API session guard.
 ///
-/// In minimal API mode all modification functions are available as normally
-/// just that generally calling them is impossible.
-#[derive(Debug, Clone)]
-pub struct Scope;
+/// Doesn't do anything but can be debug formatted.
+#[derive(Default)]
+#[must_use = "The duration of the Session from start to end is defined by the lifetime of this guard."]
+pub struct SessionGuard;
+
+impl fmt::Debug for SessionGuard {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SessionGuard")
+    }
+}
 
 /// A minimal API scope guard.
 ///
@@ -20,6 +26,13 @@ impl fmt::Debug for ScopeGuard {
         write!(f, "ScopeGuard")
     }
 }
+
+/// The minimal scope.
+///
+/// In minimal API mode all modification functions are available as normally
+/// just that generally calling them is impossible.
+#[derive(Debug, Clone)]
+pub struct Scope;
 
 impl Scope {
     /// Clear the scope.

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 use std::fmt;
-use std::sync::{Arc, PoisonError, RwLock};
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
 use crate::protocol::{Breadcrumb, Context, Event, Level, User, Value};
-use crate::Client;
+use crate::session::{Session, SessionUpdate};
+use crate::{Client, Envelope};
 
 #[derive(Debug)]
 pub struct Stack {
@@ -41,6 +42,7 @@ pub struct Scope {
     pub(crate) tags: im::HashMap<String, String>,
     pub(crate) contexts: im::HashMap<String, Context>,
     pub(crate) event_processors: im::Vector<Arc<EventProcessor>>,
+    pub(crate) session: Option<Arc<Mutex<Session>>>,
 }
 
 impl fmt::Debug for Scope {
@@ -55,6 +57,7 @@ impl fmt::Debug for Scope {
             .field("tags", &self.tags)
             .field("contexts", &self.contexts)
             .field("event_processors", &self.event_processors.len())
+            .field("session", &self.session)
             .finish()
     }
 }
@@ -71,6 +74,7 @@ impl Default for Scope {
             tags: Default::default(),
             contexts: Default::default(),
             event_processors: Default::default(),
+            session: None,
         }
     }
 }
@@ -89,15 +93,19 @@ impl Stack {
     }
 
     pub fn push(&mut self) {
-        let scope = self.layers[self.layers.len() - 1].clone();
-        self.layers.push(scope);
+        let mut layer = self.layers[self.layers.len() - 1].clone();
+        // don’t clone the session itself, it should only be on one layer, so
+        // that `end`-ing it works correctly.
+        let mut scope = Arc::make_mut(&mut layer.scope);
+        scope.session = None;
+        self.layers.push(layer);
     }
 
-    pub fn pop(&mut self) {
+    pub fn pop(&mut self) -> Option<StackLayer> {
         if self.layers.len() <= 1 {
             panic!("Pop from empty stack");
         }
-        self.layers.pop().unwrap();
+        self.layers.pop()
     }
 
     pub fn top(&self) -> &StackLayer {
@@ -136,7 +144,21 @@ impl Drop for ScopeGuard {
             if stack.depth() != depth {
                 panic!("Tried to pop guards out of order");
             }
-            stack.pop();
+            let mut layer = stack.pop().unwrap();
+            (|| {
+                let scope = Arc::make_mut(&mut layer.scope);
+                let mut session = Arc::try_unwrap(scope.session.take()?)
+                    .ok()?
+                    .into_inner()
+                    .ok()?;
+                let client = layer.client.as_ref()?;
+
+                session.close();
+                let mut envelope = Envelope::new();
+                envelope.add(session.into());
+                client.capture_envelope(envelope);
+                None::<()>
+            })();
         }
     }
 }
@@ -256,5 +278,13 @@ impl Scope {
         }
 
         Some(event)
+    }
+
+    pub(crate) fn update_session_from_event(&self, event: &Event<'static>) -> SessionUpdate {
+        if let Some(session) = &self.session {
+            session.lock().unwrap().update_from_event(event)
+        } else {
+            SessionUpdate::Unchanged
+        }
     }
 }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -140,7 +140,7 @@ impl Drop for SessionGuard {
             if let Some(session) = scope.session.lock().unwrap().take() {
                 if let SessionUpdate::NeedsFlushing(session) = session.close() {
                     let mut envelope = Envelope::new();
-                    envelope.add(session.into());
+                    envelope.add(session);
                     client.capture_envelope(envelope);
                 }
             }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
 use crate::protocol::{Breadcrumb, Context, Event, Level, User, Value};
 use crate::session::Session;
-use crate::{Client, Envelope};
+use crate::Client;
 
 #[derive(Debug)]
 pub struct Stack {
@@ -115,37 +115,6 @@ impl Stack {
 
     pub fn depth(&self) -> usize {
         self.layers.len()
-    }
-}
-
-/// A session guard.
-///
-/// This is returned from [`Hub::start_session`] and will automatically end the
-/// newly created session on drop.
-///
-/// [`Hub::start_session`]: struct.Hub.html#method.start_session
-#[derive(Default)]
-#[must_use = "The duration of the Session from start to end is defined by the lifetime of this guard."]
-pub struct SessionGuard(pub(crate) Option<(Arc<Client>, Arc<Scope>)>);
-
-impl fmt::Debug for SessionGuard {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SessionGuard")
-    }
-}
-
-impl Drop for SessionGuard {
-    fn drop(&mut self) {
-        if let Some((client, scope)) = self.0.take() {
-            if let Some(mut session) = scope.session.lock().unwrap().take() {
-                session.close();
-                if let Some(item) = session.to_envelope_item() {
-                    let mut envelope = Envelope::new();
-                    envelope.add(item);
-                    client.capture_envelope(envelope);
-                }
-            }
-        }
     }
 }
 

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::protocol::{Event, Level, User};
 use crate::scope::StackLayer;
@@ -35,7 +35,7 @@ pub struct Session {
     environment: Option<Cow<'static, str>>,
     started: Instant,
     started_utc: DateTime<Utc>,
-    duration: Option<f64>,
+    duration: Option<Duration>,
     init: bool,
     dirty: bool,
 }
@@ -96,7 +96,7 @@ impl Session {
 
     pub(crate) fn close(mut self) -> SessionUpdate {
         if self.status == SessionStatus::Ok {
-            self.duration = Some(self.started.elapsed().as_secs_f64());
+            self.duration = Some(self.started.elapsed());
             self.status = SessionStatus::Exited;
             SessionUpdate::NeedsFlushing(self)
         } else {
@@ -146,7 +146,7 @@ impl serde::Serialize for Session {
         session.serialize_field("started", &self.started_utc)?;
 
         if let Some(duration) = self.duration {
-            session.serialize_field("duration", &duration)?;
+            session.serialize_field("duration", &duration.as_secs_f64())?;
         } else {
             session.skip_field("duration")?;
         }

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -2,15 +2,13 @@
 //!
 //! https://develop.sentry.dev/sdk/sessions/
 
-use std::fmt;
-use std::{borrow::Cow, sync::Arc, time::Instant};
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::time::Instant;
 
-use crate::protocol::{Event, Level};
-use crate::{
-    scope::StackLayer,
-    types::{DateTime, Utc, Uuid},
-};
-use sentry_types::protocol::v7::User;
+use crate::protocol::{Event, Level, User};
+use crate::scope::StackLayer;
+use crate::types::{DateTime, Utc, Uuid};
 
 /// Represents the status of a session.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -66,7 +64,7 @@ impl Session {
         for exc in &event.exception.values {
             has_error = true;
             if let Some(mechanism) = &exc.mechanism {
-                if matches!(mechanism.handled, Some(false)) {
+                if let Some(false) = mechanism.handled {
                     is_crash = true;
                     break;
                 }

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -1,0 +1,231 @@
+//! Release Health Sessions
+//!
+//! https://develop.sentry.dev/sdk/sessions/
+
+use std::fmt;
+use std::{borrow::Cow, sync::Arc, time::Instant};
+
+use crate::protocol::{Event, Level};
+use crate::{
+    scope::StackLayer,
+    types::{DateTime, Utc, Uuid},
+};
+use sentry_types::protocol::v7::User;
+
+/// Represents the status of a session.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SessionStatus {
+    Ok,
+    Crashed,
+    #[allow(dead_code)]
+    Abnormal,
+    Exited,
+}
+
+pub enum SessionUpdate {
+    NeedsFlushing(Session),
+    Unchanged,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Session {
+    session_id: Uuid,
+    status: SessionStatus,
+    errors: usize,
+    user: Option<Arc<User>>,
+    release: Cow<'static, str>,
+    environment: Option<Cow<'static, str>>,
+    started: Instant,
+    started_utc: DateTime<Utc>,
+    duration: Option<f64>,
+    init: bool,
+    dirty: bool,
+}
+
+impl Session {
+    pub fn from_stack(stack: &StackLayer) -> Option<Self> {
+        let options = stack.client.as_ref()?.options();
+        Some(Self {
+            session_id: Uuid::new_v4(),
+            status: SessionStatus::Ok,
+            errors: 0,
+            user: stack.scope.user.clone(),
+            release: options.release.clone()?,
+            environment: options.environment.clone(),
+            started: Instant::now(),
+            started_utc: Utc::now(),
+            duration: None,
+            init: true,
+            dirty: true,
+        })
+    }
+
+    pub(crate) fn update_from_event(&mut self, event: &Event<'static>) -> SessionUpdate {
+        let mut has_error = event.level >= Level::Error;
+        let mut is_crash = false;
+        for exc in &event.exception.values {
+            has_error = true;
+            if let Some(mechanism) = &exc.mechanism {
+                if matches!(mechanism.handled, Some(false)) {
+                    is_crash = true;
+                    break;
+                }
+            }
+        }
+
+        if is_crash {
+            self.status = SessionStatus::Crashed;
+        }
+        if has_error {
+            self.errors += 1;
+            self.dirty = true;
+        }
+
+        if self.dirty {
+            self.dirty = false;
+            let session = self.clone();
+            self.init = false;
+            SessionUpdate::NeedsFlushing(session)
+        } else {
+            SessionUpdate::Unchanged
+        }
+    }
+
+    pub(crate) fn close(&mut self) {
+        self.duration = Some(self.started.elapsed().as_secs_f64());
+        if self.status == SessionStatus::Ok {
+            self.status = SessionStatus::Exited;
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct Attrs {
+    release: Cow<'static, str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    environment: Option<Cow<'static, str>>,
+}
+
+impl serde::Serialize for Session {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut session = serializer.serialize_struct("Session", 8)?;
+        session.serialize_field("sid", &self.session_id)?;
+        let did = self.user.as_ref().and_then(|user| {
+            user.id
+                .as_ref()
+                .or_else(|| user.email.as_ref())
+                .or_else(|| user.username.as_ref())
+        });
+        if let Some(did) = did {
+            session.serialize_field("did", &did)?;
+        } else {
+            session.skip_field("did")?;
+        }
+
+        session.serialize_field(
+            "status",
+            match self.status {
+                SessionStatus::Ok => "ok",
+                SessionStatus::Crashed => "crashed",
+                SessionStatus::Abnormal => "abnormal",
+                SessionStatus::Exited => "exited",
+            },
+        )?;
+        session.serialize_field("errors", &self.errors)?;
+        session.serialize_field("started", &self.started_utc)?;
+
+        if let Some(duration) = self.duration {
+            session.serialize_field("duration", &duration)?;
+        } else {
+            session.skip_field("duration")?;
+        }
+        if self.init {
+            session.serialize_field("init", &true)?;
+        } else {
+            session.skip_field("init")?;
+        }
+
+        session.serialize_field(
+            "attrs",
+            &Attrs {
+                release: self.release.clone(),
+                environment: self.environment.clone(),
+            },
+        )?;
+
+        session.end()
+    }
+}
+
+#[cfg(all(test, feature = "test"))]
+mod tests {
+    use crate as sentry;
+    use crate::test::with_captured_envelopes_options;
+    use crate::{ClientOptions, Envelope};
+
+    fn to_buf(envelope: &Envelope) -> Vec<u8> {
+        let mut vec = Vec::new();
+        envelope.to_writer(&mut vec).unwrap();
+        vec
+    }
+    fn to_str(envelope: &Envelope) -> String {
+        String::from_utf8(to_buf(envelope)).unwrap()
+    }
+
+    #[test]
+    fn test_session_startstop() {
+        let envelopes = with_captured_envelopes_options(
+            || {
+                sentry::start_session();
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                sentry::end_session();
+            },
+            ClientOptions {
+                release: Some("some-release".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(envelopes.len(), 1);
+
+        let body = to_str(&envelopes[0]);
+        assert!(body.starts_with("{}\n{\"type\":\"session\","));
+        assert!(body.contains(r#""attrs":{"release":"some-release"}"#));
+        assert!(body.contains(r#""status":"exited","errors":0"#));
+        assert!(body.contains(r#""init":true"#));
+    }
+
+    #[test]
+    fn test_session_error() {
+        let envelopes = with_captured_envelopes_options(
+            || {
+                sentry::start_session();
+
+                let err = "NaN".parse::<usize>().unwrap_err();
+                sentry::capture_error(&err);
+
+                sentry::end_session();
+            },
+            ClientOptions {
+                release: Some("some-release".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(envelopes.len(), 2);
+
+        let body = to_str(&envelopes[0]);
+        assert!(body.contains("{\"type\":\"session\","));
+        assert!(body.contains(r#""attrs":{"release":"some-release"}"#));
+        assert!(body.contains(r#""status":"ok","errors":1"#));
+        assert!(body.contains(r#""init":true"#));
+
+        let body = to_str(&envelopes[1]);
+        assert!(body.contains("{\"type\":\"session\","));
+        assert!(body.contains(r#""status":"exited","errors":1"#));
+        assert!(!body.contains(r#""init":true"#));
+    }
+}

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -44,7 +44,7 @@ pub struct Session {
 impl Drop for Session {
     fn drop(&mut self) {
         self.close();
-        if let Some(item) = self.into_envelope_item() {
+        if let Some(item) = self.create_envelope_item() {
             let mut envelope = Envelope::new();
             envelope.add(item);
             self.client.capture_envelope(envelope);
@@ -107,7 +107,7 @@ impl Session {
         }
     }
 
-    pub(crate) fn into_envelope_item(&mut self) -> Option<EnvelopeItem> {
+    pub(crate) fn create_envelope_item(&mut self) -> Option<EnvelopeItem> {
         if self.dirty {
             let item = EnvelopeItem::Session(self.clone());
             self.init = false;

--- a/sentry/examples/health.rs
+++ b/sentry/examples/health.rs
@@ -11,12 +11,12 @@ fn main() {
 
     let handle = std::thread::spawn(|| {
         // this session will be set to crashed
-        let _session = sentry::start_session();
+        sentry::start_session();
         std::thread::sleep(std::time::Duration::from_secs(3));
         panic!("oh no!");
     });
 
-    let session = sentry::start_session();
+    sentry::start_session();
 
     sentry::capture_message(
         "anything with a level >= Error will increase the error count",
@@ -31,7 +31,7 @@ fn main() {
 
     // this session will have an error count of 2, but otherwise have
     // a clean exit.
-    drop(session);
+    sentry::end_session();
 
     handle.join().ok();
 }

--- a/sentry/examples/health.rs
+++ b/sentry/examples/health.rs
@@ -1,0 +1,34 @@
+fn main() {
+    let _sentry = sentry::init(sentry::ClientOptions {
+        // release health requires a session to be set
+        release: sentry::release_name!(),
+        debug: true,
+        ..Default::default()
+    });
+
+    let handle = std::thread::spawn(|| {
+        // this session will be set to crashed
+        sentry::start_session();
+        std::thread::sleep(std::time::Duration::from_secs(3));
+        panic!("oh no!");
+    });
+
+    sentry::start_session();
+
+    sentry::capture_message(
+        "anything with a level >= Error will increase the error count",
+        sentry::Level::Error,
+    );
+
+    // or any error that has an explicit exception attached
+    let err = "NaN".parse::<usize>().unwrap_err();
+    sentry::capture_error(&err);
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // so this session will increase the errors count by 2, but otherwise has
+    // a clean exit.
+    sentry::end_session();
+
+    handle.join().ok();
+}

--- a/sentry/src/init.rs
+++ b/sentry/src/init.rs
@@ -2,14 +2,15 @@ use std::sync::Arc;
 
 use sentry_core::sentry_debug;
 
-use crate::{defaults::apply_defaults, Client, ClientOptions, Hub};
+use crate::defaults::apply_defaults;
+use crate::{Client, ClientOptions, Hub, SessionGuard};
 
 /// Helper struct that is returned from `init`.
 ///
 /// When this is dropped events are drained with a 1 second timeout.
 #[must_use = "when the init guard is dropped the transport will be shut down and no further \
               events can be sent.  If you do want to ignore this use mem::forget on it."]
-pub struct ClientInitGuard(Arc<Client>);
+pub struct ClientInitGuard(Arc<Client>, Option<SessionGuard>);
 
 impl std::ops::Deref for ClientInitGuard {
     type Target = Client;
@@ -32,6 +33,8 @@ impl Drop for ClientInitGuard {
         } else {
             sentry_debug!("dropping client guard (no client to dispose)");
         }
+        // end any session that might be open before closing the client
+        drop(self.1.take());
         self.0.close(None);
     }
 }
@@ -88,6 +91,7 @@ where
     C: Into<ClientOptions>,
 {
     let opts = apply_defaults(opts.into());
+    let auto_session_tracking = opts.auto_session_tracking;
     let client = Arc::new(Client::from(opts));
 
     Hub::with(|hub| hub.bind_client(Some(client.clone())));
@@ -96,5 +100,10 @@ where
     } else {
         sentry_debug!("initialized disabled sentry client due to disabled or invalid DSN");
     }
-    ClientInitGuard(client)
+    let session = if auto_session_tracking {
+        Some(crate::start_session())
+    } else {
+        None
+    };
+    ClientInitGuard(client, session)
 }

--- a/sentry/src/transport.rs
+++ b/sentry/src/transport.rs
@@ -225,7 +225,6 @@ implement_http_transport! {
                     let mut body = Vec::new();
                     envelope.to_writer(&mut body).unwrap();
 
-                    sentry_debug!("sending to \"{}\"", url);
                     match http_client
                         .post(url.as_str())
                         .body(body)
@@ -233,7 +232,6 @@ implement_http_transport! {
                         .send()
                     {
                         Ok(resp) => {
-                            sentry_debug!("got response {} {:#?}", resp.status(), resp.headers());
                             if resp.status() == 429 {
                                 if let Some(retry_after) = resp
                                     .headers()
@@ -244,7 +242,6 @@ implement_http_transport! {
                                     disabled = Some(retry_after);
                                 }
                             }
-                            sentry_debug!("{}", resp.text().unwrap());
                         }
                         Err(err) => {
                             sentry_debug!("Failed to send event: {}", err);

--- a/sentry/src/transport.rs
+++ b/sentry/src/transport.rs
@@ -225,6 +225,7 @@ implement_http_transport! {
                     let mut body = Vec::new();
                     envelope.to_writer(&mut body).unwrap();
 
+                    sentry_debug!("sending to \"{}\"", url);
                     match http_client
                         .post(url.as_str())
                         .body(body)
@@ -232,6 +233,7 @@ implement_http_transport! {
                         .send()
                     {
                         Ok(resp) => {
+                            sentry_debug!("got response {} {:#?}", resp.status(), resp.headers());
                             if resp.status() == 429 {
                                 if let Some(retry_after) = resp
                                     .headers()
@@ -242,6 +244,7 @@ implement_http_transport! {
                                     disabled = Some(retry_after);
                                 }
                             }
+                            sentry_debug!("{}", resp.text().unwrap());
                         }
                         Err(err) => {
                             sentry_debug!("Failed to send event: {}", err);


### PR DESCRIPTION
This adds release health sessions to the SDK, with some things that require special attention:

* sessions live on the scope.
* sessions are forward-inherited, which means that creating a new Hub from another one, and pushing scopes will use the exact same session.
* however, sessions are not backward-inherited, which means that starting a new session will not propagate backwards to any parent scopes/hubs.

So far, intermediate session updates are sent along with normal events, however session end updates are sent on their own and not yet batched together. This means that request-mode sessions are not yet as efficient as we would like them to be.