### PR TITLE
fix(deps): correct minium chrono version and MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [1.45.0]
+        rust: [1.46.0]
 
     name: Check / Test MSRV ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Breaking Changes**:
+
+- The minium supported Rust version was bumped to **1.46.0** due to requirements from dependencies.
+
 ## 0.22.0
 
 **Breaking Changes**:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ best API and adding new features.
 We currently only verify this crate against a recent version of Sentry hosted on [sentry.io](https://sentry.io/) but it
 should work with on-prem Sentry versions 20.6 and later.
 
-Additionally, the lowest Rust version we target is _1.45.0_.
+Additionally, the lowest Rust version we target is _1.46.0_.
 
 ## Resources
 

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -29,7 +29,7 @@ test = ["client"]
 [dependencies]
 sentry-types = { version = "0.22.0", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
-chrono = "0.4.10"
+chrono = "0.4.13"
 lazy_static = "1.4.0"
 rand = { version = "0.8.1", optional = true }
 serde_json = "1.0.46"

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -24,6 +24,6 @@ thiserror = "1.0.15"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.46"
 url = { version = "2.1.1", features = ["serde"] }
-chrono = { version = "0.4.10", default-features = false, features = ["clock", "std", "serde"] }
+chrono = { version = "0.4.13", default-features = false, features = ["clock", "std", "serde"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 debugid = { version = "0.7.2", features = ["serde"] }


### PR DESCRIPTION
The sentry-core crate uses the chrono::DurationRound trait which was
only introduced in chrono 0.4.13.  The sentry-types crate is updated
just to keep the versions in sync.