### PR TITLE
fix: Explicitly drop SessionFlusher

### DIFF
--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -156,7 +156,7 @@ impl Hub {
             f(&PROCESS_HUB.0)
         } else {
             // note on safety: this is safe because even though we change the Arc
-            // by temorary binding we guarantee that the original Arc stays alive.
+            // by temporary binding we guarantee that the original Arc stays alive.
             // For more information see: run
             THREAD_HUB.with(|stack| unsafe {
                 let ptr = stack.get();

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -51,7 +51,7 @@ log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"]
 reqwest_ = { package = "reqwest", version = "0.11", optional = true, features = ["blocking", "json"], default-features = false }
 curl_ = { package = "curl", version = "0.4.25", optional = true }
 surf_ = { package = "surf", version = "2.0.0", optional = true }
-httpdate = { version = "0.3.2", optional = true }
+httpdate = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0.48", optional = true }
 tokio = { version = "1.0", features = ["rt"] }
 

--- a/sentry/tests/test_client.rs
+++ b/sentry/tests/test_client.rs
@@ -56,3 +56,18 @@ fn test_unwind_safe() {
 
     assert_eq!(events.len(), 1);
 }
+
+#[test]
+fn test_concurrent_init() {
+    let _guard = sentry::init(sentry::ClientOptions {
+        ..Default::default()
+    });
+
+    std::thread::spawn(|| {
+        let _guard = sentry::init(sentry::ClientOptions {
+            ..Default::default()
+        });
+    })
+    .join()
+    .unwrap();
+}


### PR DESCRIPTION
It seems that doing a thread::join from within the Drop impl of a thread
local THREAD_HUB will deadlock for some reason.
Explicitly joining the background flusher as part of the ClientGuard
Drop does work, and is also more correct, as otherwise the PROCESS_HUB
might keep the worker alive forever.

Fixes #322