### PR TITLE
Upgrade to `tokio 1.0` and `reqwest 0.11`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.42.0]
+        rust: [1.45.0]
 
     name: checkfast/testfast using ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ best API and adding new features.
 We currently only verify this crate against a recent version of Sentry hosted on [sentry.io](https://sentry.io/) but it
 should work with on-prem Sentry versions 8.20 and later.
 
-Additionally, the lowest Rust version we target is _1.42.0_.
+Additionally, the lowest Rust version we target is _1.45.0_.
 
 ## Resources
 

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -38,4 +38,4 @@ log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"]
 sentry = { version = "0.21.0", path = "../sentry", default-features = false, features = ["test"] }
 thiserror = "1.0.15"
 anyhow = "1.0.30"
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
+tokio = { version = "1.0", features = ["rt", "macros"] }

--- a/sentry-core/src/futures.rs
+++ b/sentry-core/src/futures.rs
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn test_futures() {
         let mut events = with_captured_events(|| {
-            let mut runtime = Runtime::new().unwrap();
+            let runtime = Runtime::new().unwrap();
 
             // spawn two separate tasks, and await them in the end.
             runtime.block_on(async {

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -48,7 +48,7 @@ sentry-log = { version = "0.21.0", path = "../sentry-log", optional = true }
 sentry-panic = { version = "0.21.0", path = "../sentry-panic", optional = true }
 sentry-slog = { version = "0.21.0", path = "../sentry-slog", optional = true }
 log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
-reqwest_ = { package = "reqwest", version = "0.10.8", optional = true, features = ["blocking", "json"], default-features = false }
+reqwest_ = { package = "reqwest", version = "0.11", optional = true, features = ["blocking", "json"], default-features = false }
 curl_ = { package = "curl", version = "0.4.25", optional = true }
 surf_ = { package = "surf", version = "2.0.0", optional = true }
 futures = { version = "0.3", optional = true }
@@ -62,6 +62,6 @@ sentry-slog = { version = "0.21.0", path = "../sentry-slog" }
 log_ = { package = "log", version = "0.4.8", features = ["std"] }
 slog_ = { package = "slog", version = "2.5.2" }
 actix-web = { version = "3", default-features = false }
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros"] }
 pretty_env_logger = "0.4.0"
 anyhow_ = { package = "anyhow", version = "1.0.30" }


### PR DESCRIPTION
This upgrades `sentry-core` and `sentry` to the new releases. `sentry-actix` is still based on `tokio 0.2`. The MSRV is bumped to 1.45.0.