### PR TITLE
ci: Collect Code Coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,28 @@ jobs:
       - run: make checkfast
 
       - run: make testfast
+
+  codecov:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true # well, its nightly and highly experimental
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: llvm-tools-preview
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: Swatinem/fucov@v1
+        with:
+          args: --workspace --all-features
+
+      - uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
+        with:
+          directory: coverage

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 # Sentry SDK for Rust
 
 [![Build Status](https://travis-ci.com/getsentry/sentry-rust.svg?branch=master)](https://travis-ci.com/getsentry/sentry-rust)
+[![codecov](https://codecov.io/gh/getsentry/sentry-rust/branch/master/graph/badge.svg?token=x4RzFE8N6t)](https://codecov.io/gh/getsentry/sentry-rust)
 
 This workspace contains various crates that provide support for logging events and errors / panics to the
 [Sentry](https://sentry.io/) error logging service.


### PR DESCRIPTION
This uses the experimental nightly-only source-based code coverage based on llvm tooling.
Uses my own https://github.com/Swatinem/fucov github action to orchestrate all the steps. That repo has links to some tracking issues. Especially getting coverage for doctests is still broken in workspaces, which I am tracking.

I think this is good enough to land, and will get automatically better once rust/cargo upstream will get fixed.