### PR TITLE
Add missing support for WASM images/frames

### DIFF
--- a/sentry-types/tests/test_protocol_v7.rs
+++ b/sentry-types/tests/test_protocol_v7.rs
@@ -932,6 +932,7 @@ mod test_exception {
                         image_addr: Some(v7::Addr(0)),
                         instruction_addr: Some(v7::Addr(0)),
                         symbol_addr: Some(v7::Addr(0)),
+                        addr_mode: None,
                     }],
                     frames_omitted: Some((1, 2)),
                     registers: {


### PR DESCRIPTION
This adds support for reporting events with WASM stack traces when eg. running modules via wasmtime or other runtimes.