### PR TITLE
docs: Document integrations and the Hub better

### DIFF
--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -1,4 +1,17 @@
-//! Adds support for capturing Sentry errors from `anyhow::Error`.
+//! Adds support for capturing Sentry errors from [`anyhow::Error`].
+//!
+//! This integration adds a new event *source*, which allows you to create events directly
+//! from an [`anyhow::Error`] struct.  As it is only an event source it only needs to be
+//! enabled using the `anyhow` cargo feature, it does not need to be enabled in the call to
+//! [`sentry::init`](../../fn.init.html).
+//!
+//! This integration does not need to be installed, instead it provides an extra function to
+//! capture [`anyhow::Error`], optionally exposing it as a method on the
+//! [`sentry::Hub`](../../struct.Hub.html) using the [`AnyhowHubExt`] trait.
+//!
+//! Like a plain [`std::error::Error`] being captured, [`anyhow::Error`] is captured with a
+//! chain of all error sources, if present.  See
+//! [`sentry::capture_error`](../../fn.capture_error.html) for details of this.
 //!
 //! # Example
 //!
@@ -13,6 +26,8 @@
 //!     capture_anyhow(&err);
 //! }
 //! ```
+//!
+//! [`anyhow::Error`]: https://docs.rs/anyhow/*/anyhow/struct.Error.html
 
 #![doc(html_favicon_url = "https://sentry-brand.storage.googleapis.com/favicon.ico")]
 #![doc(html_logo_url = "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png")]
@@ -22,16 +37,27 @@
 use sentry_core::types::Uuid;
 use sentry_core::Hub;
 
-/// Captures an `anyhow::Error`.
+/// Captures an [`anyhow::Error`].
+///
+/// This will capture an anyhow error as a sentry event if a
+/// [`sentry::Client`](../../struct.Client.html) is initialised, otherwise it will be a
+/// no-op.  The event is dispatched to the thread-local hub, with semantics as described in
+/// [`Hub::current`].
 ///
 /// See [module level documentation](index.html) for more information.
+///
+/// [`anyhow::Error`]: https://docs.rs/anyhow/*/anyhow/struct.Error.html
 pub fn capture_anyhow(e: &anyhow::Error) -> Uuid {
     Hub::with_active(|hub| hub.capture_anyhow(e))
 }
 
-/// Hub extension methods for working with `anyhow`.
+/// Hub extension methods for working with [`anyhow`].
+///
+/// [`anyhow`]: https://docs.rs/anyhow
 pub trait AnyhowHubExt {
     /// Captures an [`anyhow::Error`] on a specific hub.
+    ///
+    /// [`anyhow::Error`]: https://docs.rs/anyhow/*/anyhow/struct.Error.html
     fn capture_anyhow(&self, e: &anyhow::Error) -> Uuid;
 }
 

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -3,15 +3,17 @@
 //! This integration adds a new event *source*, which allows you to create events directly
 //! from an [`anyhow::Error`] struct.  As it is only an event source it only needs to be
 //! enabled using the `anyhow` cargo feature, it does not need to be enabled in the call to
-//! [`sentry::init`](../../fn.init.html).
+//! [`sentry::init`](https://docs.rs/sentry/*/sentry/fn.init.html).
 //!
 //! This integration does not need to be installed, instead it provides an extra function to
 //! capture [`anyhow::Error`], optionally exposing it as a method on the
-//! [`sentry::Hub`](../../struct.Hub.html) using the [`AnyhowHubExt`] trait.
+//! [`sentry::Hub`](https://docs.rs/sentry/*/sentry/struct.Hub.html) using the
+//! [`AnyhowHubExt`] trait.
 //!
 //! Like a plain [`std::error::Error`] being captured, [`anyhow::Error`] is captured with a
 //! chain of all error sources, if present.  See
