### PR TITLE
Add scope.clear_breadcrumbs()

### DIFF
--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -155,6 +155,11 @@ impl Scope {
         *self = Default::default();
     }
 
+    /// Deletes current breadcrumbs from the scope.
+    pub fn clear_breadcrumbs(&mut self) {
+        self.breadcrumbs.clear();
+    }
+
     /// Sets a level override.
     pub fn set_level(&mut self, level: Option<Level>) {
         self.level = level;

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -32,6 +32,12 @@ fn test_breadcrumbs() {
     let events = sentry::test::with_captured_events(|| {
         sentry::add_breadcrumb(|| sentry::Breadcrumb {
             ty: "log".into(),
+            message: Some("Old breadcrumb to be removed".into()),
+            ..Default::default()
+        });
+        sentry::configure_scope(|scope| scope.clear_breadcrumbs());
+        sentry::add_breadcrumb(|| sentry::Breadcrumb {
+            ty: "log".into(),
             message: Some("First breadcrumb".into()),
             ..Default::default()
         });


### PR DESCRIPTION
The [Unified API](https://develop.sentry.dev/sdk/unified-api/) docs specify a function on the scope for clearing all current breadcrumbs. This is an implementation of that.