### PR TITLE
feat: Allow capturing backtraces from anyhow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The minium supported Rust version was bumped to **1.46.0** due to requirements from dependencies.
 
+**Features**:
+
+- Allow capturing backtraces from anyhow errors.
+
 ## 0.22.0
 
 **Breaking Changes**:

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -12,8 +12,9 @@ Sentry integration for anyhow.
 edition = "2018"
 
 [dependencies]
+sentry-backtrace = { version = "0.22.0", path = "../sentry-backtrace" }
 sentry-core = { version = "0.22.0", path = "../sentry-core" }
-anyhow = "1.0.30"
+anyhow = { version = "1.0.39", features = ["backtrace"] }
 
 [dev-dependencies]
 sentry = { version = "0.22.0", path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -64,8 +64,33 @@ pub trait AnyhowHubExt {
 }
 
 impl AnyhowHubExt for Hub {
-    fn capture_anyhow(&self, e: &anyhow::Error) -> Uuid {
-        let e: &dyn std::error::Error = e.as_ref();
-        self.capture_error(e)
+    fn capture_anyhow(&self, anyhow_error: &anyhow::Error) -> Uuid {
+        let dyn_err: &dyn std::error::Error = anyhow_error.as_ref();
+        let mut event = sentry_core::event_from_error(dyn_err);
+
+        // exception records are sorted in reverse
+        if let Some(exc) = event.exception.iter_mut().last() {
+            let backtrace = anyhow_error.backtrace();
+            exc.stacktrace = sentry_backtrace::parse_stacktrace(&format!("{:#}", backtrace));
+        }
+
+        self.capture_event(event)
     }
+}
+
+#[test]
+fn test_has_backtrace() {
+    std::env::set_var("RUST_BACKTRACE", "1");
+
+    let events = sentry::test::with_captured_events(|| {
+        capture_anyhow(&anyhow::anyhow!("Oh jeez"));
+    });
+
+    let stacktrace = events[0].exception[0].stacktrace.as_ref().unwrap();
+    let found_test_fn = stacktrace
+        .frames
+        .iter()
+        .any(|frame| frame.function.as_deref() == Some("sentry_anyhow::test_has_backtrace"));
+
+    assert!(found_test_fn);
 }

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -87,10 +87,10 @@ fn test_has_backtrace() {
     });
 
     let stacktrace = events[0].exception[0].stacktrace.as_ref().unwrap();
-    let found_test_fn = stacktrace
-        .frames
-        .iter()
-        .any(|frame| frame.function.as_deref() == Some("sentry_anyhow::test_has_backtrace"));
+    let found_test_fn = stacktrace.frames.iter().any(|frame| match &frame.function {
+        Some(f) => f.contains("test_has_backtrace"),
+        None => false,
+    });
 
     assert!(found_test_fn);
 }


### PR DESCRIPTION
This also fixes parsing of backtraces that have both line and column numbers.

fixes #337