### PR TITLE
feat: create Exception from tracing event

### DIFF
--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 sentry-core = { version = "0.23.0", path = "../sentry-core", features = ["client"] }
+sentry-backtrace = { version = "0.23.0", path = "../sentry-backtrace" }
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
 

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -12,7 +12,7 @@ Sentry integration for tracing and tracing-subscriber crates.
 edition = "2018"
 
 [dependencies]
-sentry-core = { version = "0.23.0", path = "../sentry-core" }
+sentry-core = { version = "0.23.0", path = "../sentry-core", features = ["client"] }
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
 

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -127,7 +127,10 @@ fn add_parent_transaction_to_event<S>(
             let context = protocol::Context::from(TraceContext {
                 span_id: trace.span.span_id,
                 trace_id: trace.span.trace_id,
-                ..TraceContext::default()
+                parent_span_id: trace.span.parent_span_id,
+                op: trace.span.op.clone(),
+                description: trace.span.description.clone(),
+                status: trace.span.status,
             });
 
             sentry_event.contexts.insert(String::from("trace"), context);

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -174,14 +174,14 @@ where
 
     let (message, mut visitor) = extract_event_data(event);
 
-    let ty = event.metadata().name().into();
-    let value = visitor
-        .json_values
-        .remove(DEFAULT_ERROR_VALUE_KEY)
-        .map(|v| v.as_str().map(|s| s.to_owned()))
-        .flatten()
-        .or_else(|| message.clone());
     let exception = if visitor.exceptions.is_empty() {
+        let ty = event.metadata().name().into();
+        let value = visitor
+            .json_values
+            .remove(DEFAULT_ERROR_VALUE_KEY)
+            .map(|v| v.as_str().map(|s| s.to_owned()))
+            .flatten()
+            .or_else(|| message.clone());
         vec![Exception {
             ty,
             value,

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -55,7 +55,7 @@ pub(crate) fn extract_span_data(
 
 /// Records all fields of [`tracing_core::Event`] for easy access
 #[derive(Default)]
-struct FieldVisitor {
+pub(crate) struct FieldVisitor {
     pub json_values: BTreeMap<String, Value>,
     pub exceptions: Vec<Exception>,
 }

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -168,17 +168,12 @@ where
         module,
         ..Default::default()
     };
-    let culprit = match (event.metadata().file(), event.metadata().line()) {
-        (Some(f), Some(l)) => Some(format!("{}L{}", f, l)),
-        _ => None,
-    };
     let mut result = Event {
         logger: Some(event.metadata().target().to_owned()),
         level: convert_tracing_level(event.metadata().level()),
         message,
         extra,
         exception: vec![exception].into(),
-        culprit,
         ..Default::default()
     };
 

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -424,10 +424,10 @@ where
             _ => return,
         };
 
-        let mut data = BTreeMapRecorder::default();
+        let mut data = FieldVisitor::default();
         values.record(&mut data);
 
-        for (key, value) in data.0 {
+        for (key, value) in data.json_values {
             trace.span.data.insert(key, value);
         }
     }


### PR DESCRIPTION
This PR relates to my message in #180 

This change will build an exception differently than event. It will look
for two hardcoded keys in the "extras" of an event:
1. "error_kind" - this is optional and defaults to "Unknown"
2. "error" - this is optional and defaults to the event's message

I am open to ideas for improving this! This PR simply gets exception 
handling off the ground, but makes arbitrary assumptions about how the
tracing event will communicate the error information.