### PR TITLE
fix: Expose flush method and use it in the panic hook

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -290,6 +290,16 @@ impl Client {
         self.session_flusher.enqueue(session_update)
     }
 
+    /// Drains all pending events without shutting down.
+    pub fn flush(&self, timeout: Option<Duration>) -> bool {
+        self.session_flusher.flush();
+        if let Some(ref transport) = *self.transport.read().unwrap() {
+            transport.flush(timeout.unwrap_or(self.options.shutdown_timeout))
+        } else {
+            true
+        }
+    }
+
     /// Drains all pending events and shuts down the transport behind the
     /// client.  After shutting down the transport is removed.
     ///

--- a/sentry-panic/src/lib.rs
+++ b/sentry-panic/src/lib.rs
@@ -33,7 +33,10 @@ use sentry_core::{ClientOptions, Integration};
 /// Sentry panic handler.
 pub fn panic_handler(info: &PanicInfo<'_>) {
     sentry_core::with_integration(|integration: &PanicIntegration, hub| {
-        hub.capture_event(integration.event_from_panic_info(info))
+        hub.capture_event(integration.event_from_panic_info(info));
+        if let Some(client) = hub.client() {
+            client.flush(None);
+        }
     });
 }
 


### PR DESCRIPTION
This is a followup to #314 which I apparently forgot to push.