### PR TITLE
Avoid overflow panic

### DIFF
--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -160,7 +160,9 @@ impl SessionFlusher {
                 }
                 let mut last_flush = Instant::now();
                 loop {
-                    let timeout = FLUSH_INTERVAL - last_flush.elapsed();
+                    let timeout = FLUSH_INTERVAL
+                        .checked_sub(last_flush.elapsed())
+                        .unwrap_or_else(|| Duration::from_secs(0));
                     shutdown = cvar.wait_timeout(shutdown, timeout).unwrap().0;
                     if *shutdown {
                         return;


### PR DESCRIPTION
We encountered a really strange panic (reported in Sentry, yay!), unfortunately the only information was

`overflow when subtracting durations, file: library\core\src\time.rs:895:31, thread: sentry-session-flusher`

And, AFAICT, this is the only place in that thread that dues a Duration subtraction, so putting this as a tentative workaround for it.