### PR TITLE
Update the Transaction struct to match the transaction payload spec

### DIFF
--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -27,3 +27,5 @@ url = { version = "2.1.1", features = ["serde"] }
 chrono = { version = "0.4.13", default-features = false, features = ["clock", "std", "serde"] }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 debugid = { version = "0.7.2", features = ["serde"] }
+getrandom = "0.2.3"
+hex = "0.4.3"

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -285,8 +285,8 @@ mod test {
     #[test]
     fn test_transaction() {
         let event_id = Uuid::parse_str("22d00b3f-d1b1-4b5d-8d20-49d138cd8a9c").unwrap();
-        let span_id = Uuid::parse_str("d42cee9f-c3e7-4f5c-ada9-47ab601a14d2").unwrap();
-        let trace_id = Uuid::parse_str("335e53d6-1447-4acc-9f89-e632b776cc28").unwrap();
+        let span_id = "d42cee9fc3e74f5c".parse().unwrap();
+        let trace_id = "335e53d614474acc9f89e632b776cc28".parse().unwrap();
         let start_timestamp = "2020-07-20T14:51:14.296Z".parse::<DateTime<Utc>>().unwrap();
         let spans = vec![Span {
             span_id,

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -304,8 +304,8 @@ mod test {
         assert_eq!(
             to_str(envelope),
             r#"{"event_id":"22d00b3f-d1b1-4b5d-8d20-49d138cd8a9c"}
-{"type":"transaction","length":216}
-{"event_id":"22d00b3fd1b14b5d8d2049d138cd8a9c","start_timestamp":1595256674.296,"spans":[{"span_id":"d42cee9fc3e74f5cada947ab601a14d2","trace_id":"335e53d614474acc9f89e632b776cc28","start_timestamp":1595256674.296}]}
+{"type":"transaction","length":200}
+{"event_id":"22d00b3fd1b14b5d8d2049d138cd8a9c","start_timestamp":1595256674.296,"spans":[{"span_id":"d42cee9fc3e74f5c","trace_id":"335e53d614474acc9f89e632b776cc28","start_timestamp":1595256674.296}]}
 "#
         )
     }

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1695,8 +1695,12 @@ pub struct Transaction<'a> {
     #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
     pub event_id: Uuid,
     /// The transaction name.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<String>,
+    #[serde(
+        rename = "transaction",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub name: Option<String>,
     /// Optional tags to be attached to the event.
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub tags: Map<String, String>,
@@ -1726,7 +1730,7 @@ impl<'a> Default for Transaction<'a> {
     fn default() -> Self {
         Transaction {
             event_id: event::default_id(),
-            transaction: Default::default(),
+            name: Default::default(),
             tags: Default::default(),
             sdk: Default::default(),
             platform: event::default_platform(),
@@ -1748,7 +1752,7 @@ impl<'a> Transaction<'a> {
     pub fn into_owned(self) -> Transaction<'static> {
         Transaction {
             event_id: self.event_id,
-            transaction: self.transaction,
+            name: self.name,
             tags: self.tags,
             sdk: self.sdk.map(|x| Cow::Owned(x.into_owned())),
             platform: Cow::Owned(self.platform.into_owned()),

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -7,6 +7,7 @@
 
 use std::borrow::Cow;
 use std::cmp;
+use std::convert::TryFrom;
 use std::fmt;
 use std::iter::FromIterator;
 use std::net::{AddrParseError, IpAddr};
@@ -1255,21 +1256,110 @@ pub struct BrowserContext {
     pub other: Map<String, Value>,
 }
 
+/// Holds the identifier for a Span
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[serde(try_from = "String", into = "String")]
+pub struct SpanId([u8; 8]);
+
+impl Default for SpanId {
+    fn default() -> Self {
+        let mut buf = [0; 8];
+
+        getrandom::getrandom(&mut buf)
+            .unwrap_or_else(|err| panic!("could not retrieve random bytes for SpanId: {}", err));
+
+        Self(buf)
+    }
+}
+
+impl fmt::Display for SpanId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", hex::encode(&self.0))
+    }
+}
+
+impl From<SpanId> for String {
+    fn from(span_id: SpanId) -> Self {
+        span_id.to_string()
+    }
+}
+
+impl str::FromStr for SpanId {
+    type Err = hex::FromHexError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut buf = [0; 8];
+        hex::decode_to_slice(input, &mut buf)?;
+        Ok(Self(buf))
+    }
+}
+
+impl TryFrom<String> for SpanId {
+    type Error = hex::FromHexError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+/// Holds the identifier for a Trace
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[serde(try_from = "String", into = "String")]
+pub struct TraceId([u8; 16]);
+
+impl Default for TraceId {
+    fn default() -> Self {
+        let mut buf = [0; 16];
+
+        getrandom::getrandom(&mut buf)
+            .unwrap_or_else(|err| panic!("could not retrieve random bytes for TraceId: {}", err));
+
+        Self(buf)
+    }
+}
+
+impl fmt::Display for TraceId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", hex::encode(&self.0))
+    }
+}
+
+impl From<TraceId> for String {
+    fn from(trace_id: TraceId) -> Self {
+        trace_id.to_string()
+    }
+}
+
+impl str::FromStr for TraceId {
+    type Err = hex::FromHexError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut buf = [0; 16];
+        hex::decode_to_slice(input, &mut buf)?;
+        Ok(Self(buf))
+    }
+}
+
+impl TryFrom<String> for TraceId {
+    type Error = hex::FromHexError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
 /// Holds information about a tracing event.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct TraceContext {
     /// The ID of the trace event
-    #[serde(
-        default = "event::default_id",
-        serialize_with = "event::serialize_span_id"
-    )]
-    pub span_id: Uuid,
+    #[serde(default)]
+    pub span_id: SpanId,
     /// Determines which trace the transaction belongs to.
-    #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
-    pub trace_id: Uuid,
+    #[serde(default)]
+    pub trace_id: TraceId,
     /// Determines the parent of this transaction if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parent_span_id: Option<String>,
+    pub parent_span_id: Option<SpanId>,
     /// Short code identifying the type of operation the transaction is measuring.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op: Option<String>,
@@ -1307,11 +1397,6 @@ mod event {
 
     pub fn serialize_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_some(&uuid.to_simple_ref().to_string())
-    }
-
-    pub fn serialize_span_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
-        let uuid = uuid.to_simple_ref().to_string();
-        serializer.serialize_some(&uuid[..16])
     }
 
     pub fn default_level() -> Level {
@@ -1528,17 +1613,14 @@ impl<'a> fmt::Display for Event<'a> {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Span {
     /// The ID of the span
-    #[serde(
-        default = "event::default_id",
-        serialize_with = "event::serialize_span_id"
-    )]
-    pub span_id: Uuid,
+    #[serde(default)]
+    pub span_id: SpanId,
     /// Determines which trace the span belongs to.
-    #[serde(default = "event::default_id", serialize_with = "event::serialize_id")]
-    pub trace_id: Uuid,
+    #[serde(default)]
+    pub trace_id: TraceId,
     /// Determines the parent of this span, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parent_span_id: Option<String>,
+    pub parent_span_id: Option<SpanId>,
     /// Determines whether this span is generated in the same process as its parent, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub same_process_as_parent: Option<bool>,
@@ -1569,8 +1651,8 @@ pub struct Span {
 impl Default for Span {
     fn default() -> Self {
         Span {
-            span_id: event::default_id(),
-            trace_id: event::default_id(),
+            span_id: Default::default(),
+            trace_id: Default::default(),
             timestamp: Default::default(),
             tags: Default::default(),
             start_timestamp: event::default_timestamp(),


### PR DESCRIPTION
There are two main changes here to fix errors displayed on the Sentry dashboard when submitting envelopes using the current `Transaction` struct:
- First the `name` field is renamed to `transaction`, this is technically a semver breaking change although given there is not high-level API to work with transactions yet in the SDK this struct probably doesn't have too many consumers yet. If that proves to be a problem it's always possible to just rename the field at the serde level
- Second, the `span_id` fields are now using a custom serializer to truncate the Uuid string at 16 bytes. I went for the simplest change here again, although it means using the Uuid type for fields that are not in fact holding a full UUID in the wire format. Maybe the span IDs should be either a String (like in `parent_span_id`) or a specialized `SpanId` struct of only 16 bytes