### PR TITLE
fix: Propagate User updates to the active Session

### DIFF
--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -178,6 +178,9 @@ impl Scope {
 
     /// Sets the user for the current scope.
     pub fn set_user(&mut self, user: Option<User>) {
+        if let Some(session) = self.session.lock().unwrap().as_mut() {
+            session.update_user(user.as_ref());
+        }
         self.user = user.map(Arc::new);
     }
 


### PR DESCRIPTION
In case the session was not yet flushed, we can still set the User.

Question is: Should we flush sessions as soon as we capture anything else or not?
+ on flushing early is that at least we have *something*, - is that it creates more load on the backend, and becomes immutable.