### PR TITLE
Preliminary work to integrate Performance Monitoring 

### DIFF
--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use crate::protocol::{Breadcrumb, Context, Event, Level, User, Value};
 use crate::session::Session;
 use crate::Client;
+use sentry_types::protocol::v7::Span;
 
 #[derive(Debug)]
 pub struct Stack {
@@ -43,6 +44,7 @@ pub struct Scope {
     pub(crate) contexts: im::HashMap<String, Context>,
     pub(crate) event_processors: im::Vector<Arc<EventProcessor>>,
     pub(crate) session: Arc<Mutex<Option<Session>>>,
+    pub(crate) span: Option<Arc<Span>>,
 }
 
 impl fmt::Debug for Scope {
@@ -58,6 +60,7 @@ impl fmt::Debug for Scope {
             .field("contexts", &self.contexts)
             .field("event_processors", &self.event_processors.len())
             .field("session", &self.session)
+            .field("span", &self.span)
             .finish()
     }
 }
@@ -75,6 +78,7 @@ impl Default for Scope {
             contexts: Default::default(),
             event_processors: Default::default(),
             session: Default::default(),
+            span: Default::default(),
         }
     }
 }
@@ -210,6 +214,15 @@ impl Scope {
     /// Removes a extra.
     pub fn remove_extra(&mut self, key: &str) {
         self.extra.remove(key);
+    }
+
+    pub fn set_span(&mut self, span: &mut Span) {
+        if let Some(current_span) = &self.span {
+            span.trace_id = current_span.trace_id;
+            span.parent_span_id = Some(current_span.event_id.to_simple_ref().to_string());
+        } else {
+            self.span = Some(Arc::new(span.clone()));
+        }
     }
 
     /// Add an event processor to the scope.

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use crate::protocol::{Breadcrumb, Context, Event, Level, User, Value};
 use crate::session::Session;
 use crate::Client;
-use sentry_types::protocol::v7::Span;
 
 #[derive(Debug)]
 pub struct Stack {
@@ -44,7 +43,6 @@ pub struct Scope {
     pub(crate) contexts: im::HashMap<String, Context>,
     pub(crate) event_processors: im::Vector<Arc<EventProcessor>>,
     pub(crate) session: Arc<Mutex<Option<Session>>>,
-    pub(crate) span: Option<Arc<Span>>,
 }
 
 impl fmt::Debug for Scope {
@@ -60,7 +58,6 @@ impl fmt::Debug for Scope {
             .field("contexts", &self.contexts)
             .field("event_processors", &self.event_processors.len())
             .field("session", &self.session)
-            .field("span", &self.span)
             .finish()
     }
 }
@@ -78,7 +75,6 @@ impl Default for Scope {
             contexts: Default::default(),
             event_processors: Default::default(),
             session: Default::default(),
-            span: Default::default(),
         }
     }
 }
@@ -214,15 +210,6 @@ impl Scope {
     /// Removes a extra.
     pub fn remove_extra(&mut self, key: &str) {
         self.extra.remove(key);
-    }
-
-    pub fn set_span(&mut self, span: &mut Span) {
-        if let Some(current_span) = &self.span {
-            span.trace_id = current_span.trace_id;
-            span.parent_span_id = Some(current_span.event_id.to_simple_ref().to_string());
-        } else {
-            self.span = Some(Arc::new(span.clone()));
-        }
     }
 
     /// Add an event processor to the scope.

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -247,4 +247,6 @@ mod test {
 "#
         )
     }
