### PR TITLE
Process thread stacktraces in addition to exception traces

### DIFF
--- a/sentry-backtrace/src/integration.rs
+++ b/sentry-backtrace/src/integration.rs
@@ -37,6 +37,14 @@ impl Integration for ProcessStacktraceIntegration {
                 process_event_stacktrace(stacktrace, &options);
             }
         }
+        for th in &mut event.threads {
+            if let Some(ref mut stacktrace) = th.stacktrace {
+                process_event_stacktrace(stacktrace, &options);
+            }
+        }
+        if let Some(ref mut stacktrace) = event.stacktrace {
+            process_event_stacktrace(stacktrace, &options);
+        }
         Some(event)
     }
 }


### PR DESCRIPTION
Noticed that these were getting missed in processing.