### PR TITLE
Add span / transaction collection to sentry-tracing

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -337,6 +337,17 @@ impl Client {
             random::<f32>() <= rate
         }
     }
+
+    /// Returns a random boolean with a probability defined
+    /// by the [`ClientOptions`]'s `traces_sample_rate`
+    pub fn sample_traces_should_send(&self) -> bool {
+        let rate = self.options.traces_sample_rate;
+        if rate >= 1.0 {
+            true
+        } else {
+            random::<f32>() <= rate
+        }
+    }
 }
 
 // Make this unwind safe. It's not out of the box because of the

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -72,6 +72,8 @@ pub struct ClientOptions {
     pub environment: Option<Cow<'static, str>>,
     /// The sample rate for event submission. (0.0 - 1.0, defaults to 1.0)
     pub sample_rate: f32,
+    /// The sample rate for tracing transactions. (0.0 - 1.0, defaults to 0.0)
+    pub traces_sample_rate: f32,
     /// Maximum number of breadcrumbs. (defaults to 100)
     pub max_breadcrumbs: usize,
     /// Attaches stacktraces to messages.
@@ -179,6 +181,7 @@ impl fmt::Debug for ClientOptions {
             .field("release", &self.release)
             .field("environment", &self.environment)
             .field("sample_rate", &self.sample_rate)
+            .field("traces_sample_rate", &self.traces_sample_rate)
             .field("max_breadcrumbs", &self.max_breadcrumbs)
             .field("attach_stacktrace", &self.attach_stacktrace)
             .field("send_default_pii", &self.send_default_pii)
@@ -210,6 +213,7 @@ impl Default for ClientOptions {
             release: None,
             environment: None,
             sample_rate: 1.0,
+            traces_sample_rate: 0.0,
             max_breadcrumbs: 100,
             attach_stacktrace: false,
             send_default_pii: false,

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -20,3 +20,4 @@ tracing-subscriber = "0.2.19"
 log = "0.4"
 sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
 tracing = "0.1"
+tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 sentry-core = { version = "0.23.0", path = "../sentry-core" }
 tracing-core = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.2.19"
 
 [dev-dependencies]
 log = "0.4"

--- a/sentry-tracing/README.md
+++ b/sentry-tracing/README.md
@@ -88,4 +88,3 @@ License: Apache-2.0
 
 - [Discord](https://discord.gg/ez5KZN7) server for project discussions.
 - Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates
-

--- a/sentry-tracing/README.md
+++ b/sentry-tracing/README.md
@@ -6,13 +6,15 @@
 
 # Sentry Rust SDK: sentry-tracing
 
-Adds support for automatic Breadcrumb and Event capturing from tracing events,
-similar to the `sentry-log` crate.
+Adds support for automatic Breadcrumb, Event and Transaction capturing from
+tracing events, similar to the `sentry-log` crate.
 
-The `tracing` crate is supported in two ways. First, events can be captured as
-breadcrumbs for later. Secondly, error events can be captured as events to
-Sentry. By default, anything above `Info` is recorded as breadcrumb and
-anything above `Error` is captured as error event.
+The `tracing` crate is supported in three ways. First, events can be captured
+as breadcrumbs for later. Secondly, error events can be captured as events
+to Sentry. Finally, spans can be recorded as structured transaction events.
+By default, events above `Info` are recorded as breadcrumbs, events above
+`Error` are captured as error events, and spans above `Info` are recorded
+as transactions.
 
 By using this crate in combination with `tracing-subscriber` and its `log`
 integration, `sentry-log` does not need to be used, as logs will be ingested
@@ -22,21 +24,50 @@ effectively replaces `sentry-log` when tracing is used.
 ## Examples
 
 ```rust
+use std::time::Duration;
+
+use tokio::time::sleep;
 use tracing_subscriber::prelude::*;
 
-tracing_subscriber::registry()
-    .with(tracing_subscriber::fmt::layer())
-    .with(sentry_tracing::layer())
-    .try_init()
-    .unwrap();
+#[tokio::main]
+async fn main() {
+    let _guard = sentry::init(sentry::ClientOptions {
+        dsn: "<dsn>".parse().ok(),
+        // Set this a to lower value in production
+        traces_sample_rate: 1.0,
+        ..sentry::ClientOptions::default()
+    });
 
-let _sentry = sentry::init(());
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(sentry_tracing::layer())
+        .init();
 
-tracing::info!("Generates a breadcrumb");
-tracing::error!("Generates an event");
-// Also works, since log events are ingested by the tracing system
-log::info!("Generates a breadcrumb");
-log::error!("Generates an event");
+    outer().await;
+}
+
+// Functions instrumented by tracing automatically report
+// their span as transactions
+#[tracing::instrument]
+async fn outer() {
+    tracing::info!("Generates a breadcrumb");
+
+    for _ in 0..10 {
+        inner().await;
+    }
+
+    tracing::error!("Generates an event");
+}
+
+#[tracing::instrument]
+async fn inner() {
+    // Also works, since log events are ingested by the tracing system
+    log::info!("Generates a breadcrumb");
+
+    sleep(Duration::from_millis(100)).await;
+
+    log::error!("Generates an event");
+}
 ```
 
 Or one might also set an explicit filter, to customize how to treat log

--- a/sentry-tracing/README.md
+++ b/sentry-tracing/README.md
@@ -32,7 +32,6 @@ use tracing_subscriber::prelude::*;
 #[tokio::main]
 async fn main() {
     let _guard = sentry::init(sentry::ClientOptions {
-        dsn: "<dsn>".parse().ok(),
         // Set this a to lower value in production
         traces_sample_rate: 1.0,
         ..sentry::ClientOptions::default()
@@ -75,11 +74,16 @@ records:
 
 ```rust
 use sentry_tracing::EventFilter;
+use tracing_subscriber::prelude::*;
 
-let layer = sentry_tracing::layer().filter(|md| match md.level() {
+let layer = sentry_tracing::layer().event_filter(|md| match md.level() {
     &tracing::Level::ERROR => EventFilter::Event,
     _ => EventFilter::Ignore,
 });
+
+tracing_subscriber::registry()
+    .with(layer)
+    .init();
 ```
 
 ## Resources

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -1,8 +1,15 @@
 use std::collections::BTreeMap;
 
-use sentry_core::protocol::{Event, Value};
+use sentry_core::protocol::{self, Event, TraceContext, Value};
 use sentry_core::{Breadcrumb, Level};
-use tracing_core::field::{Field, Visit};
+use tracing_core::{
+    field::{Field, Visit},
+    span, Subscriber,
+};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::Trace;
 
 /// Converts a [`tracing_core::Level`] to a Sentry [`Level`]
 pub fn convert_tracing_level(level: &tracing_core::Level) -> Level {
@@ -15,10 +22,27 @@ pub fn convert_tracing_level(level: &tracing_core::Level) -> Level {
 }
 
 /// Extracts the message and metadata from an event
-pub fn extract_data(event: &tracing_core::Event) -> (Option<String>, BTreeMap<String, Value>) {
+pub fn extract_event_data(
+    event: &tracing_core::Event,
+) -> (Option<String>, BTreeMap<String, Value>) {
     // Find message of the event, if any
     let mut data = BTreeMapRecorder::default();
     event.record(&mut data);
+    let message = data
+        .0
+        .remove("message")
+        .map(|v| v.as_str().map(|s| s.to_owned()))
+        .flatten();
+
+    (message, data.0)
+}
+
+/// Extracts the message and metadata from a span
+pub fn extract_span_data(attrs: &span::Attributes) -> (Option<String>, BTreeMap<String, Value>) {
+    let mut data = BTreeMapRecorder::default();
+    attrs.record(&mut data);
+
+    // Find message of the span, if any
     let message = data
         .0
         .remove("message")
@@ -58,7 +82,7 @@ impl Visit for BTreeMapRecorder {
 
 /// Creates a [`Breadcrumb`] from a given [`tracing_core::Event`]
 pub fn breadcrumb_from_event(event: &tracing_core::Event) -> Breadcrumb {
-    let (message, data) = extract_data(event);
+    let (message, data) = extract_event_data(event);
     Breadcrumb {
         category: Some(event.metadata().target().to_owned()),
         ty: "log".into(),
@@ -70,22 +94,55 @@ pub fn breadcrumb_from_event(event: &tracing_core::Event) -> Breadcrumb {
 }
 
 /// Creates an [`Event`] from a given [`tracing_core::Event`]
-pub fn event_from_event(event: &tracing_core::Event) -> Event<'static> {
-    let (message, extra) = extract_data(event);
-    Event {
+pub fn event_from_event<S>(event: &tracing_core::Event, ctx: Context<S>) -> Event<'static>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let (message, extra) = extract_event_data(event);
+
+    let mut result = Event {
         logger: Some(event.metadata().target().to_owned()),
         level: convert_tracing_level(event.metadata().level()),
         message,
         extra,
         ..Default::default()
+    };
+
+    let parent = event
+        .parent()
+        .and_then(|id| ctx.span(id))
+        .or_else(|| ctx.lookup_current());
+
+    if let Some(parent) = parent {
+        let extensions = parent.extensions();
+        if let Some(trace) = extensions.get::<Trace>() {
+            let context = protocol::Context::from(TraceContext {
+                span_id: trace.span.span_id,
+                trace_id: trace.span.trace_id,
+                ..TraceContext::default()
+            });
+
+            result.contexts.insert(context.type_name().into(), context);
+            result.transaction = parent
+                .parent()
+                .into_iter()
+                .flat_map(|span| span.scope())
+                .last()
+                .map(|root| root.name().into());
+        }
     }
+
+    result
 }
 
 /// Creates an exception [`Event`] from a given [`tracing_core::Event`]
-pub fn exception_from_event(event: &tracing_core::Event) -> Event<'static> {
+pub fn exception_from_event<S>(event: &tracing_core::Event, ctx: Context<S>) -> Event<'static>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
     // TODO: Exception records in Sentry need a valid type, value and full stack trace to support
     // proper grouping and issue metadata generation. tracing_core::Record does not contain sufficient
     // information for this. However, it may contain a serialized error which we can parse to emit
     // an exception record.
-    event_from_event(event)
+    event_from_event(event, ctx)
 }

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -122,7 +122,8 @@ where
                 ..TraceContext::default()
             });
 
-            result.contexts.insert(context.type_name().into(), context);
+            result.contexts.insert(String::from("trace"), context);
+
             result.transaction = parent
                 .parent()
                 .into_iter()

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -1,6 +1,18 @@
-use sentry_core::protocol::Breadcrumb;
-use tracing_core::{Event, Level, Metadata, Subscriber};
-use tracing_subscriber::layer::{Context, Layer};
+use std::{
+    collections::BTreeMap,
+    time::{Instant, SystemTime},
+};
+
+use sentry_core::{
+    protocol::{self, Breadcrumb, TraceContext, TraceId, Transaction, Value},
+    types::Uuid,
+    Envelope, Hub,
+};
+use tracing_core::{span, Event, Level, Metadata, Subscriber};
+use tracing_subscriber::{
+    layer::{Context, Layer},
+    registry::{LookupSpan, SpanRef},
+};
 
 use crate::converters::*;
 
@@ -33,7 +45,7 @@ pub enum EventMapping {
 ///
 /// By default, an exception event is captured for `error`, a breadcrumb for
 /// `warning` and `info`, and `debug` and `trace` logs are ignored.
-pub fn default_filter(metadata: &Metadata) -> EventFilter {
+pub fn default_event_filter(metadata: &Metadata) -> EventFilter {
     match metadata.level() {
         &Level::ERROR => EventFilter::Exception,
         &Level::WARN | &Level::INFO => EventFilter::Breadcrumb,
@@ -41,56 +53,229 @@ pub fn default_filter(metadata: &Metadata) -> EventFilter {
     }
 }
 
-/// Provides a tracing layer that dispatches events to sentry
-pub struct SentryLayer {
-    filter: Box<dyn Fn(&Metadata) -> EventFilter + Send + Sync>,
-    mapper: Option<Box<dyn Fn(&Event) -> EventMapping + Send + Sync>>,
+/// The default span filter.
+///
+/// By default, spans at the `error`, `warning`, and `info`
+/// levels are captured
+pub fn default_span_filter(metadata: &Metadata) -> bool {
+    matches!(
+        metadata.level(),
+        &Level::ERROR | &Level::WARN | &Level::INFO
+    )
 }
 
-impl SentryLayer {
-    /// Sets a custom filter function.
+/// The default span mapper.
+///
+/// By default, a new empty span is created with the `op`
+/// field set to the name of the span, with the `trace_id`
+/// copied from the parent span if any
+pub fn default_span_mapper<S>(
+    span: &SpanRef<S>,
+    parent: Option<&protocol::Span>,
+    attrs: &span::Attributes,
+) -> protocol::Span
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let (description, data) = extract_span_data(attrs);
+
+    let trace_id = parent
+        .map(|parent| parent.trace_id.clone())
+        .unwrap_or_else(TraceId::default);
+
+    protocol::Span {
+        trace_id,
+        op: Some(span.name().into()),
+        description,
+        data,
+        ..protocol::Span::default()
+    }
+}
+
+/// The default span on_close hook.
+///
+/// By default, this sets the end timestamp of the span,
+/// and creates `busy` and `idle` data fields from the timing data
+pub fn default_span_on_close(span: &mut protocol::Span, timings: Timings) {
+    span.data
+        .insert(String::from("busy"), Value::Number(timings.busy.into()));
+
+    span.data
+        .insert(String::from("idle"), Value::Number(timings.idle.into()));
+
+    span.timestamp = Some(timings.end_time.into());
+}
+
+/// The default transaction mapper.
+///
+/// By default, this creates a transaction from a root span
+/// containing all of its children spans
+pub fn default_transaction_mapper<S>(
+    sentry_span: protocol::Span,
+    tracing_span: &SpanRef<S>,
+    spans: Vec<protocol::Span>,
+    timings: Timings,
+) -> Transaction<'static>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let mut contexts = BTreeMap::new();
+
+    contexts.insert(
+        String::from("trace"),
+        protocol::Context::Trace(Box::new(TraceContext {
+            span_id: sentry_span.span_id,
+            trace_id: sentry_span.trace_id,
+            parent_span_id: sentry_span.parent_span_id,
+            op: sentry_span.op.clone(),
+            description: sentry_span.description.clone(),
+            status: sentry_span.status.clone(),
+        })),
+    );
+
+    Transaction {
+        event_id: Uuid::new_v4(),
+        name: Some(tracing_span.name().into()),
+        start_timestamp: timings.start_time.into(),
+        timestamp: Some(timings.end_time.into()),
+        spans,
+        contexts,
+        ..Transaction::default()
+    }
+}
+
+type SpanMapper<S> = Box<
+    dyn Fn(&SpanRef<S>, Option<&protocol::Span>, &span::Attributes) -> protocol::Span + Send + Sync,
+>;
+
+type SpanOnClose = Box<dyn Fn(&mut protocol::Span, Timings) + Send + Sync>;
+
+type TransactionMapper<S> = Box<
+    dyn Fn(protocol::Span, &SpanRef<S>, Vec<protocol::Span>, Timings) -> Transaction<'static>
+        + Send
+        + Sync,
+>;
+
+/// Provides a tracing layer that dispatches events to sentry
+pub struct SentryLayer<S> {
+    event_filter: Box<dyn Fn(&Metadata) -> EventFilter + Send + Sync>,
+    event_mapper: Option<Box<dyn Fn(&Event) -> EventMapping + Send + Sync>>,
+
+    span_filter: Box<dyn Fn(&Metadata) -> bool + Send + Sync>,
+    span_mapper: SpanMapper<S>,
+    span_on_close: SpanOnClose,
+    transaction_mapper: TransactionMapper<S>,
+}
+
+impl<S> SentryLayer<S> {
+    /// Sets a custom event filter function.
     ///
     /// The filter classifies how sentry should handle [`Event`]s based
     /// on their [`Metadata`].
-    pub fn filter<F>(mut self, filter: F) -> Self
+    pub fn event_filter<F>(mut self, filter: F) -> Self
     where
         F: Fn(&Metadata) -> EventFilter + Send + Sync + 'static,
     {
-        self.filter = Box::new(filter);
+        self.event_filter = Box::new(filter);
         self
     }
 
-    /// Sets a custom mapper function.
+    /// Sets a custom event mapper function.
     ///
     /// The mapper is responsible for creating either breadcrumbs or events from
     /// [`Event`]s.
-    pub fn mapper<F>(mut self, mapper: F) -> Self
+    pub fn event_mapper<F>(mut self, mapper: F) -> Self
     where
         F: Fn(&Event) -> EventMapping + Send + Sync + 'static,
     {
-        self.mapper = Some(Box::new(mapper));
+        self.event_mapper = Some(Box::new(mapper));
+        self
+    }
+
+    /// Sets a custom span filter function.
+    ///
+    /// The filter classifies whether sentry should handle [`tracing::Span`]s based
+    /// on their [`Metadata`].
+    pub fn span_filter<F>(mut self, filter: F) -> Self
+    where
+        F: Fn(&Metadata) -> bool + Send + Sync + 'static,
+    {
+        self.span_filter = Box::new(filter);
+        self
+    }
+
+    /// Sets a custom span mapper function.
+    ///
+    /// The mapper is responsible for creating [`protocol::Span`]s from
+    /// [`tracing::Span`]s.
+    pub fn span_mapper<F>(mut self, mapper: F) -> Self
+    where
+        F: Fn(&SpanRef<S>, Option<&protocol::Span>, &span::Attributes) -> protocol::Span
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.span_mapper = Box::new(mapper);
+        self
+    }
+
+    /// Sets a custom span on_close hook.
+    ///
+    /// The hook is called with [`Timings`] informations when a [`tracing::Span`]
+    /// is closed, and can mutate the associated [`protocol::Span`] accordingly.
+    pub fn span_on_close<F>(mut self, on_close: F) -> Self
+    where
+        F: Fn(&mut protocol::Span, Timings) + Send + Sync + 'static,
+    {
+        self.span_on_close = Box::new(on_close);
+        self
+    }
+
+    /// Sets a custom transaction mapper function.
+    ///
+    /// The mapper is responsible for creating [`Transaction`]s from
+    /// [`tracing::Span`]s.
+    pub fn transaction_mapper<F>(mut self, mapper: F) -> Self
+    where
+        F: Fn(protocol::Span, &SpanRef<S>, Vec<protocol::Span>, Timings) -> Transaction<'static>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.transaction_mapper = Box::new(mapper);
         self
     }
 }
 
-impl Default for SentryLayer {
+impl<S> Default for SentryLayer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
     fn default() -> Self {
         Self {
-            filter: Box::new(default_filter),
-            mapper: None,
+            event_filter: Box::new(default_event_filter),
+            event_mapper: None,
+
+            span_filter: Box::new(default_span_filter),
+            span_mapper: Box::new(default_span_mapper),
+            span_on_close: Box::new(default_span_on_close),
+            transaction_mapper: Box::new(default_transaction_mapper),
         }
     }
 }
 
-impl<S: Subscriber> Layer<S> for SentryLayer {
-    fn on_event(&self, event: &Event, _ctx: Context<'_, S>) {
-        let item = match &self.mapper {
+impl<S> Layer<S> for SentryLayer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event, ctx: Context<'_, S>) {
+        let item = match &self.event_mapper {
             Some(mapper) => mapper(event),
-            None => match (self.filter)(event.metadata()) {
+            None => match (self.event_filter)(event.metadata()) {
                 EventFilter::Ignore => EventMapping::Ignore,
                 EventFilter::Breadcrumb => EventMapping::Breadcrumb(breadcrumb_from_event(event)),
-                EventFilter::Event => EventMapping::Event(event_from_event(event)),
-                EventFilter::Exception => EventMapping::Event(exception_from_event(event)),
+                EventFilter::Event => EventMapping::Event(event_from_event(event, ctx)),
+                EventFilter::Exception => EventMapping::Event(exception_from_event(event, ctx)),
             },
         };
 
@@ -102,9 +287,168 @@ impl<S: Subscriber> Layer<S> for SentryLayer {
             _ => (),
         }
     }
+
+    /// When a new Span gets created, run the filter and initialize the trace extension
+    /// if it passes
+    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+
+        if !(self.span_filter)(span.metadata()) {
+            return;
+        }
+
+        let mut extensions = span.extensions_mut();
+        if extensions.get_mut::<Trace>().is_none() {
+            for parent in span.parent().into_iter().flat_map(|span| span.scope()) {
+                let parent = parent.extensions();
+                let parent = match parent.get::<Trace>() {
+                    Some(trace) => trace,
+                    None => continue,
+                };
+
+                let span = (self.span_mapper)(&span, Some(&parent.span), attrs);
+                extensions.insert(Trace::new(span));
+                return;
+            }
+
+            let span = (self.span_mapper)(&span, None, attrs);
+            extensions.insert(Trace::new(span));
+        }
+    }
+
+    /// From the tracing-subscriber implementation of span timings,
+    /// keep track of when the span was last entered
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if let Some(timings) = extensions.get_mut::<Trace>() {
+            let now = Instant::now();
+            timings.idle += (now - timings.last).as_nanos() as u64;
+            timings.last = now;
+        }
+    }
+
+    /// From the tracing-subscriber implementation of span timings,
+    /// keep track of when the span was last exited
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if let Some(timings) = extensions.get_mut::<Trace>() {
+            let now = Instant::now();
+            timings.busy += (now - timings.last).as_nanos() as u64;
+            timings.last = now;
+            timings.last_sys = SystemTime::now();
+        }
+    }
+
+    /// When a span gets closed, if it has a trace extension either
+    /// attach it to a parent span or submit it as a Transaction if
+    /// it is a root of the span tree
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        let mut trace = match extensions.remove::<Trace>() {
+            Some(trace) => trace,
+            None => return,
+        };
+
+        // Construct the timing data and call the on_close hook
+        trace.idle += (Instant::now() - trace.last).as_nanos() as u64;
+
+        let timings = Timings {
+            start_time: trace.first,
+            end_time: trace.last_sys,
+            idle: trace.idle,
+            busy: trace.busy,
+        };
+
+        (self.span_on_close)(&mut trace.span, timings);
+
+        // Traverse the parents of this span to attach to the nearest one
+        // that has tracing data (spans ignored by the span_filter do not)
+        for parent in span.parent().into_iter().flat_map(|span| span.scope()) {
+            let mut extensions = parent.extensions_mut();
+            if let Some(parent) = extensions.get_mut::<Trace>() {
+                parent.spans.extend(trace.spans);
+
+                trace.span.parent_span_id = Some(parent.span.span_id);
+                parent.spans.push(trace.span);
+                return;
+            }
+        }
+
+        // If no parent was found, consider this span a
+        // transaction root and submit it to Sentry
+        let span = &span;
+        Hub::with_active(move |hub| {
+            let client = hub.client().unwrap();
+            if !client.sample_traces_should_send() {
+                return;
+            }
+
+            let transaction = (self.transaction_mapper)(trace.span, span, trace.spans, timings);
+            let envelope = Envelope::from(transaction);
+            client.send_envelope(envelope);
+        });
+    }
+}
+
+/// Timing informations for a given Span
+#[derive(Clone, Copy, Debug)]
+pub struct Timings {
+    /// The time the span was first entered
+    pub start_time: SystemTime,
+    /// The time the span was last entered
+    pub end_time: SystemTime,
+    /// The total busy time for this span, in nanoseconds
+    pub busy: u64,
+    /// The total idle time for this span, in nanoseconds
+    pub idle: u64,
+}
+
+/// Private internal state for a Span
+///
+/// Every Span that passes the `span_filter` has
+/// an instance of this struct attached as an extension.
+/// It is used to store transient informations while the
+/// Span is being built such as the incomplete protocol::Span
+/// as well as finished children Spans.
+pub(crate) struct Trace {
+    pub(crate) span: protocol::Span,
+    spans: Vec<protocol::Span>,
+
+    // From the tracing-subscriber implementation of span timings,
+    // with additional SystemTime informations to reconstruct the UTC
+    // times needed by Sentry
+    idle: u64,
+    busy: u64,
+    last: Instant,
+    first: SystemTime,
+    last_sys: SystemTime,
+}
+
+impl Trace {
+    fn new(span: protocol::Span) -> Self {
+        Trace {
+            span,
+            spans: Vec::new(),
+
+            idle: 0,
+            busy: 0,
+            last: Instant::now(),
+            first: SystemTime::now(),
+            last_sys: SystemTime::now(),
+        }
+    }
 }
 
 /// Creates a default Sentry layer
-pub fn layer() -> SentryLayer {
+pub fn layer<S>() -> SentryLayer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
     Default::default()
 }

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -219,9 +219,9 @@ impl<S> SentryLayer<S> {
         self
     }
 
-    /// Sets a custom span on_close hook.
+    /// Sets a custom span `on_close` hook.
     ///
-    /// The hook is called with [`Timings`] informations when a [`tracing::Span`]
+    /// The hook is called with [`Timings`] information when a [`tracing::Span`]
     /// is closed, and can mutate the associated [`protocol::Span`] accordingly.
     pub fn span_on_close<F>(mut self, on_close: F) -> Self
     where

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -5,7 +5,7 @@
 //! as breadcrumbs for later. Secondly, error events can be captured as events
 //! to Sentry. Finally, spans can be recorded as structured transaction events.
 //! By default, events above `Info` are recorded as breadcrumbs, events above
-//! `Error` are captured as error events, and spans above `Info` and recorded
+//! `Error` are captured as error events, and spans above `Info` are recorded
 //! as transactions.
 //!
 //! By using this crate in combination with `tracing-subscriber` and its `log`

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -1,10 +1,12 @@
-//! Adds support for automatic Breadcrumb and Event capturing from tracing
-//! events, similar to the `sentry-log` crate.
+//! Adds support for automatic Breadcrumb, Event and Transaction capturing from
+//! tracing events, similar to the `sentry-log` crate.
 //!
-//! The `tracing` crate is supported in two ways. First, events can be captured
+//! The `tracing` crate is supported in three ways. First, events can be captured
 //! as breadcrumbs for later. Secondly, error events can be captured as events
-//! to Sentry. By default, anything above `Info` is recorded as breadcrumb and
-//! anything above `Error` is captured as error event.
+//! to Sentry. Finally, spans can be recorded as structured transaction events.
+//! By default, events above `Info` are recorded as breadcrumbs, events above
+//! `Error` are captured as error events, and spans above `Info` and recorded
+//! as transactions.
 //!
 //! By using this crate in combination with `tracing-subscriber` and its `log`
 //! integration, `sentry-log` does not need to be used, as logs will be ingested
@@ -35,12 +37,18 @@
 //! records:
 //!
 //! ```rust
+//! use tracing_subscriber::prelude::*;
 //! use sentry_tracing::EventFilter;
 //!
-//! let layer = sentry_tracing::layer().filter(|md| match md.level() {
-//!     &tracing::Level::ERROR => EventFilter::Event,
-//!     _ => EventFilter::Ignore,
-//! });
+//! tracing_subscriber::registry()
+//!     .with(
+//!         sentry_tracing::layer().event_filter(|md| match md.level() {
+//!             &tracing::Level::ERROR => EventFilter::Event,
+//!             _ => EventFilter::Ignore,
+//!         })
+//!     )
+//!     .try_init()
+//!     .unwrap();
 //! ```
 
 #![doc(html_favicon_url = "https://sentry-brand.storage.googleapis.com/favicon.ico")]

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -24,7 +24,6 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let _guard = sentry::init(sentry::ClientOptions {
-//!         dsn: "<dsn>".parse().ok(),
 //!         // Set this a to lower value in production
 //!         traces_sample_rate: 1.0,
 //!         ..sentry::ClientOptions::default()
@@ -67,11 +66,16 @@
 //!
 //! ```rust
 //! use sentry_tracing::EventFilter;
+//! use tracing_subscriber::prelude::*;
 //!
-//! let layer = sentry_tracing::layer().filter(|md| match md.level() {
+//! let layer = sentry_tracing::layer().event_filter(|md| match md.level() {
 //!     &tracing::Level::ERROR => EventFilter::Event,
 //!     _ => EventFilter::Ignore,
 //! });
+//!
+//! tracing_subscriber::registry()
+//!     .with(layer)
+//!     .init();
 //! ```
 
 #![doc(html_favicon_url = "https://sentry-brand.storage.googleapis.com/favicon.ico")]

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -40,13 +40,13 @@
 //! use tracing_subscriber::prelude::*;
 //! use sentry_tracing::EventFilter;
 //!
+//! let layer = sentry_tracing::layer().event_filter(|md| match md.level() {
+//!     &tracing::Level::ERROR => EventFilter::Event,
+//!     _ => EventFilter::Ignore,
+//! });
+//!
 //! tracing_subscriber::registry()
-//!     .with(
-//!         sentry_tracing::layer().event_filter(|md| match md.level() {
-//!             &tracing::Level::ERROR => EventFilter::Event,
-//!             _ => EventFilter::Ignore,
-//!         })
-//!     )
+//!     .with(layer)
 //!     .try_init()
 //!     .unwrap();
 //! ```


### PR DESCRIPTION
I'm marking this as a draft for now as it builds upon the changes in #349 to submit Transaction data directly to the Client as an Envelope. I'll rebase this branch on master when that other PR gets sorted out. (Edit: PR got merged, I rebased my branch)

Anyway for the actual changes: this builds upon the existing `sentry-tracing` infrastructure, a new filter and 3 mappers to the crate. First is `span_filter`, it is used to select spans that are candidate for transaction collection, then `span_mapper` is called for all spans that pass the filter to create a `protocol::Span`. This Span is expected to only be partially initialized as the `tracing::Span` has only been newly created when the mapper is called, and more informations can be added by mutating the protocol struct when the tracing Span gets closed in `span_on_close`. Finally, either the closing span can be attached to another span that passed the filter higher up in the hierarchy, or if no parent can be found the span is turned into a full transaction by `transaction_mapper` and submitted (This last part could be further improved by either adding a `transaction_filter` or having the `span_filter` return an enum to select which Spans are allowed to be submitted as Transactions).

For the last part, besides the previously mentioned changes to `sentry-types` I has to implement the `traces_sample_rate` config options as well as a new `sample_traces_should_send` method on the Client (unlike `sample_should_send` this one is public so that it can be called from another crate).