### PR TITLE
ref: Remove deprecated feature flags and items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+**Breaking Changes**:
+
+- Removed all deprecated exports and deprecated feature flags.
+
+**Deprecations**:
+
+- The `error_chain` integration was officialy deprecated and will be removed soon.
+
 ## 0.20.1
 
 **Fixes**:
@@ -74,7 +84,7 @@ Additionally, sentry can now be extended via `Integration`s.
 **Deprecations**:
 
 - The `internals` module is deprecated. Please `use` items from the crate root or the `types` module instead.
-- All the feature flags have been renamed, the old names are still available but
+- All the feature flags have been renamed, the old names are still available but will be removed in the future.
 
 ## 0.18.1
 

--- a/sentry-backtrace/src/trim.rs
+++ b/sentry-backtrace/src/trim.rs
@@ -9,6 +9,7 @@ lazy_static::lazy_static! {
         "alloc::",
         "backtrace::",
         "sentry::",
+        "sentry_core::",
         "sentry_types::",
         // these are not modules but things like __rust_maybe_catch_panic
         "__rust_",
@@ -20,6 +21,7 @@ lazy_static::lazy_static! {
         "core::panicking::panic",
     ];
 
+    // TODO: remove all of this together with the deprecated `error_chain` support
     static ref SECONDARY_BORDER_FRAMES: Vec<(&'static str, &'static str)> = vec![
         ("error_chain::make_backtrace", "<T as core::convert::Into<U>>::into")
     ];

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -78,12 +78,6 @@ pub use crate::intodsn::IntoDsn;
 pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 
-// deprecated exports
-#[deprecated = "The export was renamed to `SentryFuture`"]
-pub use crate::futures::SentryFuture as Future;
-#[deprecated = "The export was renamed to `SentryFutureExt`"]
-pub use crate::futures::SentryFutureExt as FutureExt;
-
 // client feature
 #[cfg(feature = "client")]
 mod client;

--- a/sentry-error-chain/src/lib.rs
+++ b/sentry-error-chain/src/lib.rs
@@ -27,6 +27,7 @@
 #![doc(html_logo_url = "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png")]
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
+#![allow(deprecated)]
 
 use std::fmt::{Debug, Display};
 
@@ -64,6 +65,7 @@ where
 }
 
 /// Creates an event from an error chain.
+#[deprecated = "The `error_chain` integration is deprecated and will be removed in the future."]
 pub fn event_from_error_chain<T>(e: &T) -> Event<'static>
 where
     T: ChainedError,
@@ -77,6 +79,7 @@ where
 }
 
 /// Captures an error chain.
+#[deprecated = "The `error_chain` integration is deprecated and will be removed in the future."]
 pub fn capture_error_chain<T>(e: &T) -> Uuid
 where
     T: ChainedError,
@@ -86,6 +89,7 @@ where
 }
 
 /// Hub extension methods for working with error chain
+#[deprecated = "The `error_chain` integration is deprecated and will be removed in the future."]
 pub trait ErrorChainHubExt {
     /// Captures an error chain on a specific hub.
     fn capture_error_chain<T>(&self, e: &T) -> Uuid
@@ -106,6 +110,7 @@ impl ErrorChainHubExt for Hub {
 
 /// The Sentry `error-chain` Integration.
 #[derive(Default)]
+#[deprecated = "The `error_chain` integration is deprecated and will be removed in the future."]
 pub struct ErrorChainIntegration;
 
 impl ErrorChainIntegration {

--- a/sentry-types/src/auth.rs
+++ b/sentry-types/src/auth.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports, deprecated)]
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -41,25 +41,6 @@ surf = ["surf_", "httpdate", "http-client", "futures"]
 native-tls = ["reqwest_/default-tls"]
 rustls = ["reqwest_/rustls-tls"]
 
-# deprecated feature flags, here for backwards compatibility, will be removed
-# at some point
-with_client_implementation = []
-with_backtrace = ["backtrace"]
-with_failure = ["failure"]
-with_panic = ["panic"]
-with_error_chain = ["error-chain"]
-with_debug_to_log = ["debug-logs"]
-with_test_support = ["test"]
-with_debug_meta = ["debug-images"]
-with_device_info = ["contexts"]
-with_rust_info = ["contexts"]
-with_default_transport = ["transport"]
-with_reqwest_transport = ["reqwest"]
-with_curl_transport = ["curl"]
-with_surf_transport = ["surf"]
-with_native_tls = ["native-tls"]
-with_rustls = ["rustls"]
-
 [dependencies]
 sentry-core = { version = "0.20.1", path = "../sentry-core", features = ["client"] }
 sentry-anyhow = { version = "0.20.1", path = "../sentry-anyhow", optional = true }

--- a/sentry/examples/error-chain-demo.rs
+++ b/sentry/examples/error-chain-demo.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[macro_use]
 extern crate error_chain_;
 

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "error-chain", allow(deprecated))]
+
 use std::env;
 use std::{borrow::Cow, sync::Arc};
 

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -109,6 +109,7 @@ pub mod integrations {
     pub use sentry_debug_images as debug_images;
     #[cfg(feature = "error-chain")]
     #[doc(inline)]
+    #[deprecated = "The `error_chain` integration is deprecated and will be removed in the future."]
     pub use sentry_error_chain as error_chain;
     #[cfg(feature = "failure")]
     #[doc(inline)]
@@ -122,19 +123,6 @@ pub mod integrations {
     #[cfg(feature = "slog")]
     #[doc(inline)]
     pub use sentry_slog as slog;
-}
-
-/// Useful internals.
-///
-/// This module contains types that users of the crate typically do not
-/// have to interface with directly.  These are often returned
-/// from methods on other types.
-#[deprecated = "These exports have been moved to the root or the `types` mod."]
-pub mod internals {
-    pub use crate::{
-        apply_defaults, ClientInitGuard, IntoBreadcrumbs, IntoDsn, Transport, TransportFactory,
-    };
-    pub use sentry_core::types::*;
 }
 
 #[doc(inline)]


### PR DESCRIPTION
This also officially deprecates the `error_chain` integration.