### PR TITLE
build(actix): Update actix-web to v4.

### DIFF
--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -12,8 +12,8 @@ Sentry client extension for actix-web 3.
 edition = "2018"
 
 [dependencies]
-sentry-core = { version = "0.23.0", path = "../sentry-core", default-features = false }
-actix-web = { version = "3", default-features = false }
+sentry-core = { version = "0.23.0", path = "../sentry-core", default-features = false, features = ["client"] }
+actix-web = { version = "4.0.0-beta", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
 
 [dev-dependencies]

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -150,12 +150,11 @@ impl Default for Sentry {
     }
 }
 
-impl<S, B> Transform<S> for Sentry
+impl<S, B> Transform<S, ServiceRequest> for Sentry
 where
-    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = Error;
     type Transform = SentryMiddleware<S>;
@@ -176,24 +175,23 @@ pub struct SentryMiddleware<S> {
     inner: Sentry,
 }
 
-impl<S, B> Service for SentryMiddleware<S>
+impl<S, B> Service<ServiceRequest> for SentryMiddleware<S>
 where
-    S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
 {
-    type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
 
     fn poll_ready(
-        &mut self,
+        &self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, req: ServiceRequest) -> Self::Future {
+    fn call(&self, req: ServiceRequest) -> Self::Future {
         let inner = self.inner.clone();
         let hub = Arc::new(Hub::new_from_top(
             inner.hub.clone().unwrap_or_else(Hub::main),
@@ -349,7 +347,7 @@ mod tests {
                     HttpResponse::Ok()
                 };
 
-                let mut app = init_service(
+                let app = init_service(
                     App::new()
                         .wrap(Sentry::builder().with_hub(Hub::current()).finish())
                         .service(web::resource("/test").to(service)),
@@ -359,7 +357,7 @@ mod tests {
                 // Call the service twice (sequentially) to ensure the middleware isn't sticky
                 for _ in 0..2 {
                     let req = TestRequest::get().uri("/test").to_request();
-                    let res = call_service(&mut app, req).await;
+                    let res = call_service(&app, req).await;
                     assert!(res.status().is_success());
                 }
             })
@@ -388,7 +386,7 @@ mod tests {
                     Err(io::Error::new(io::ErrorKind::Other, "Test Error").into())
                 }
 
-                let mut app = init_service(
+                let app = init_service(
                     App::new()
                         .wrap(Sentry::builder().with_hub(Hub::current()).finish())
                         .service(failing),
@@ -398,7 +396,7 @@ mod tests {
                 // Call the service twice (sequentially) to ensure the middleware isn't sticky
                 for _ in 0..2 {
                     let req = TestRequest::get().uri("/test").to_request();
-                    let res = call_service(&mut app, req).await;
+                    let res = call_service(&app, req).await;
                     assert!(res.status().is_server_error());
                 }
             })
@@ -423,7 +421,7 @@ mod tests {
             block_on(async {
                 let service = || HttpResponse::NotFound();
 
-                let mut app = init_service(
+                let app = init_service(
                     App::new()
                         .wrap(Sentry::builder().with_hub(Hub::current()).finish())
                         .service(web::resource("/test").to(service)),
@@ -431,7 +429,7 @@ mod tests {
                 .await;
 
                 let req = TestRequest::get().uri("/test").to_request();
-                let res = call_service(&mut app, req).await;
+                let res = call_service(&app, req).await;
                 assert!(res.status().is_client_error());
             })
         });
@@ -451,7 +449,7 @@ mod tests {
                     Err(io::Error::new(io::ErrorKind::Other, "Test Error").into())
                 }
 
-                let mut app = init_service(
+                let app = init_service(
                     App::new()
                         .wrap(Sentry::builder().with_hub(Hub::current()).finish())
                         .service(original_transaction),
@@ -459,7 +457,7 @@ mod tests {
                 .await;
 
                 let req = TestRequest::get().uri("/test").to_request();
-                let res = call_service(&mut app, req).await;
+                let res = call_service(&app, req).await;
                 assert!(res.status().is_server_error());
             })
         });
@@ -487,11 +485,11 @@ mod tests {
 
                     let middleware = Sentry::builder().with_hub(Hub::current()).finish();
 
-                    let mut app = init_service(App::new().wrap(middleware).service(hello)).await;
+                    let app = init_service(App::new().wrap(middleware).service(hello)).await;
 
                     for _ in 0..5 {
                         let req = TestRequest::get().uri("/").to_request();
-                        call_service(&mut app, req).await;
+                        call_service(&app, req).await;
                     }
                 })
             },

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -70,7 +70,7 @@ log_ = { package = "log", version = "0.4.8", features = ["std"] }
 slog_ = { package = "slog", version = "2.5.2" }
 tracing_ = { package = "tracing", version = "0.1" }
 tracing-subscriber = { version = "0.2", features = ["fmt", "tracing-log"] }
-actix-web = { version = "3", default-features = false }
+actix-web = { version = "4.0.0-beta", default-features = false }
 tokio = { version = "1.0", features = ["macros"] }
 pretty_env_logger = "0.4.0"
 anyhow_ = { package = "anyhow", version = "1.0.30" }


### PR DESCRIPTION
Updated sentry-actix to support actix-web v4 (currently still in beta).