### PR TITLE
Remove dependency on regex

### DIFF
--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -16,8 +16,6 @@ edition = "2018"
 sentry-core = { version = "0.23.0", path = "../sentry-core" }
 libc = "0.2.66"
 hostname = "0.3.0"
-regex = "1.3.4"
-lazy_static = "1.4.0"
 
 [target."cfg(not(windows))".dependencies]
 uname = "0.1.1"


### PR DESCRIPTION
Pulling in the whole Regex crate with Unicode support enabled is an overkill for taking a few ASCII chars.

I've also added error handling to the sysctlbyname calls.