### PR TITLE
feat: add feature for using surf with the h1-client

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -40,7 +40,8 @@ debug-logs = ["log_", "sentry-core/debug-logs"]
 transport = ["reqwest", "native-tls"]
 reqwest = ["reqwest_", "httpdate"]
 curl = ["curl_", "httpdate", "serde_json"]
-surf = ["surf_", "httpdate"]
+surf-h1 = ["surf_/h1-client", "httpdate"]
+surf = ["surf_/curl-client", "httpdate"]
 native-tls = ["reqwest_/default-tls"]
 rustls = ["reqwest_/rustls-tls"]
 
@@ -58,8 +59,8 @@ sentry-tracing = { version = "0.23.0", path = "../sentry-tracing", optional = tr
 log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
 reqwest_ = { package = "reqwest", version = "0.11", optional = true, features = ["blocking", "json"], default-features = false }
 curl_ = { package = "curl", version = "0.4.25", optional = true }
-surf_ = { package = "surf", version = "2.0.0", optional = true }
 httpdate = { version = "1.0.0", optional = true }
+surf_ = { package = "surf", version = "2.0.0", optional = true, default-features = false }
 serde_json = { version = "1.0.48", optional = true }
 tokio = { version = "1.0", features = ["rt"] }
 


### PR DESCRIPTION
The current Cargo.toml enables default-features for surf which uses surf's curl-client.  Since surf contains multiple client backends, the current feature set doesn't provide enough flexibility so that one can use the same HTTP client already in use in other parts of an application.

My project is using the h1-client from surf, and I would like to be able to use just a single HTTP client in my project.  This pull request adds a new feature `surf-h1` specifically to use surf with the h1-client.

It might be reasonable to also add additional features for surf so that the other clients can be enabled, here is a link to the client features in surf:
https://github.com/http-rs/surf/blob/1ffaba8873d49c672a45442bfd69ca53b81ea1cc/Cargo.toml#L24-L47