### PR TITLE
ref: Deprecate public fields on Integrations

### DIFF
--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -17,3 +17,6 @@ all-features = true
 [dependencies]
 sentry-core = { version = "0.20.1", path = "../sentry-core" }
 anyhow = "1.0.30"
+
+[dev-dependencies]
+sentry = { version = "0.20.1", path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -12,7 +12,7 @@
 //! let _sentry =
 //!     sentry::init(sentry::ClientOptions::new().add_integration(AnyhowIntegration));
 //!
-//! if let Err(err) = match function_that_might_fail() {
+//! if let Err(err) = function_that_might_fail() {
 //!     capture_anyhow(&err);
 //! }
 //! ```

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -3,20 +3,18 @@
 //! # Example
 //!
 //! ```no_run
-//! # fn function_that_might_fail() -> anyhow::Result<()> { Ok(()) }
 //! use sentry_anyhow::{capture_anyhow, AnyhowIntegration};
-//! # fn test() -> anyhow::Result<()> {
+//!
+//! fn function_that_might_fail() -> anyhow::Result<()> {
+//!     Err(anyhow::anyhow!("some kind of error"))
+//! }
+//!
 //! let _sentry =
 //!     sentry::init(sentry::ClientOptions::new().add_integration(AnyhowIntegration));
 //!
-//! let result = match function_that_might_fail() {
-//!     Ok(result) => result,
-//!     Err(err) => {
-//!         capture_anyhow(&err);
-//!         return Err(err);
-//!     }
-//! };
-//! # Ok(()) }
+//! if let Err(err) = match function_that_might_fail() {
+//!     capture_anyhow(&err);
+//! }
 //! ```
 
 #![doc(html_favicon_url = "https://sentry-brand.storage.googleapis.com/favicon.ico")]

--- a/sentry-contexts/src/integration.rs
+++ b/sentry-contexts/src/integration.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::borrow::Cow;
 
 use sentry_core::protocol::map::Entry;
@@ -14,10 +16,13 @@ use crate::utils::{device_context, os_context, rust_context, server_name};
 #[derive(Debug)]
 pub struct ContextIntegration {
     /// Add `os` context, enabled by default.
+    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
     pub add_os: bool,
     /// Add `rust` context, enabled by default.
+    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
     pub add_rust: bool,
     /// Add `device` context, enabled by default.
+    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
     pub add_device: bool,
 }
 
@@ -35,6 +40,23 @@ impl ContextIntegration {
     /// Create a new Context Integration.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Add `os` context, enabled by default.
+    pub fn add_os(mut self, add_os: bool) -> Self {
+        self.add_os = add_os;
+        self
+    }
+    /// Add `rust` context, enabled by default.
+    pub fn add_rust(mut self, add_rust: bool) -> Self {
+        self.add_rust = add_rust;
+        self
+    }
+
+    /// Add `device` context, enabled by default.
+    pub fn add_device(mut self, add_device: bool) -> Self {
+        self.add_device = add_device;
+        self
     }
 }
 

--- a/sentry-contexts/src/integration.rs
+++ b/sentry-contexts/src/integration.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use std::borrow::Cow;
 
 use sentry_core::protocol::map::Entry;
@@ -15,15 +13,9 @@ use crate::utils::{device_context, os_context, rust_context, server_name};
 /// [Contexts Interface]: https://develop.sentry.dev/sdk/event-payloads/contexts/
 #[derive(Debug)]
 pub struct ContextIntegration {
-    /// Add `os` context, enabled by default.
-    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
-    pub add_os: bool,
-    /// Add `rust` context, enabled by default.
-    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
-    pub add_rust: bool,
-    /// Add `device` context, enabled by default.
-    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
-    pub add_device: bool,
+    add_os: bool,
+    add_rust: bool,
+    add_device: bool,
 }
 
 impl Default for ContextIntegration {

--- a/sentry-contexts/src/lib.rs
+++ b/sentry-contexts/src/lib.rs
@@ -9,11 +9,8 @@
 //! # Examples
 //!
 //! ```
-//! let integration = sentry_contexts::ContextIntegration {
-//!     add_os: false,
-//!     ..Default::default()
-//! };
-//! let _sentry = sentry::init(sentry::ClientOptions::default().add_integration(integration));
+//! let integration = sentry_contexts::ContextIntegration::new().add_os(false);
+//! let _sentry = sentry::init(sentry::ClientOptions::new().add_integration(integration));
 //! ```
 //!
 //! [Contexts Interface]: https://develop.sentry.dev/sdk/event-payloads/contexts/

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -9,11 +9,10 @@ use std::thread;
 use std::time::Duration;
 
 use crate::protocol::{Breadcrumb, Event, Level, SessionStatus};
-use crate::session::Session;
 use crate::types::Uuid;
 use crate::{event_from_error, Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 #[cfg(feature = "client")]
-use crate::{scope::Stack, Client, Envelope};
+use crate::{scope::Stack, session::Session, Client, Envelope};
 
 #[cfg(feature = "client")]
 lazy_static::lazy_static! {

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -63,7 +63,6 @@ mod hub;
 mod integration;
 mod intodsn;
 mod scope;
-mod session;
 mod transport;
 
 // public api or exports from this crate
@@ -81,6 +80,8 @@ pub use crate::transport::{Transport, TransportFactory};
 // client feature
 #[cfg(feature = "client")]
 mod client;
+#[cfg(feature = "client")]
+mod session;
 #[cfg(feature = "client")]
 pub use crate::client::Client;
 

--- a/sentry-debug-images/src/integration.rs
+++ b/sentry-debug-images/src/integration.rs
@@ -5,7 +5,7 @@ use sentry_core::{ClientOptions, Integration};
 
 /// The Sentry Debug Images Integration.
 pub struct DebugImagesIntegration {
-    filter: Box<dyn Fn(&Event<'static>) -> bool + Send + Sync>,
+    filter: Box<dyn Fn(&Event<'_>) -> bool + Send + Sync>,
 }
 
 impl DebugImagesIntegration {
@@ -19,7 +19,7 @@ impl DebugImagesIntegration {
     /// The filter specified which [`Event`]s should get debug images.
     pub fn filter<F>(mut self, filter: F) -> Self
     where
-        F: Fn(&Event<'static>) -> bool + Send + Sync + 'static,
+        F: Fn(&Event<'_>) -> bool + Send + Sync + 'static,
     {
         self.filter = Box::new(filter);
         self

--- a/sentry-debug-images/src/integration.rs
+++ b/sentry-debug-images/src/integration.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use std::borrow::Cow;
 
 use sentry_core::protocol::{DebugMeta, Event};
@@ -7,9 +5,7 @@ use sentry_core::{ClientOptions, Integration};
 
 /// The Sentry Debug Images Integration.
 pub struct DebugImagesIntegration {
-    /// A custom filter for which Events should get debug images.
-    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
-    pub filter: Box<dyn Fn(&Event<'static>) -> bool + Send + Sync>,
+    filter: Box<dyn Fn(&Event<'static>) -> bool + Send + Sync>,
 }
 
 impl DebugImagesIntegration {
@@ -20,7 +16,7 @@ impl DebugImagesIntegration {
 
     /// Sets a custom filter function.
     ///
-    /// The filter specified which Events should get debug images.
+    /// The filter specified which [`Event`]s should get debug images.
     pub fn filter<F>(mut self, filter: F) -> Self
     where
         F: Fn(&Event<'static>) -> bool + Send + Sync + 'static,

--- a/sentry-debug-images/src/integration.rs
+++ b/sentry-debug-images/src/integration.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::borrow::Cow;
 
 use sentry_core::protocol::{DebugMeta, Event};
@@ -6,6 +8,7 @@ use sentry_core::{ClientOptions, Integration};
 /// The Sentry Debug Images Integration.
 pub struct DebugImagesIntegration {
     /// A custom filter for which Events should get debug images.
+    #[deprecated = "use builder functions instead; direct field access will be removed soon"]
     pub filter: Box<dyn Fn(&Event<'static>) -> bool + Send + Sync>,
 }
 
@@ -13,6 +16,17 @@ impl DebugImagesIntegration {
     /// Creates a new Debug Images Integration.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Sets a custom filter function.
+    ///
+    /// The filter specified which Events should get debug images.
+    pub fn filter<F>(mut self, filter: F) -> Self
+    where
+        F: Fn(&Event<'static>) -> bool + Send + Sync + 'static,
+    {
+        self.filter = Box::new(filter);
+        self
     }
 }
 

--- a/sentry-debug-images/src/lib.rs
+++ b/sentry-debug-images/src/lib.rs
@@ -1,7 +1,7 @@
 //! The Sentry Debug Images Integration.
 //!
-//! The `DebugImagesIntegration` adds metadata about the loaded shared libraries
-//! to Sentry `Event`s.
+//! The [`DebugImagesIntegration`] adds metadata about the loaded shared libraries
+//! to Sentry [`Event`]s.
 //!
 //! # Configuration
 //!
@@ -10,11 +10,11 @@
 //!
 //! ```
 //! use sentry_core::Level;
-//! let integration = sentry_debug_images::DebugImagesIntegration {
-//!     filter: Box::new(|event| event.level >= Level::Warning),
-//!     ..Default::default()
-//! };
+//! let integration = sentry_debug_images::DebugImagesIntegration::new()
+//!     .filter(|event| event.level >= Level::Warning);
 //! ```
+//!
+//! [`Event`]: sentry_core::Event
 
 #![doc(html_favicon_url = "https://sentry-brand.storage.googleapis.com/favicon.ico")]
 #![doc(html_logo_url = "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png")]

--- a/sentry-debug-images/src/lib.rs
+++ b/sentry-debug-images/src/lib.rs
@@ -17,7 +17,7 @@
 //!     .filter(|event| event.level >= Level::Warning);
 //! ```
 //!
-//! [`Event`]: sentry_core::Event
+//! [`Event`]: sentry_core::protocol::Event
 
 #![doc(html_favicon_url = "https://sentry-brand.storage.googleapis.com/favicon.ico")]
 #![doc(html_logo_url = "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png")]

--- a/sentry-debug-images/src/lib.rs
+++ b/sentry-debug-images/src/lib.rs
@@ -1,12 +1,15 @@
 //! The Sentry Debug Images Integration.
 //!
-//! The [`DebugImagesIntegration`] adds metadata about the loaded shared libraries
-//! to Sentry [`Event`]s.
+//! The [`DebugImagesIntegration`] adds metadata about the loaded shared
+//! libraries to Sentry [`Event`]s.
+//!
+//! This Integration only works on Unix-like OSs right now. Support for Windows
+//! will be added in the future.
 //!
 //! # Configuration
 //!
-//! The integration by default attaches this information to all Events, but a
-//! custom filter can be defined as well.
+//! The integration by default attaches this information to all [`Event`]s, but
+//! a custom filter can be defined as well.
 //!
 //! ```
 //! use sentry_core::Level;


### PR DESCRIPTION
Not really sure if I should deprecate these first, or just break them right away. I don’t think people use these integrations directly a lot.