### PR TITLE
fix: Remove versions from local dev-dependencies

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -4,7 +4,6 @@ artifactProvider:
   name: none
 targets:
   - name: crates
-    noDevDeps: true
   - name: github
   - name: registry
     sdks:

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -17,6 +17,6 @@ actix-web = { version = "3", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
 
 [dev-dependencies]
-sentry = { version = "0.23.0", path = "../sentry", features = ["test"] }
+sentry = { path = "../sentry", features = ["test"] }
 actix-rt = "2.1.0"
 futures = "0.3"

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -21,4 +21,4 @@ sentry-core = { version = "0.23.0", path = "../sentry-core" }
 anyhow = "1.0.39"
 
 [dev-dependencies]
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -26,4 +26,4 @@ uname = "0.1.1"
 rustc_version = "0.4.0"
 
 [dev-dependencies]
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -39,7 +39,7 @@ log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"]
 # Because we re-export all the public API in `sentry`, we actually run all the
 # doctests using the `sentry` crate. This also takes care of the doctest
 # limitation documented in https://github.com/rust-lang/rust/issues/45599.
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }
 thiserror = "1.0.15"
 anyhow = "1.0.30"
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -16,5 +16,5 @@ sentry-core = { version = "0.23.0", path = "../sentry-core" }
 log = { version = "0.4.8", features = ["std"] }
 
 [dev-dependencies]
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }
 pretty_env_logger = "0.4.0"

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -16,4 +16,4 @@ sentry-core = { version = "0.23.0", path = "../sentry-core" }
 sentry-backtrace = { version = "0.23.0", path = "../sentry-backtrace" }
 
 [dev-dependencies]
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -17,6 +17,6 @@ slog = { version = "2.5.2", features = ["nested-values"] }
 serde_json = "1.0.46"
 
 [dev-dependencies]
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }
 serde = "1.0.117"
 erased-serde = "0.3.12"

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -19,8 +19,8 @@ sentry-core = { version = "0.23.0", path = "../sentry-core", default-features = 
 [dev-dependencies]
 anyhow = "1"
 prost = "0.8"
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
-sentry-anyhow = { version = "0.23.0", path = "../sentry-anyhow" }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }
+sentry-anyhow = { path = "../sentry-anyhow" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tonic = { version = "0.5", features = ["transport"] }
 tower = { version = "0.4", features = ["util", "timeout"] }

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -18,6 +18,6 @@ tracing-subscriber = "0.2.19"
 
 [dev-dependencies]
 log = "0.4"
-sentry = { version = "0.23.0", path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test"] }
 tracing = "0.1"
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "time"] }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -65,11 +65,11 @@ serde_json = { version = "1.0.48", optional = true }
 tokio = { version = "1.0", features = ["rt"], optional = true }
 
 [dev-dependencies]
-sentry-anyhow = { version = "0.23.0", path = "../sentry-anyhow" }
-sentry-log = { version = "0.23.0", path = "../sentry-log" }
-sentry-slog = { version = "0.23.0", path = "../sentry-slog" }
-sentry-tower = { version = "0.23.0", path = "../sentry-tower" }
-sentry-tracing = { version = "0.23.0", path = "../sentry-tracing" }
+sentry-anyhow = { path = "../sentry-anyhow" }
+sentry-log = { path = "../sentry-log" }
+sentry-slog = { path = "../sentry-slog" }
+sentry-tower = { path = "../sentry-tower" }
+sentry-tracing = { path = "../sentry-tracing" }
 log_ = { package = "log", version = "0.4.8", features = ["std"] }
 slog_ = { package = "slog", version = "2.5.2" }
 tower_ = { package = "tower", version = "0.4", features = ["util"] }


### PR DESCRIPTION
This way, cargo will not verify the versions when publishing, removing
the need to use `cargo-hack` for publishing.

fixes #374 