### PR TITLE
ref: Avoid double-indirection through Arc<Box<T>>

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -214,9 +214,7 @@ where
         let (tx, sentry_req) = sentry_request_from_http(&req, with_pii);
         hub.configure_scope(|scope| {
             scope.set_transaction(tx.as_deref());
-            scope.add_event_processor(Box::new(move |event| {
-                Some(process_event(event, &sentry_req))
-            }))
+            scope.add_event_processor(move |event| Some(process_event(event, &sentry_req)))
         });
 
         let fut = self.service.call(req).bind_hub(hub.clone());

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -95,10 +95,10 @@ impl Scope {
     }
 
     /// Add an event processor to the scope.
-    pub fn add_event_processor(
-        &mut self,
-        f: Box<dyn Fn(Event<'static>) -> Option<Event<'static>> + Send + Sync>,
-    ) {
+    pub fn add_event_processor<F>(&mut self, f: F)
+    where
+        F: Fn(Event<'static>) -> Option<Event<'static>> + Send + Sync + 'static,
+    {
         let _f = f;
         minimal_unreachable!();
     }

--- a/sentry/examples/event-processors.rs
+++ b/sentry/examples/event-processors.rs
@@ -2,14 +2,14 @@ fn main() {
     let _sentry = sentry::init(());
 
     sentry::configure_scope(|scope| {
-        scope.add_event_processor(Box::new(move |mut event| {
+        scope.add_event_processor(|mut event| {
             event.request = Some(sentry::protocol::Request {
                 url: Some("https://example.com/".parse().unwrap()),
                 method: Some("GET".into()),
                 ..Default::default()
             });
             Some(event)
-        }));
+        });
     });
 
     sentry::configure_scope(|scope| {

--- a/sentry/tests/test_processors.rs
+++ b/sentry/tests/test_processors.rs
@@ -7,13 +7,13 @@ fn test_event_processors() {
     let events = sentry::test::with_captured_events(|| {
         sentry::configure_scope(|scope| {
             scope.set_tag("worker", "worker1");
-            scope.add_event_processor(Box::new(move |mut event| {
+            scope.add_event_processor(|mut event| {
                 event.user = Some(sentry::User {
                     email: Some("foo@example.com".into()),
                     ..Default::default()
                 });
                 Some(event)
-            }));
+            });
         });
         sentry::capture_message("Hello World!", sentry::Level::Warning);
     });


### PR DESCRIPTION
This also removes the need to manually box the argument to `add_event_processor`.