### PR TITLE
fix: sentry-actix should not capture client errors

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -217,7 +217,7 @@ where
             };
 
             // Response errors
-            if inner.capture_server_errors {
+            if inner.capture_server_errors && res.response().status().is_server_error() {
                 if let Some(e) = res.response().error() {
                     let event_id = hub.capture_error(e);
 
@@ -329,8 +329,6 @@ mod tests {
     async fn test_explicit_events() {
         let events = sentry::test::with_captured_events(|| {
             block_on(async {
-                let test_hub = Hub::current();
-
                 let service = || {
                     // Current Hub should have no events
                     _assert_hub_no_events();
@@ -345,7 +343,7 @@ mod tests {
 
                 let mut app = init_service(
                     App::new()
-                        .wrap(Sentry::builder().with_hub(test_hub).finish())
+                        .wrap(Sentry::builder().with_hub(Hub::current()).finish())
                         .service(web::resource("/test").to(service)),
                 )
                 .await;
@@ -374,8 +372,6 @@ mod tests {
     async fn test_response_errors() {
         let events = sentry::test::with_captured_events(|| {
             block_on(async {
-                let test_hub = Hub::current();
-
                 #[get("/test")]
                 async fn failing(_req: HttpRequest) -> Result<String, Error> {
                     // Current hub should have no events
@@ -386,7 +382,7 @@ mod tests {
 
                 let mut app = init_service(
                     App::new()
-                        .wrap(Sentry::builder().with_hub(test_hub).finish())
+                        .wrap(Sentry::builder().with_hub(Hub::current()).finish())
                         .service(failing),
                 )
                 .await;
@@ -410,5 +406,28 @@ mod tests {
             assert_eq!(event.level, Level::Error);
             assert_eq!(request.method, Some("GET".into()));
         }
+    }
+
+    /// Ensures client errors (4xx) are not captured.
+    #[actix_rt::test]
+    async fn test_client_errors_discarded() {
+        let events = sentry::test::with_captured_events(|| {
+            block_on(async {
+                let service = || HttpResponse::NotFound();
+
+                let mut app = init_service(
+                    App::new()
+                        .wrap(Sentry::builder().with_hub(Hub::current()).finish())
+                        .service(web::resource("/test").to(service)),
+                )
+                .await;
+
+                let req = TestRequest::get().uri("/test").to_request();
+                let res = call_service(&mut app, req).await;
+                assert!(res.status().is_client_error());
+            })
+        });
+
+        assert!(events.is_empty());
     }
 }


### PR DESCRIPTION
Client errors (4xx) should not be captured in the sentry-actix integration.