### PR TITLE
ci: Make testfast actually fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
     name: checkall using ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
+    env:
+      RUSTFLAGS: -Dwarnings
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -106,6 +109,9 @@ jobs:
 
     name: checkfast/testfast using ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    env:
+      RUSTFLAGS: -Dwarnings
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
turns out, changing RUSTFLAGS invalidates all the caches, thats why the `checkfast/fastfast` job was not using it properly.