-//! [`sentry::capture_error`](../../fn.capture_error.html) for details of this.
+//! [`sentry::capture_error`](https://docs.rs/sentry/*/sentry/fn.capture_error.html) for
+//! details of this.
 //!
 //! # Example
 //!

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -58,8 +58,14 @@ pub struct ClientOptions {
     pub in_app_exclude: Vec<&'static str>,
     // Integration options
     /// A list of integrations to enable.
+    ///
+    /// See [`sentry::integrations`](integrations/index.html#installing-integrations) for
+    /// how to use this to enable extra integrations.
     pub integrations: Vec<Arc<dyn Integration>>,
     /// Whether to add default integrations.
+    ///
+    /// See [`sentry::integrations`](integrations/index.html#default-integrations) for
+    /// details how this works and interacts with manually installed integrations.
     pub default_integrations: bool,
     // Hooks
     /// Callback that is executed before event sending.

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -188,6 +188,8 @@ impl Scope {
     }
 
     /// Removes a tag.
+    ///
+    /// If the tag is not set, does nothing.
     pub fn remove_tag(&mut self, key: &str) {
         self.tags.remove(key);
     }

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -1,6 +1,6 @@
 //! Release Health Sessions
 //!
-//! https://develop.sentry.dev/sdk/sessions/
+//! <https://develop.sentry.dev/sdk/sessions/>
 
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::JoinHandle;

--- a/sentry-panic/src/lib.rs
+++ b/sentry-panic/src/lib.rs
@@ -18,7 +18,6 @@
 #![doc(html_logo_url = "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png")]
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
-#![warn(missing_doc_code_examples)]
 
 use std::panic::{self, PanicInfo};
 use std::sync::Once;

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -15,9 +15,9 @@ use crate::{ClientOptions, Integration};
 /// also sets the `dsn`, `release`, `environment`, and proxy settings based on
 /// environment variables.
 ///
-/// When the `default_integrations` option is set to `true` (by default), the
-/// following integrations will be added *before* any manually defined
-/// integrations, depending on enabled feature flags:
+/// When the [`ClientOptions::default_integrations`] option is set to
+/// `true` (the default), the following integrations will be added *before*
+/// any manually defined integrations, depending on enabled feature flags:
 ///
 /// 1. [`AttachStacktraceIntegration`] (`feature = "backtrace"`)
 /// 2. [`DebugImagesIntegration`] (`feature = "debug-images"`)

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -90,8 +90,51 @@ pub use crate::init::{init, ClientInitGuard};
 
 /// Available Sentry Integrations.
 ///
-/// See the [`apply_defaults`] function for more information on which integrations are
-/// used by default.
+/// Integrations extend the functionality of the SDK for some common frameworks and
+/// libraries.  Integrations come two primary kinds: as event *sources* or as event
+/// *processors*.
+///
+/// Integrations which are *sources*, like e.g. the
+/// [`sentry::integrations::anyhow`](integrations::anyhow) integration, usually provide one
+/// or more functions to create new events.  They will usually provide their own extension
+/// trait exposing a new method on the [`Hub`].
+///
+/// Integrations which *process* events in some way usually implement the
+/// [`Itegration`](crate::Integration) trait and need to be installed when sentry is
+/// initialised.
+///
+/// # Installing Integrations
+///
+/// Processing integrations which implement [`Integration`](crate::Integration) need to be
+/// installed when sentry is initialised.  This is done using the
+/// [`ClientOptions::integrations`](crate::ClientOptions::integrations) field, which you can
+/// use to add extra integrations.
+///
+/// For example if you disabled the default integrations (see below) but still wanted the
+/// [`sentry::integrations::debug_images`](integrations::debug_images) integration enabled,
+/// you could do this as such:
+///
+/// ```
+/// use sentry::ClientOptions;
+/// use sentry::integrations::debug_images::DebugImagesIntegration;
+///
+/// let options = ClientOptions {
+///     // Add a DSN.
+///     default_integrations: false,
+///     integrations: vec![DebugImagesIntegration::default()],
+///     ..Default::default()
+/// };
+/// let _guard = sentry::init(options);
+/// ```
+///
+/// # Default Integrations
+///
+/// The [`ClientOptions::default_integrations`](crate::ClientOptions::default_integrations)
+/// option is a boolean field that when enabled will enable a number of default integrations
+/// **before** any integrations provided by
+/// [`ClientOptions::integrations`](crate::ClientOptions::integrations) are installed.  This
+/// is done using the [`apply_defaults`] function, which should be consulted for more
+/// details and the list of which integrations are by default enabled.
 ///
 /// [`apply_defaults`]: ../fn.apply_defaults.html
 pub mod integrations {

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::init::{init, ClientInitGuard};
 ///
 /// Processing integrations which implement [`Integration`](crate::Integration) need to be
 /// installed when sentry is initialised.  This is done using the
-/// [`ClientOptions::integrations`](crate::ClientOptions::integrations) field, which you can
+/// [`ClientOptions::add_integration`](crate::ClientOptions::add_integration) function, which you can
 /// use to add extra integrations.
 ///
 /// For example if you disabled the default integrations (see below) but still wanted the
@@ -119,11 +119,9 @@ pub use crate::init::{init, ClientInitGuard};
 /// use sentry::integrations::debug_images::DebugImagesIntegration;
 ///
 /// let options = ClientOptions {
-///     // Add a DSN.
 ///     default_integrations: false,
-///     integrations: vec![DebugImagesIntegration::default()],
 ///     ..Default::default()
-/// };
+/// }.add_integration(DebugImagesIntegration::new());
 /// let _guard = sentry::init(options);
 /// ```
 ///
@@ -134,7 +132,7 @@ pub use crate::init::{init, ClientInitGuard};
 /// **before** any integrations provided by
 /// [`ClientOptions::integrations`](crate::ClientOptions::integrations) are installed.  This
 /// is done using the [`apply_defaults`] function, which should be consulted for more
-/// details and the list of which integrations are by default enabled.
+/// details and the list of which integrations are enabled by default.
 ///
 /// [`apply_defaults`]: ../fn.apply_defaults.html
 pub mod integrations {

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -115,6 +115,7 @@ pub use crate::init::{init, ClientInitGuard};
 /// you could do this as such:
 ///
 /// ```
+/// # #[cfg(feature = "debug-images")] {
 /// use sentry::ClientOptions;
 /// use sentry::integrations::debug_images::DebugImagesIntegration;
 ///
@@ -123,6 +124,7 @@ pub use crate::init::{init, ClientInitGuard};
 ///     ..Default::default()
 /// }.add_integration(DebugImagesIntegration::new());
 /// let _guard = sentry::init(options);
+/// # }
 /// ```
 ///
 /// # Default Integrations


### PR DESCRIPTION
This adds more documentation for how to use integrations and uses much
more intra-doc links.  The Hub documentation as well as the anyhow
integration documentation have also seen various improvements.

The docs no build again without any warnings.

#skip-changelog