+
+    // TODO: test_transaction
 }

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -264,14 +264,12 @@ mod test {
         let span_id = Uuid::parse_str("d42cee9f-c3e7-4f5c-ada9-47ab601a14d2").unwrap();
         let trace_id = Uuid::parse_str("335e53d6-1447-4acc-9f89-e632b776cc28").unwrap();
         let start_timestamp = "2020-07-20T14:51:14.296Z".parse::<DateTime<Utc>>().unwrap();
-        let spans = vec![
-            Span {
-                span_id,
-                trace_id,
-                start_timestamp,
-                ..Default::default()
-            }
-        ];
+        let spans = vec![Span {
+            span_id,
+            trace_id,
+            start_timestamp,
+            ..Default::default()
+        }];
         let transaction = Transaction {
             event_id,
             start_timestamp,

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -27,7 +27,7 @@ pub enum EnvelopeItem {
     ///
     /// See the [Transaction Item documentation](https://develop.sentry.dev/sdk/envelopes/#transaction)
     /// for more details.
-    Transaction(Transaction<'static>)
+    Transaction(Transaction<'static>),
     // TODO:
     // * Attachment,
     // etc…

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use super::v7::Event;
 use super::v7::SessionUpdate;
+use super::v7::Transaction;
 
 /// An Envelope Item.
 ///
@@ -22,6 +23,11 @@ pub enum EnvelopeItem {
     /// See the [Session Item documentation](https://develop.sentry.dev/sdk/envelopes/#session)
     /// for more details.
     SessionUpdate(SessionUpdate<'static>),
+    /// A Transaction Item.
+    ///
+    /// See the [Transaction Item documentation](https://develop.sentry.dev/sdk/envelopes/#transaction)
+    /// for more details.
+    Transaction(Transaction<'static>)
     // TODO:
     // * Attachment,
     // etc…
@@ -36,6 +42,12 @@ impl From<Event<'static>> for EnvelopeItem {
 impl From<SessionUpdate<'static>> for EnvelopeItem {
     fn from(session: SessionUpdate<'static>) -> Self {
         EnvelopeItem::SessionUpdate(session)
+    }
+}
+
+impl From<Transaction<'static>> for EnvelopeItem {
+    fn from(session: Transaction<'static>) -> Self {
+        EnvelopeItem::Transaction(session)
     }
 }
 
@@ -135,10 +147,14 @@ impl Envelope {
                 EnvelopeItem::SessionUpdate(session) => {
                     serde_json::to_writer(&mut item_buf, session)?
                 }
+                EnvelopeItem::Transaction(transaction) => {
+                    serde_json::to_writer(&mut item_buf, transaction)?
+                }
             }
             let item_type = match item {
                 EnvelopeItem::Event(_) => "event",
                 EnvelopeItem::SessionUpdate(_) => "session",
+                EnvelopeItem::Transaction(_) => "transaction",
             };
             writeln!(
                 writer,

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1546,23 +1546,6 @@ impl Span {
         Default::default()
     }
 
-    /// Creates a fully owned version of the span.
-    pub fn into_owned(self) -> Span {
-        Span {
-            span_id: self.span_id,
-            trace_id: self.trace_id,
-            timestamp: self.timestamp,
-            tags: self.tags,
-            start_timestamp: self.start_timestamp,
-            description: self.description,
-            status: self.status,
-            parent_span_id: self.parent_span_id,
-            same_process_as_parent: self.same_process_as_parent,
-            op: self.op,
-            data: self.data,
-        }
-    }
-
     /// Finalizes the span.
     pub fn finish(&mut self) {
         self.timestamp = Some(Utc::now());
@@ -1585,9 +1568,9 @@ pub struct Transaction<'a> {
     /// The ID of the event
     #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
     pub event_id: Uuid,
-    /// The transaction name of the event.
+    /// The transaction name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<String>,
+    pub name: Option<String>,
     /// Optional tags to be attached to the event.
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub tags: Map<String, String>,
@@ -1617,7 +1600,7 @@ impl<'a> Default for Transaction<'a> {
     fn default() -> Self {
         Transaction {
             event_id: event::default_id(),
-            transaction: Default::default(),
+            name: Default::default(),
             tags: Default::default(),
             sdk: Default::default(),
             platform: event::default_platform(),
@@ -1639,7 +1622,7 @@ impl<'a> Transaction<'a> {
     pub fn into_owned(self) -> Transaction<'static> {
         Transaction {
             event_id: self.event_id,
-            transaction: self.transaction,
+            name: self.name,
             tags: self.tags,
             sdk: self.sdk.map(|x| Cow::Owned(x.into_owned())),
             platform: Cow::Owned(self.platform.into_owned()),

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1590,8 +1590,8 @@ pub struct Transaction<'a> {
     pub sdk: Option<Cow<'a, ClientSdkInfo>>,
     /// A platform identifier for this event.
     #[serde(
-    default = "event::default_platform",
-    skip_serializing_if = "event::is_default_platform"
+        default = "event::default_platform",
+        skip_serializing_if = "event::is_default_platform"
     )]
     pub platform: Cow<'a, str>,
     /// The end time of the transaction.
@@ -1618,7 +1618,7 @@ impl<'a> Default for Transaction<'a> {
             timestamp: Default::default(),
             start_timestamp: event::default_timestamp(),
             spans: Default::default(),
-            contexts: Default::default()
+            contexts: Default::default(),
         }
     }
 }

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1224,16 +1224,22 @@ pub struct BrowserContext {
 /// Holds information about a tracing event.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct TraceContext {
-    #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
-    pub trace_id: Uuid,
+    /// The ID of the trace event
     #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
     pub span_id: Uuid,
+    /// Determines which trace the transaction belongs to.
+    #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
+    pub trace_id: Uuid,
+    /// Determines the parent of this transaction if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_span_id: Option<String>,
+    /// Short code identifying the type of operation the transaction is measuring.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op: Option<String>,
+    /// Human readable detail description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Describes the status of the span (e.g. `ok`, `cancelled`, etc.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 }
@@ -1486,7 +1492,7 @@ pub struct Span {
     /// Determines which trace the span belongs to.
     #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
     pub trace_id: Uuid,
-    /// Determines the parent to which this span is a child of, if any.
+    /// Determines the parent of this span, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_span_id: Option<String>,
     /// Determines whether this span is generated in the same process as its parent, if any.


### PR DESCRIPTION
Hello! I'm the lead developer at [Wavy Labs Inc.](https://github.com/WavyLabs/) We're integrating Rust more and more into our stack and we've been using Sentry for over a year. We'd love to start integrating Performance Monitoring, but it seems this SDK doesn't support it yet.

I'd like to kickstart the discussion on this and contribute some developer time for this. I've been reading the [Guidelines for Tracing Support](https://develop.sentry.dev/sdk/unified-api/tracing/) and peeking into the Python SDK for reference. I've started some preliminary work on adding the new types (Span and Transaction), but I'll need some guidance on integrating with Hub. Feel free to start reviewing at any time!