### PR TITLE
Upgrade `findshlibs` dependency again: Otherwise it stuck forever when an error is captured

### DIFF
--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -14,4 +14,4 @@ edition = "2018"
 [dependencies]
 sentry-core = { version = "0.23.0", path = "../sentry-core" }
 lazy_static = "1.4.0"
-findshlibs = "0.10.0"
+findshlibs = "0.10.1"


### PR DESCRIPTION
Related to: #382
But #382 is a more general problem.