### PR TITLE
fix: Deal with concurrent hub access better

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -11,7 +11,7 @@ use rand::random;
 use crate::constants::SDK_INFO;
 use crate::protocol::{ClientSdkInfo, Event};
 use crate::types::{Dsn, Uuid};
-use crate::{ClientOptions, Integration, Scope, Transport};
+use crate::{ClientOptions, Hub, Integration, Scope, Transport};
 
 impl<T: Into<ClientOptions>> From<T> for Client {
     fn from(o: T) -> Client {
@@ -93,6 +93,10 @@ impl Client {
     /// If the DSN on the options is set to `None` the client will be entirely
     /// disabled.
     pub fn with_options(mut options: ClientOptions) -> Client {
+        // Create the main hub eagerly to avoid problems with the background thread
+        // See https://github.com/getsentry/sentry-rust/issues/237
+        Hub::with(|_| {});
+
         let create_transport = || {
             options.dsn.as_ref()?;
             let factory = options.transport.as_ref()?;

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -52,10 +52,12 @@ impl HubImpl {
             Err(err) => err.into_inner(),
             Ok(guard) => guard,
         };
-        if let Some(client) = guard.top().client.as_ref() {
-            return client.is_enabled();
-        }
-        false
+
+        guard
+            .top()
+            .client
+            .as_ref()
+            .map_or(false, |c| c.is_enabled())
     }
 }
 

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -48,12 +48,14 @@ impl HubImpl {
     }
 
     fn is_active_and_usage_safe(&self) -> bool {
-        let guard = match self.stack.try_read() {
-            Err(TryLockError::Poisoned(err)) => err.into_inner(),
-            Err(TryLockError::WouldBlock) => return false,
+        let guard = match self.stack.read() {
+            Err(err) => err.into_inner(),
             Ok(guard) => guard,
         };
-        guard.top().client.is_some()
+        if let Some(client) = guard.top().client.as_ref() {
+            return client.is_enabled();
+        }
+        false
     }
 }
 

--- a/sentry-log/src/integration.rs
+++ b/sentry-log/src/integration.rs
@@ -43,8 +43,7 @@ impl Integration for LogIntegration {
         }
 
         INIT.call_once(|| {
-            // silently ignore errors here, as running tests will hit this condition for some reason.
-            log::set_boxed_logger(Box::new(Logger::default())).ok();
+            log::set_boxed_logger(Box::new(Logger::default())).unwrap();
         });
     }
 }

--- a/sentry-log/src/integration.rs
+++ b/sentry-log/src/integration.rs
@@ -43,7 +43,7 @@ impl Integration for LogIntegration {
         }
 
         INIT.call_once(|| {
-            log::set_boxed_logger(Box::new(Logger::default())).unwrap();
+            log::set_boxed_logger(Box::new(Logger::default())).ok();
         });
     }
 }


### PR DESCRIPTION
This should fix #237, and we should backport this to 0.19 as well.