### PR TITLE
feat: End sessions with explicit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - The `log` and `slog` integrations were re-designed, they now offer types that wrap a `log::Log` or `slog::Drain` and forward log events to the currently active sentry `Hub` based on an optional filter and an optional mapper.
 - The new `log` integration will not implicitly call `log::set_max_level_filter` anymore, and users need to do so manually.
 
+**Features**:
+
+- Add the new `end_session_with` global and Hub functions which allow ending a Release Health Session with an explicit `SessionStatus`.
+
 **Deprecations**:
 
 - The `error-chain` and `failure` integration was officially deprecated and will be removed soon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 **Features**:
 
-- Add the new `end_session_with` global and Hub functions which allow ending a Release Health Session with an explicit `SessionStatus`.
+- Add the new `end_session_with_status` global and Hub functions which allow ending a Release Health Session with an explicit `SessionStatus`.
 
 **Deprecations**:
 

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -285,7 +285,7 @@ pub fn start_session() {
 
 /// End the current Release Health Session.
 pub fn end_session() {
-    end_session_with(SessionStatus::Exited)
+    end_session_with_status(SessionStatus::Exited)
 }
 
 /// End the current Release Health Session with the given [`SessionStatus`].
@@ -295,6 +295,6 @@ pub fn end_session() {
 ///
 /// When an `Abnormal` session should be captured, it has to be done explicitly
 /// using this function.
-pub fn end_session_with(status: SessionStatus) {
-    Hub::with_active(|hub| hub.end_session_with(status))
+pub fn end_session_with_status(status: SessionStatus) {
+    Hub::with_active(|hub| hub.end_session_with_status(status))
 }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -1,3 +1,5 @@
+use sentry_types::protocol::v7::SessionStatus;
+
 use crate::protocol::{Event, Level};
 use crate::types::Uuid;
 use crate::{Hub, Integration, IntoBreadcrumbs, Scope};
@@ -283,5 +285,16 @@ pub fn start_session() {
 
 /// End the current Release Health Session.
 pub fn end_session() {
-    Hub::with_active(|hub| hub.end_session())
+    end_session_with(SessionStatus::Exited)
+}
+
+/// End the current Release Health Session with the given [`SessionStatus`].
+///
+/// By default, the SDK will only consider the `Exited` and `Crashed` status
+/// based on the type of events that were captured during the session.
+///
+/// When an `Abnormal` session should be captured, it has to be done explicitly
+/// using this function.
+pub fn end_session_with(status: SessionStatus) {
+    Hub::with_active(|hub| hub.end_session_with(status))
 }

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -279,12 +279,6 @@ impl Client {
         self.session_flusher.enqueue(session_update)
     }
 
-    pub(crate) fn capture_envelope(&self, envelope: Envelope) {
-        if let Some(ref transport) = *self.transport.read().unwrap() {
-            transport.send_envelope(envelope);
-        }
-    }
-
     /// Drains all pending events and shuts down the transport behind the
     /// client.  After shutting down the transport is removed.
     ///

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -334,13 +334,13 @@ impl Hub {
     /// See the global [`end_session`](crate::end_session_with)
     /// for more documentation.
     pub fn end_session(&self) {
-        self.end_session_with(SessionStatus::Exited)
+        self.end_session_with_status(SessionStatus::Exited)
     }
     /// End the current Release Health Session with the given [`SessionStatus`].
     ///
-    /// See the global [`end_session_with`](crate::end_session_with)
+    /// See the global [`end_session_with_status`](crate::end_session_with_status)
     /// for more documentation.
-    pub fn end_session_with(&self, status: SessionStatus) {
+    pub fn end_session_with_status(&self, status: SessionStatus) {
         with_client_impl! {{
             self.inner.with_mut(|stack| {
                 let top = stack.top_mut();

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -331,21 +331,22 @@ impl Hub {
 
     /// End the current Release Health Session.
     ///
-    /// See the global [`end_session`](fn.end_session.html)
+    /// See the global [`end_session`](crate::end_session_with)
     /// for more documentation.
     pub fn end_session(&self) {
+        self.end_session_with(SessionStatus::Exited)
+    }
+    /// End the current Release Health Session with the given [`SessionStatus`].
+    ///
+    /// See the global [`end_session_with`](crate::end_session_with)
+    /// for more documentation.
+    pub fn end_session_with(&self, status: SessionStatus) {
         with_client_impl! {{
             self.inner.with_mut(|stack| {
                 let top = stack.top_mut();
+                // drop will close and enqueue the session
                 if let Some(mut session) = top.scope.session.lock().unwrap().take() {
-                    session.close();
-                    if let Some(item) = session.create_envelope_item() {
-                        let mut envelope = Envelope::new();
-                        envelope.add_item(item);
-                        if let Some(ref client) = top.client {
-                            client.capture_envelope(envelope);
-                        }
-                    }
+                    session.close(status);
                 }
             })
         }}

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -24,7 +24,7 @@ pub struct Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        self.close();
+        self.close(SessionStatus::Exited);
         if self.dirty {
             self.client.enqueue_session(self.session_update.clone());
         }
@@ -95,10 +95,14 @@ impl Session {
         }
     }
 
-    pub(crate) fn close(&mut self) {
+    pub(crate) fn close(&mut self, status: SessionStatus) {
         if self.session_update.status == SessionStatus::Ok {
+            let status = match status {
+                SessionStatus::Ok => SessionStatus::Exited,
+                s => s,
+            };
             self.session_update.duration = Some(self.started.elapsed().as_secs_f64());
-            self.session_update.status = SessionStatus::Exited;
+            self.session_update.status = status;
             self.dirty = true;
         }
     }
@@ -329,6 +333,23 @@ mod tests {
         assert_eq!(items.next(), None);
     }
 
+    #[test]
+    fn test_session_abnormal() {
+        let envelopes = capture_envelopes(|| {
+            sentry::start_session();
+            sentry::end_session_with(SessionStatus::Abnormal);
+        });
+        assert_eq!(envelopes.len(), 1);
+
+        let mut items = envelopes[0].items();
+        if let Some(EnvelopeItem::SessionUpdate(session)) = items.next() {
+            assert_eq!(session.status, SessionStatus::Abnormal);
+            assert_eq!(session.init, true);
+        } else {
+            panic!("expected session");
+        }
+        assert_eq!(items.next(), None);
+    }
     #[test]
     fn test_session_sampled_errors() {
         let mut envelopes = crate::test::with_captured_envelopes_options(

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -337,7 +337,7 @@ mod tests {
     fn test_session_abnormal() {
         let envelopes = capture_envelopes(|| {
             sentry::start_session();
-            sentry::end_session_with(SessionStatus::Abnormal);
+            sentry::end_session_with_status(SessionStatus::Abnormal);
         });
         assert_eq!(envelopes.len(), 1);
 


### PR DESCRIPTION
This adds the `end_session_with` global and Hub functions that allow
providing an explicit `SessionStatus`.