### PR TITLE
ref: Introduce a SessionFlusher

### DIFF
--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -102,6 +102,7 @@ impl ClientOptions {
     pub fn new() -> Self {
         Self::default()
     }
+
     /// Adds a configured integration to the options.
     ///
     /// # Examples

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -40,6 +40,7 @@ impl From<SessionUpdate<'static>> for EnvelopeItem {
 }
 
 /// An Iterator over the items of an Envelope.
+#[derive(Clone)]
 pub struct EnvelopeItemIter<'s> {
     inner: std::slice::Iter<'s, EnvelopeItem>,
 }

--- a/sentry/src/init.rs
+++ b/sentry/src/init.rs
@@ -7,9 +7,9 @@ use crate::{Client, ClientOptions, Hub};
 
 /// Helper struct that is returned from `init`.
 ///
-/// When this is dropped events are drained with a 1 second timeout.
-#[must_use = "when the init guard is dropped the transport will be shut down and no further \
-              events can be sent.  If you do want to ignore this use mem::forget on it."]
+/// When this is dropped events are drained with the configured `shutdown_timeout`.
+#[must_use = "when the init guard is dropped the send queue is flushed and the \
+              transport will be shut down and no further events can be sent."]
 pub struct ClientInitGuard(Arc<Client>);
 
 impl std::ops::Deref for ClientInitGuard {
@@ -56,6 +56,8 @@ impl Drop for ClientInitGuard {
 /// ```
 ///
 /// Or if draining on shutdown should be ignored:
+/// This is not recommended, as events or session updates that have been queued
+/// might be lost.
 ///
 /// ```
 /// std::mem::forget(sentry::init("https://key@sentry.io/1234"));


### PR DESCRIPTION
The flusher maintains a queue that is flushed every minute.
Sessions are batched into Envelopes at this point, but in the future
might be pre-aggregated.