### PR TITLE
Make contexts::utils public

### DIFF
--- a/sentry-contexts/src/lib.rs
+++ b/sentry-contexts/src/lib.rs
@@ -23,6 +23,8 @@
 #![warn(missing_docs)]
 
 mod integration;
-mod utils;
+/// Contains functions to retrieve various contexts that can be useful
+/// to attach to events
+pub mod utils;
 
 pub use integration::ContextIntegration;


### PR DESCRIPTION
0.19.0 made the utility functions in context private, but they were quite useful when using `sentry-contrib-native` to get the same information as the Rust SDK eg.

```rust
if let sentry::protocol::Context::Device(dev) =
    sentry::integrations::contexts::utils::device_context()
{
    let mut dev_ctx = Vec::new();

    ser!(dev_ctx, dev, [name, family, model, model_id, arch]);
    dev_ctx.push(("type", "device"));

    sentry_native::set_context("device", dev_ctx);
}
```