### PR TITLE
fix: Correctly apply environment from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The deprecated `error-chain` and `failure` integrations, features and crates were removed.
 
+**Fixes**:
+
+- Fix regression defaulting `ClientOptions::environment` from `SENTRY_ENVIRONMENT`.
+
 ## 0.21.0
 
 **Breaking Changes**:

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -167,16 +167,11 @@ impl fmt::Debug for ClientOptions {
 
 impl Default for ClientOptions {
     fn default() -> ClientOptions {
-        let env = if cfg!(debug_assertions) {
-            "development"
-        } else {
-            "production"
-        };
         ClientOptions {
             dsn: None,
             debug: false,
             release: None,
-            environment: Some(env.into()),
+            environment: None,
             sample_rate: 1.0,
             max_breadcrumbs: 100,
             attach_stacktrace: false,


### PR DESCRIPTION
I basically broke this in https://github.com/getsentry/sentry-rust/pull/280