### PR TITLE
feat: actix-web 3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.40.0]
+        rust: [1.42.0]
 
     name: checkfast/testfast using ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Breaking Changes**:
 
+- Bump the minimum required Rust version to **1.42.0**.
+- The `actix` integration / middleware is now compatible with `actix-web 3`.
 - Removed all deprecated exports and deprecated feature flags.
 - The `failure` integration / feature is now off-by-default along with its deprecation.
 - The `log` and `slog` integrations were re-designed, they now offer types that wrap a `log::Log` or `slog::Drain` and forward log events to the currently active sentry `Hub` based on an optional filter and an optional mapper.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This workspace contains various crates that provide support for logging events a
   [![crates.io](https://img.shields.io/crates/v/sentry-actix.svg)](https://crates.io/crates/sentry-actix)
   [![docs.rs](https://docs.rs/sentry-actix/badge.svg)](https://docs.rs/sentry-actix)
 
-  An integration for the `actix-web (0.7)` framework.
+  An integration for the `actix-web (3.0+)` framework.
 
 - [sentry-anyhow](./sentry-anyhow)
   [![crates.io](https://img.shields.io/crates/v/sentry-anyhow.svg)](https://crates.io/crates/sentry-anyhow)
@@ -99,7 +99,7 @@ best API and adding new features.
 We currently only verify this crate against a recent version of Sentry hosted on [sentry.io](https://sentry.io/) but it
 should work with on-prem Sentry versions 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.40.0_.
+Additionally, the lowest Rust version we target is _1.42.0_.
 
 ## Resources
 

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -24,6 +24,7 @@ with_sentry_default = [
 [dependencies]
 sentry = { version = "0.20.1", path = "../sentry", default-features = false }
 sentry-failure = { version = "0.20.1", path = "../sentry-failure" }
-actix-web = { version = "0.7", default-features = false }
+actix-web = { version = "3", default-features = false }
 failure = "0.1.3"
+futures-util = "0.3.5"
 fragile = "0.3.0"

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -27,5 +27,6 @@ actix-web = { version = "3", default-features = false }
 futures-util = "0.3.5"
 
 [dev-dependencies]
-sentry = { version = "0.20.1", path = "../sentry", default-features = false }
+sentry = { version = "0.20.1", path = "../sentry", default-features = false, features = ["test"] }
 actix-rt = "1.1.1"
+futures = "0.3"

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -28,3 +28,4 @@ futures-util = "0.3.5"
 
 [dev-dependencies]
 sentry = { version = "0.20.1", path = "../sentry", default-features = false }
+actix-rt = "1.1.1"

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -22,9 +22,9 @@ with_sentry_default = [
 ]
 
 [dependencies]
-sentry = { version = "0.20.1", path = "../sentry", default-features = false }
-sentry-failure = { version = "0.20.1", path = "../sentry-failure" }
+sentry-core = { version = "0.20.1", path = "../sentry-core", default-features = false }
 actix-web = { version = "3", default-features = false }
-failure = "0.1.3"
 futures-util = "0.3.5"
-fragile = "0.3.0"
+
+[dev-dependencies]
+sentry = { version = "0.20.1", path = "../sentry", default-features = false }

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -29,7 +29,7 @@ async fn failing(_req: HttpRequest) -> Result<String, Error> {
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {
-    let _guard = sentry::init("https://public@sentry.io/1234");
+    let _guard = sentry::init(());
     env::set_var("RUST_BACKTRACE", "1");
 
     HttpServer::new(|| {
@@ -45,29 +45,20 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-## Reusing the Hub
+# Reusing the Hub
 
-If you use this integration the `Hub::current()` returned hub is typically the wrong one.
-To get the request specific one you need to use the `ActixWebHubExt` trait:
-
-```rust
-use sentry::{Hub, Level};
-use sentry_actix::ActixWebHubExt;
-
-let hub = Hub::from_request(req);
-hub.capture_message("Something is not well", Level::Warning);
-```
-
-The hub can also be made current:
+This integration will automatically update the current Hub instance. For example,
+the following will capture a message in the current request's Hub:
 
 ```rust
-use sentry::{Hub, Level};
-use sentry_actix::ActixWebHubExt;
+use actix_web::{Error, get, HttpRequest};
+use sentry::Level;
 
-let hub = Hub::from_request(req);
-Hub::run(hub, || {
+#[get("/")]
+async fn hello_world(_req: HttpRequest) -> Result<String, Error> {
     sentry::capture_message("Something is not well", Level::Warning);
-});
+    Ok("Hello World".into())
+}
 ```
 
 ## Resources

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -20,11 +20,18 @@ such as breadcrumbs do not work unless you bind the actix hub.
 use std::env;
 use std::io;
 
-use actix_web::{App, Error, get, HttpRequest, HttpServer};
+use actix_web::{get, App, Error, HttpRequest, HttpServer};
+use sentry::Level;
 
 #[get("/")]
 async fn failing(_req: HttpRequest) -> Result<String, Error> {
     Err(io::Error::new(io::ErrorKind::Other, "An error happens here").into())
+}
+
+#[get("/hello")]
+async fn hello_world(_req: HttpRequest) -> Result<String, Error> {
+    sentry::capture_message("Something is not well", Level::Warning);
+    Ok("Hello World".into())
 }
 
 #[actix_web::main]
@@ -36,10 +43,11 @@ async fn main() -> io::Result<()> {
         App::new()
             .wrap(sentry_actix::Sentry::new())
             .service(failing)
+            .service(hello_world)
     })
-        .bind("127.0.0.1:3001")?
-        .run()
-        .await?;
+    .bind("127.0.0.1:3001")?
+    .run()
+    .await?;
 
     Ok(())
 }

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -2,10 +2,17 @@ use std::env;
 use std::io;
 
 use actix_web::{get, App, Error, HttpRequest, HttpServer};
+use sentry::Level;
 
 #[get("/")]
 async fn failing(_req: HttpRequest) -> Result<String, Error> {
     Err(io::Error::new(io::ErrorKind::Other, "An error happens here").into())
+}
+
+#[get("/hello")]
+async fn hello_world(_req: HttpRequest) -> Result<String, Error> {
+    sentry::capture_message("Something is not well", Level::Warning);
+    Ok("Hello World".into())
 }
 
 #[actix_web::main]
@@ -17,6 +24,7 @@ async fn main() -> io::Result<()> {
         App::new()
             .wrap(sentry_actix::Sentry::new())
             .service(failing)
+            .service(hello_world)
     })
     .bind("127.0.0.1:3001")?
     .run()

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -10,7 +10,7 @@ async fn failing(_req: HttpRequest) -> Result<String, Error> {
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {
-    let _guard = sentry::init("https://public@sentry.io/1234");
+    let _guard = sentry::init(());
     env::set_var("RUST_BACKTRACE", "1");
 
     HttpServer::new(|| {

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -306,15 +306,11 @@ mod tests {
 
     use actix_web::test::{call_service, init_service, TestRequest};
     use actix_web::{get, web, App, HttpRequest, HttpResponse};
+    use futures::executor::block_on;
 
-    use sentry::{ClientInitGuard, Level};
+    use sentry::Level;
 
     use super::*;
-
-    fn _init() -> ClientInitGuard {
-        // Initialize with a 'valid' DSN so errors are captured
-        sentry::init("https://public@sentry.invalid/1")
-    }
 
     fn _assert_hub_no_events() {
         if Hub::current().last_event_id().is_some() {
@@ -331,88 +327,88 @@ mod tests {
     /// Test explicit events sent to the current Hub inside an Actix service.
     #[actix_rt::test]
     async fn test_explicit_events() {
-        let _guard = _init();
+        let events = sentry::test::with_captured_events(|| {
+            block_on(async {
+                let test_hub = Hub::current();
 
-        let service = || {
-            // Current hub should have no events
-            _assert_hub_no_events();
+                let service = || {
+                    // Current Hub should have no events
+                    _assert_hub_no_events();
 
-            // Add processor to ensure proper event fields
-            sentry::configure_scope(|scope| {
-                scope.add_event_processor(Box::new(move |event| {
-                    let request = event.request.expect("Request should be set.");
-                    assert_eq!(event.transaction, Some("/test".into()));
-                    assert_eq!(event.message, Some("Message".into()));
-                    assert_eq!(event.level, Level::Warning);
-                    assert_eq!(request.method, Some("GET".into()));
-                    None
-                }))
-            });
+                    sentry::capture_message("Message", Level::Warning);
 
-            // Creates an event
-            sentry::capture_message("Message", Level::Warning);
+                    // Current Hub should have the event
+                    _assert_hub_has_events();
 
-            // Current Hub should have the event
-            _assert_hub_has_events();
+                    HttpResponse::Ok()
+                };
 
-            HttpResponse::Ok()
-        };
+                let mut app = init_service(
+                    App::new()
+                        .wrap(Sentry::builder().with_hub(test_hub).finish())
+                        .service(web::resource("/test").to(service)),
+                )
+                .await;
 
-        let mut app = init_service(
-            App::new()
-                .wrap(Sentry::new())
-                .service(web::resource("/test").to(service)),
-        )
-        .await;
+                // Call the service twice (sequentially) to ensure the middleware isn't sticky
+                for _ in 0..2 {
+                    let req = TestRequest::get().uri("/test").to_request();
+                    let res = call_service(&mut app, req).await;
+                    assert!(res.status().is_success());
+                }
+            })
+        });
 
-        // Call the service twice to check the isolation between them
-        for _ in 0..2 {
-            let req = TestRequest::get().uri("/test").to_request();
-            let res = call_service(&mut app, req).await;
-            assert!(res.status().is_success());
+        assert_eq!(events.len(), 2);
+        for event in events {
+            let request = event.request.expect("Request should be set.");
+            assert_eq!(event.transaction, Some("/test".into()));
+            assert_eq!(event.message, Some("Message".into()));
+            assert_eq!(event.level, Level::Warning);
+            assert_eq!(request.method, Some("GET".into()));
         }
-
-        // Make sure the main Hub was never used
-        _assert_hub_no_events();
     }
 
     /// Ensures errors returned in the Actix service trigger an event.
     #[actix_rt::test]
     async fn test_response_errors() {
-        let _guard = _init();
+        let events = sentry::test::with_captured_events(|| {
+            block_on(async {
+                let test_hub = Hub::current();
 
-        #[get("/test")]
-        async fn failing(_req: HttpRequest) -> Result<String, Error> {
-            // Current hub should have no events
-            _assert_hub_no_events();
+                #[get("/test")]
+                async fn failing(_req: HttpRequest) -> Result<String, Error> {
+                    // Current hub should have no events
+                    _assert_hub_no_events();
 
-            // Add processor to ensure proper event fields
-            sentry::configure_scope(|scope| {
-                scope.add_event_processor(Box::new(move |event| {
-                    let request = event.request.expect("Request should be set.");
-                    assert_eq!(event.transaction, Some("failing".into())); // Transaction name is the name of the function
-                    assert_eq!(event.message, None);
-                    assert_eq!(event.exception.values[0].ty, String::from("Custom"));
-                    assert_eq!(event.exception.values[0].value, Some("Test Error".into()));
-                    assert_eq!(event.level, Level::Error);
-                    assert_eq!(request.method, Some("GET".into()));
-                    None
-                }))
-            });
+                    Err(io::Error::new(io::ErrorKind::Other, "Test Error").into())
+                }
 
-            Err(io::Error::new(io::ErrorKind::Other, "Test Error").into())
+                let mut app = init_service(
+                    App::new()
+                        .wrap(Sentry::builder().with_hub(test_hub).finish())
+                        .service(failing),
+                )
+                .await;
+
+                // Call the service twice (sequentially) to ensure the middleware isn't sticky
+                for _ in 0..2 {
+                    let req = TestRequest::get().uri("/test").to_request();
+                    let res = call_service(&mut app, req).await;
+                    assert!(res.status().is_server_error());
+                }
+            })
+        });
+
+        assert_eq!(events.len(), 2);
+        for event in events {
+            let request = event.request.expect("Request should be set.");
+            assert_eq!(event.transaction, Some("failing".into())); // Transaction name is the name of the function
+            assert_eq!(event.message, None);
+            assert_eq!(event.exception.values[0].ty, String::from("Custom"));
+            assert_eq!(event.exception.values[0].value, Some("Test Error".into()));
+            assert_eq!(event.level, Level::Error);
+            assert_eq!(request.method, Some("GET".into()));
         }
-
-        let mut app = init_service(App::new().wrap(Sentry::new()).service(failing)).await;
-
-        // Call the service twice to check the isolation between them
-        for _ in 0..2 {
-            let req = TestRequest::get().uri("/test").to_request();
-            let res = call_service(&mut app, req).await;
-            assert!(res.status().is_server_error());
-        }
-
-        // Make sure the main Hub was never used
-        _assert_hub_no_events();
     }
 }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -68,7 +68,7 @@ sentry-slog = { version = "0.20.1", path = "../sentry-slog" }
 log_ = { package = "log", version = "0.4.8", features = ["std"] }
 slog_ = { package = "slog", version = "2.5.2" }
 failure_derive = "0.1.6"
-actix-web = { version = "0.7.19", default-features = false }
+actix-web = { version = "3", default-features = false }
 tokio = { version = "0.2", features = ["macros"] }
 failure_ = { package = "failure", version = "0.1.6" }
 pretty_env_logger = "0.4.0"


### PR DESCRIPTION
I refactored the middleware by basing it on 'official' v3 middleware (logger, cors, etc.) Some of the Sentry implementation was re-used from https://github.com/mozilla-services/autopush-rs/blob/9b93817776bb7c8f27383185a1b5ce08607a6b35/autoendpoint/src/middleware/sentry.rs (v2.0 middleware, adapted for v3.0 and `wrap`-style middleware).

Example is updated and tested locally.

Bumped minimum Rust version to 1.42.0 because that's what actix-web 3.0 targets.

Resolves #143 