### PR TITLE
feat: Add per-request sessions to actix integration

### DIFF
--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -26,4 +26,4 @@ sentry = { version = "0.19.1", path = "../sentry", default-features = false }
 sentry-failure = { version = "0.19.1", path = "../sentry-failure" }
 actix-web = { version = "0.7", default-features = false }
 failure = "0.1.3"
-fragile = "0.3.0"
+fragile = "1.0.0"

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -1,20 +1,32 @@
-use std::env;
-use std::io;
-
 use actix_web::{server, App, Error, HttpRequest};
 use sentry_actix::SentryMiddleware;
 
 fn failing(_req: &HttpRequest) -> Result<String, Error> {
-    Err(io::Error::new(io::ErrorKind::Other, "Something went really wrong here").into())
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "Something went really wrong here",
+    )
+    .into())
 }
 
+const USE_REQUEST_MODE_SESSIONS: bool = true;
+
 fn main() {
-    let _guard = sentry::init(());
-    env::set_var("RUST_BACKTRACE", "1");
+    let _guard = sentry::init(sentry::ClientOptions {
+        release: sentry::release_name!(),
+        auto_session_tracking: !USE_REQUEST_MODE_SESSIONS,
+        ..Default::default()
+    });
+    std::env::set_var("RUST_BACKTRACE", "1");
 
     server::new(|| {
+        let middleware = SentryMiddleware::builder()
+            .emit_header(true)
+            .track_session(USE_REQUEST_MODE_SESSIONS)
+            .finish();
+
         App::new()
-            .middleware(SentryMiddleware::builder().emit_header(true).finish())
+            .middleware(middleware)
             .resource("/", |r| r.f(failing))
     })
     .bind("127.0.0.1:3001")


### PR DESCRIPTION
Built on top of #240 , this has to be opt-in for now, as the actix middleware currently has no way to disable the *user-mode* session which is now the default on the main Hub.