### PR TITLE
Add slog KVs to the Sentry Map

### DIFF
--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -21,3 +21,5 @@ serde_json = "1.0.46"
 
 [dev-dependencies]
 sentry = { version = "0.21.0", path = "../sentry", default-features = false, features = ["test"] }
+serde = "1.0.117"
+erased-serde = "0.3.12"

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -16,7 +16,8 @@ all-features = true
 
 [dependencies]
 sentry-core = { version = "0.21.0", path = "../sentry-core" }
-slog = "2.5.2"
+slog = { version = "2.5.2", features = ["nested-values"] }
+serde_json = "1.0.46"
 
 [dev-dependencies]
 sentry = { version = "0.21.0", path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-slog/src/converters.rs
+++ b/sentry-slog/src/converters.rs
@@ -1,5 +1,6 @@
 use sentry_core::protocol::{Breadcrumb, Event, Exception, Frame, Level, Map, Stacktrace, Value};
-use slog::{OwnedKVList, Record, KV};
+use slog::{Key, OwnedKVList, Record, Serializer, KV};
+use std::fmt;
 
 /// Converts a [`slog::Level`] to a Sentry [`Level`]
 pub fn convert_log_level(level: slog::Level) -> Level {
@@ -11,17 +12,49 @@ pub fn convert_log_level(level: slog::Level) -> Level {
     }
 }
 
+struct MapSerializer<'a>(&'a mut Map<String, Value>);
+
+macro_rules! impl_into {
+    ($t:ty => $f:ident) => {
+        fn $f(&mut self, key: Key, val: $t) -> slog::Result {
+            self.0.insert(key.into(), val.into());
+            Ok(())
+        }
+    };
+}
+impl<'a> Serializer for MapSerializer<'a> {
+    fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments) -> slog::Result {
+        self.0.insert(key.into(), format!("{}", val).into());
+        Ok(())
+    }
+
+    impl_into! { usize => emit_usize }
+    impl_into! { isize => emit_isize }
+    impl_into! { bool  => emit_bool  }
+    impl_into! { u8    => emit_u8    }
+    impl_into! { i8    => emit_i8    }
+    impl_into! { u16   => emit_u16   }
+    impl_into! { i16   => emit_i16   }
+    impl_into! { u32   => emit_u32   }
+    impl_into! { i32   => emit_i32   }
+    impl_into! { f32   => emit_f32   }
+    impl_into! { u64   => emit_u64   }
+    impl_into! { i64   => emit_i64   }
+    impl_into! { f64   => emit_f64   }
+    impl_into! { &str  => emit_str   }
+}
+
 /// Adds the data from a [`slog::KV`] into a Sentry [`Map`].
-fn add_kv_to_map(map: &mut Map<String, Value>, kv: &impl KV) {
-    let _ = (map, kv);
-    // TODO: actually implement this ;-)
+fn add_kv_to_map(map: &mut Map<String, Value>, record: &Record, kv: &impl KV) {
+    // TODO: Do something with these errors?
+    let _ = record.kv().serialize(record, &mut MapSerializer(map));
+    let _ = kv.serialize(record, &mut MapSerializer(map));
 }
 
 /// Creates a Sentry [`Breadcrumb`] from the [`Record`].
 pub fn breadcrumb_from_record(record: &Record, values: &OwnedKVList) -> Breadcrumb {
     let mut data = Map::new();
-    add_kv_to_map(&mut data, &record.kv());
-    add_kv_to_map(&mut data, values);
+    add_kv_to_map(&mut data, record, values);
 
     Breadcrumb {
         ty: "log".into(),
@@ -35,8 +68,7 @@ pub fn breadcrumb_from_record(record: &Record, values: &OwnedKVList) -> Breadcru
 /// Creates a simple message [`Event`] from the [`Record`].
 pub fn event_from_record(record: &Record, values: &OwnedKVList) -> Event<'static> {
     let mut extra = Map::new();
-    add_kv_to_map(&mut extra, &record.kv());
-    add_kv_to_map(&mut extra, values);
+    add_kv_to_map(&mut extra, record, values);
     Event {
         message: Some(record.msg().to_string()),
         level: convert_log_level(record.level()),

--- a/sentry-slog/src/converters.rs
+++ b/sentry-slog/src/converters.rs
@@ -28,6 +28,12 @@ impl<'a> Serializer for MapSerializer<'a> {
         Ok(())
     }
 
+    fn emit_serde(&mut self, key: Key, val: &dyn slog::SerdeValue) -> slog::Result {
+        let value = serde_json::to_value(val.as_serde()).map_err(|_e| slog::Error::Other)?;
+        self.0.insert(key.into(), value);
+        Ok(())
+    }
+
     impl_into! { usize => emit_usize }
     impl_into! { isize => emit_isize }
     impl_into! { bool  => emit_bool  }


### PR DESCRIPTION
Pretty straightforward - adds a wrapper for `Map` that lets it be used as a `slog::Serializer`, which `KV`s can be appended too.

This also enables the `nested-values` feature on `slog` so that it can accept any serde-serializable values. Considered adding a feature flag, but `sentry-core` already pulls in `serde` & co, so it wouldn't really save any dependencies.