### PR TITLE
fix(log): Create a plain message for exception logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fix regression defaulting `ClientOptions::environment` from `SENTRY_ENVIRONMENT`.
 - The `debug-images` integration now captures the correct `image_addr`.
+- Do not send invalid exception events in the `log` and `slog` integrations. Both integrations no longer attach the location. To receive location information, set `options.attach_stacktrace` to `true`.
 
 **Thank you**:
 

--- a/sentry-slog/src/converters.rs
+++ b/sentry-slog/src/converters.rs
@@ -1,4 +1,4 @@
-use sentry_core::protocol::{Breadcrumb, Event, Exception, Frame, Level, Map, Stacktrace, Value};
+use sentry_core::protocol::{Breadcrumb, Event, Level, Map, Value};
 use slog::{Key, OwnedKVList, Record, Serializer, KV};
 use std::fmt;
 
@@ -85,9 +85,6 @@ pub fn event_from_record(record: &Record, values: &OwnedKVList) -> Event<'static
 
 /// Creates an exception [`Event`] from the [`Record`].
 ///
-/// The exception will have a stacktrace that corresponds to the location
-/// information contained in the [`Record`].
-///
 /// # Examples
 ///
 /// ```
@@ -95,13 +92,6 @@ pub fn event_from_record(record: &Record, values: &OwnedKVList) -> Event<'static
 /// let record = slog::record!(slog::Level::Error, "", &args, slog::b!());
 /// let kv = slog::o!().into();
 /// let event = sentry_slog::exception_from_record(&record, &kv);
-///
-/// let frame = &event.exception.as_ref()[0]
-///     .stacktrace
-///     .as_ref()
-///     .unwrap()
-///     .frames[0];
-/// assert!(frame.lineno.unwrap() > 0);
 /// ```
 pub fn exception_from_record(record: &Record, values: &OwnedKVList) -> Event<'static> {
     // TODO: Exception records in Sentry need a valid type, value and full stack trace to support

--- a/sentry-slog/src/converters.rs
+++ b/sentry-slog/src/converters.rs
@@ -104,25 +104,11 @@ pub fn event_from_record(record: &Record, values: &OwnedKVList) -> Event<'static
 /// assert!(frame.lineno.unwrap() > 0);
 /// ```
 pub fn exception_from_record(record: &Record, values: &OwnedKVList) -> Event<'static> {
-    let mut event = event_from_record(record, values);
-    let frame = Frame {
-        function: Some(record.function().into()),
-        module: Some(record.module().into()),
-        filename: Some(record.file().into()),
-        lineno: Some(record.line().into()),
-        colno: Some(record.column().into()),
-        ..Default::default()
-    };
-    let exception = Exception {
-        ty: "slog::Record".into(),
-        stacktrace: Some(Stacktrace {
-            frames: vec![frame],
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
-    event.exception = vec![exception].into();
-    event
+    // TODO: Exception records in Sentry need a valid type, value and full stack trace to support
+    // proper grouping and issue metadata generation. log::Record does not contain sufficient
+    // information for this. However, it may contain a serialized error which we can parse to emit
+    // an exception record.
+    event_from_record(record, values)
 }
 
 #[cfg(test)]

--- a/sentry-slog/src/lib.rs
+++ b/sentry-slog/src/lib.rs
@@ -43,7 +43,10 @@
 //! # });
 //! # let captured_event = events.into_iter().next().unwrap();
 //!
-//! assert_eq!(captured_event.exception.len(), 1);
+//! assert_eq!(
+//!     captured_event.message.as_deref(),
+//!     Some("recorded as exception event")
+//! );
 //! ```
 //!
 //! The Drain can also be customized with a `filter`, and a `mapper`:


### PR DESCRIPTION
Valid exception records in Sentry require a type that reflects the exception name, and frames with function names. Otherwise, issue grouping cannot work properly.