### PR TITLE
feat: Add support of tracing::Span::record operation for sentry-tracing

### DIFF
--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -54,7 +54,7 @@ pub fn extract_span_data(attrs: &span::Attributes) -> (Option<String>, BTreeMap<
 
 #[derive(Default)]
 /// Records all fields of [`tracing_core::Event`] for easy access
-struct BTreeMapRecorder(pub BTreeMap<String, Value>);
+pub(crate) struct BTreeMapRecorder(pub BTreeMap<String, Value>);
 
 impl BTreeMapRecorder {
     fn record<T: Into<Value>>(&mut self, field: &Field, value: T) {

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -410,6 +410,27 @@ where
             client.send_envelope(envelope);
         });
     }
+
+    /// Implement the writing of extra data to span
+    fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        let span = match ctx.span(span) {
+            Some(s) => s,
+            _ => return
+        };
+
+        let mut extensions_holder = span.extensions_mut();
+        let trace = match extensions_holder.get_mut::<Trace>() {
+            Some(t) => t,
+            _ => return
+        };
+
+        let mut data = BTreeMapRecorder::default();
+        values.record(&mut data);
+
+        for (key, value) in data.0 {
+            trace.span.data.insert(key, value);
+        }
+    }
 }
 
 /// Timing informations for a given Span

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -415,13 +415,13 @@ where
     fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
         let span = match ctx.span(span) {
             Some(s) => s,
-            _ => return
+            _ => return,
         };
 
         let mut extensions_holder = span.extensions_mut();
         let trace = match extensions_holder.get_mut::<Trace>() {
             Some(t) => t,
-            _ => return
+            _ => return,
         };
 
         let mut data = BTreeMapRecorder::default();

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -65,23 +65,32 @@ fn test_span_record() {
         .with(sentry_tracing::layer())
         .set_default();
 
-    let options = sentry::ClientOptions{
+    let options = sentry::ClientOptions {
         traces_sample_rate: 1.0,
         ..Default::default()
     };
 
-    let envelopes = sentry::test::with_captured_envelopes_options(|| {
-        let _span = tracing::span!(tracing::Level::INFO, "span").entered();
-        function();
-    }, options);
+    let envelopes = sentry::test::with_captured_envelopes_options(
+        || {
+            let _span = tracing::span!(tracing::Level::INFO, "span").entered();
+            function();
+        },
+        options,
+    );
 
     assert_eq!(envelopes.len(), 1);
 
     let envelope_item = envelopes[0].items().next().unwrap();
     let ref transaction = match envelope_item {
         sentry::protocol::EnvelopeItem::Transaction(t) => t,
-        _ => { assert!(false); return; }
+        _ => {
+            assert!(false);
+            return;
+        }
     };
 
-    assert_eq!(transaction.spans[0].data["span_field"].as_str().unwrap(), "some data");
+    assert_eq!(
+        transaction.spans[0].data["span_field"].as_str().unwrap(),
+        "some data"
+    );
 }

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -81,7 +81,7 @@ fn test_span_record() {
     assert_eq!(envelopes.len(), 1);
 
     let envelope_item = envelopes[0].items().next().unwrap();
-    let ref transaction = match envelope_item {
+    let transaction = match envelope_item {
         sentry::protocol::EnvelopeItem::Transaction(t) => t,
         _ => panic!("expected only a transaction item"),
     };

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -83,10 +83,7 @@ fn test_span_record() {
     let envelope_item = envelopes[0].items().next().unwrap();
     let ref transaction = match envelope_item {
         sentry::protocol::EnvelopeItem::Transaction(t) => t,
-        _ => {
-            assert!(false);
-            return;
-        }
+        _ => panic!("expected only a transaction item"),
     };
 
     assert_eq!(


### PR DESCRIPTION
Before this PR this code had no effect:

```rust
tracing::Span::current().record("field", &"data");
```