### PR TITLE
feat: API for manual performance monitoring (NATIVE-309)

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -39,7 +39,7 @@ log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"]
 # Because we re-export all the public API in `sentry`, we actually run all the
 # doctests using the `sentry` crate. This also takes care of the doctest
 # limitation documented in https://github.com/rust-lang/rust/issues/45599.
-sentry = { path = "../sentry", default-features = false, features = ["test"] }
+sentry = { path = "../sentry", default-features = false, features = ["test", "transport"] }
 thiserror = "1.0.15"
 anyhow = "1.0.30"
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros"] }

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -76,6 +76,7 @@ pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
+pub use crate::performance::start_transaction;
 pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -76,7 +76,7 @@ pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
-pub use crate::performance::{start_transaction, Transaction};
+pub use crate::performance::*;
 pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -76,7 +76,7 @@ pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
-pub use crate::performance::start_transaction;
+pub use crate::performance::{start_transaction, Transaction};
 pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -63,6 +63,7 @@ mod futures;
 mod hub;
 mod integration;
 mod intodsn;
+mod performance;
 mod scope;
 mod transport;
 

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -19,13 +19,6 @@ impl Hub {
     pub fn start_transaction(&self, ctx: TransactionContext) -> Transaction {
         Transaction::new(self.client(), ctx)
     }
-
-    // oh well, its on the hub, not on the scope -_-
-    pub fn get_span(&self) -> Option<TransactionOrSpan> {
-        with_client_impl! {{
-            self.with_current_scope(|scope| scope.span.as_ref().as_ref().cloned())
-        }}
-    }
 }
 
 // "Context" Types:

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -252,7 +252,11 @@ impl Transaction {
             trace_id: inner.context.trace_id,
             parent_span_id: Some(inner.context.span_id),
             op: Some(op.into()),
-            description: Some(description.into()),
+            description: if description.is_empty() {
+                None
+            } else {
+                Some(description.into())
+            },
             ..Default::default()
         };
         Span {
@@ -304,7 +308,11 @@ impl Span {
             trace_id: self.span.trace_id,
             parent_span_id: Some(self.span.span_id),
             op: Some(op.into()),
-            description: Some(description.into()),
+            description: if description.is_empty() {
+                None
+            } else {
+                Some(description.into())
+            },
             ..Default::default()
         };
         Span {

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -57,7 +57,7 @@ impl TransactionContext {
     /// can be used for distributed tracing.
     #[must_use = "this must be used with `start_transaction`"]
     pub fn new(name: &str, op: &str) -> Self {
-        Self::continue_from_headers(name, op, [])
+        Self::continue_from_headers(name, op, vec![])
     }
 
     /// Creates a new Transaction Context based on the distributed tracing `headers`.

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -109,7 +109,7 @@ struct TransactionInner {
 
 type TransactionArc = Arc<Mutex<TransactionInner>>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Transaction {
     inner: TransactionArc,
 }
@@ -174,7 +174,7 @@ impl Transaction {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Span {
     transaction: TransactionArc,
     span: protocol::Span,

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -1,11 +1,17 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::Weak;
+
 use crate::protocol;
 
 use crate::Hub;
 
+const MAX_SPANS: usize = 1_000;
+
 // global API:
 
 pub fn start_transaction() -> Transaction {
-    todo!()
+    Transaction::new()
 }
 
 pub fn start_span() -> Span {
@@ -22,33 +28,135 @@ impl Hub {
 
 // global API types:
 
-pub struct Transaction {}
+struct TransactionInner {
+    context: protocol::TraceContext,
+    transaction: Mutex<protocol::Transaction<'static>>,
+}
+
+pub struct Transaction {
+    inner: Arc<TransactionInner>,
+}
 
 impl Transaction {
+    #[must_use = "a transaction must be explicitly closed via `finish()`"]
+    pub fn new() -> Self {
+        Self::continue_from_headers([])
+    }
+
+    #[must_use = "a transaction must be explicitly closed via `finish()`"]
     pub fn continue_from_headers<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(
         headers: I,
     ) -> Self {
-        Transaction {}
+        let mut trace = None;
+        for (k, v) in headers.into_iter() {
+            if k == "sentry-trace" {
+                trace = parse_sentry_trace(v);
+            }
+        }
+
+        let (trace_id, parent_span_id) = match trace {
+            Some(trace) => (trace.0, Some(trace.1)),
+            None => (protocol::TraceId::default(), None),
+        };
+
+        let context = protocol::TraceContext {
+            trace_id,
+            parent_span_id,
+            ..Default::default()
+        };
+
+        let transaction = Mutex::new(protocol::Transaction {
+            ..Default::default()
+        });
+
+        Self {
+            inner: Arc::new(TransactionInner {
+                context,
+                transaction,
+            }),
+        }
     }
 
-    pub fn finish(self) {}
+    pub fn finish(self) {
+        // TODO: maybe we should hold onto a ref of the client directly?
+        if let Some(client) = Hub::current().client() {
+            // NOTE: we expect this to always succeed, since all other places
+            // use weak references (well, except if you are inside a `Span::finish`)
+            if let Ok(inner) = Arc::try_unwrap(self.inner) {
+                let mut transaction = inner.transaction.into_inner().unwrap();
+                transaction.finish();
+                transaction
+                    .contexts
+                    .insert("trace".into(), inner.context.into());
 
-    pub fn start_child() -> Span {
-        todo!()
+                let mut envelope = protocol::Envelope::new();
+                envelope.add_item(transaction);
+
+                client.send_envelope(envelope)
+            }
+        }
+    }
+
+    #[must_use = "a span must be explicitly closed via `finish()`"]
+    pub fn start_child(&self) -> Span {
+        let span = protocol::Span {
+            trace_id: self.inner.context.trace_id,
+            parent_span_id: Some(self.inner.context.span_id),
+            ..Default::default()
+        };
+        Span {
+            transaction: Arc::downgrade(&self.inner),
+            span,
+        }
     }
 }
 
-pub struct Span {}
+pub struct Span {
+    transaction: Weak<TransactionInner>,
+    span: protocol::Span,
+}
 
 impl Span {
-    pub fn to_sentry_trace(&self) -> String {
-        format!("")
+    pub fn iter_headers(&self) -> TraceHeadersIter {
+        let trace = SentryTrace(self.span.trace_id, self.span.span_id, None);
+        TraceHeadersIter {
+            sentry_trace: Some(trace.to_string()),
+        }
     }
 
-    pub fn finish(self) {}
+    pub fn finish(mut self) {
+        self.span.finish();
+        if let Some(transaction) = self.transaction.upgrade() {
+            let mut transaction = transaction.transaction.lock().unwrap();
+            if transaction.spans.len() <= MAX_SPANS {
+                transaction.spans.push(self.span);
+            }
+        }
+    }
 
-    pub fn start_child() -> Span {
-        todo!()
+    #[must_use = "a span must be explicitly closed via `finish()`"]
+    pub fn start_child(&self) -> Span {
+        let span = protocol::Span {
+            trace_id: self.span.trace_id,
+            parent_span_id: Some(self.span.span_id),
+            ..Default::default()
+        };
+        Span {
+            transaction: self.transaction.clone(),
+            span,
+        }
+    }
+}
+
+pub struct TraceHeadersIter {
+    sentry_trace: Option<String>,
+}
+
+impl Iterator for TraceHeadersIter {
+    type Item = (&'static str, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.sentry_trace.take().map(|st| ("sentry-trace", st))
     }
 }
 

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -153,6 +153,17 @@ impl TransactionOrSpan {
         };
         event.contexts.insert("trace".into(), context.into());
     }
+
+    /// Finishes the Transaction/Span.
+    ///
+    /// This records the end timestamp and either sends the inner [`Transaction`]
+    /// directly to Sentry, or adds the [`Span`] to its transaction.
+    pub fn finish(self) {
+        match self {
+            TransactionOrSpan::Transaction(transaction) => transaction.finish(),
+            TransactionOrSpan::Span(span) => span.finish(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -1,0 +1,103 @@
+use crate::protocol;
+
+use crate::Hub;
+
+// global API:
+
+pub fn start_transaction() -> Transaction {
+    todo!()
+}
+
+pub fn start_span() -> Span {
+    todo!()
+}
+
+// Hub API:
+
+impl Hub {
+    pub fn start_transaction() -> Transaction {
+        todo!()
+    }
+}
+
+// global API types:
+
+pub struct Transaction {}
+
+impl Transaction {
+    pub fn continue_from_headers<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(
+        headers: I,
+    ) -> Self {
+        Transaction {}
+    }
+
+    pub fn finish(self) {}
+
+    pub fn start_child() -> Span {
+        todo!()
+    }
+}
+
+pub struct Span {}
+
+impl Span {
+    pub fn to_sentry_trace(&self) -> String {
+        format!("")
+    }
+
+    pub fn finish(self) {}
+
+    pub fn start_child() -> Span {
+        todo!()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct SentryTrace(protocol::TraceId, protocol::SpanId, Option<bool>);
+
+fn parse_sentry_trace(header: &str) -> Option<SentryTrace> {
+    let header = header.trim();
+    let mut parts = header.splitn(3, '-');
+
+    let trace_id = parts.next()?.parse().ok()?;
+    let parent_span_id = parts.next()?.parse().ok()?;
+    let parent_sampled = parts.next().and_then(|sampled| match sampled {
+        "1" => Some(true),
+        "0" => Some(false),
+        _ => None,
+    });
+
+    Some(SentryTrace(trace_id, parent_span_id, parent_sampled))
+}
+
+impl std::fmt::Display for SentryTrace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}", self.0, self.1)?;
+        if let Some(sampled) = self.2 {
+            write!(f, "-{}", if sampled { '1' } else { '0' })?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_sentry_trace() {
+        use std::str::FromStr;
+        let trace_id = protocol::TraceId::from_str("09e04486820349518ac7b5d2adbf6ba5").unwrap();
+        let parent_trace_id = protocol::SpanId::from_str("9cf635fa5b870b3a").unwrap();
+
+        let trace = parse_sentry_trace("09e04486820349518ac7b5d2adbf6ba5-9cf635fa5b870b3a-0");
+        assert_eq!(
+            trace,
+            Some(SentryTrace(trace_id, parent_trace_id, Some(false)))
+        );
+
+        let trace = SentryTrace(Default::default(), Default::default(), None);
+        let parsed = parse_sentry_trace(&format!("{}", trace));
+        assert_eq!(parsed, Some(trace));
+    }
+}

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -108,4 +108,8 @@ impl Scope {
         let _event = event;
         minimal_unreachable!();
     }
+
+    pub fn set_span(&mut self) {
+        minimal_unreachable!();
+    }
 }

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -109,7 +109,13 @@ impl Scope {
         minimal_unreachable!();
     }
 
-    pub fn set_span(&mut self) {
+    /// Set the given [`TransactionOrSpan`] as the active span for this scope.
+    pub fn set_span(&mut self, span: Option<TransactionOrSpan>) {
         minimal_unreachable!();
+    }
+
+    /// Returns the currently active span.
+    pub fn get_span(&self) -> Option<TransactionOrSpan> {
+        None
     }
 }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -265,10 +265,12 @@ impl Scope {
         Some(event)
     }
 
+    /// Set the given [`TransactionOrSpan`] as the active span for this scope.
     pub fn set_span(&mut self, span: Option<TransactionOrSpan>) {
         self.span = Arc::new(span);
     }
 
+    /// Returns the currently active span.
     pub fn get_span(&self) -> Option<TransactionOrSpan> {
         self.span.as_ref().clone()
     }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -265,8 +265,8 @@ impl Scope {
         Some(event)
     }
 
-    pub fn set_span(&mut self) {
-        // self.
+    pub fn set_span(&mut self, span: Option<TransactionOrSpan>) {
+        self.span = Arc::new(span);
     }
 
     pub(crate) fn update_session_from_event(&self, event: &Event<'static>) {

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
+use crate::performance::TransactionOrSpan;
 use crate::protocol::{Breadcrumb, Context, Event, Level, User, Value};
 use crate::session::Session;
 use crate::Client;
@@ -44,6 +45,7 @@ pub struct Scope {
     pub(crate) contexts: Arc<HashMap<String, Context>>,
     pub(crate) event_processors: Arc<Vec<EventProcessor>>,
     pub(crate) session: Arc<Mutex<Option<Session>>>,
+    pub(crate) span: Arc<Option<TransactionOrSpan>>,
 }
 
 impl fmt::Debug for Scope {
@@ -231,6 +233,10 @@ impl Scope {
                 .map(|(k, v)| (k.to_owned(), v.to_owned())),
         );
 
+        if let Some(span) = self.span.as_ref() {
+            span.apply_to_event(&mut event);
+        }
+
         if event.transaction.is_none() {
             if let Some(txn) = self.transaction.as_deref() {
                 event.transaction = Some(txn.to_owned());
@@ -257,6 +263,10 @@ impl Scope {
         }
 
         Some(event)
+    }
+
+    pub fn set_span(&mut self) {
+        // self.
     }
 
     pub(crate) fn update_session_from_event(&self, event: &Event<'static>) {

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -269,6 +269,10 @@ impl Scope {
         self.span = Arc::new(span);
     }
 
+    pub fn get_span(&self) -> Option<TransactionOrSpan> {
+        self.span.as_ref().clone()
+    }
+
     pub(crate) fn update_session_from_event(&self, event: &Event<'static>) {
         if let Some(session) = self.session.lock().unwrap().as_mut() {
             session.update_from_event(event);

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -10,41 +10,58 @@ fn main() {
 
     let transaction =
         sentry::start_transaction(sentry::TransactionContext::new("transaction", "root span"));
+    sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+
     let span1 = transaction.start_child("span1");
+    sentry::configure_scope(|scope| scope.set_span(Some(span1.clone().into())));
+
     thread::sleep(Duration::from_millis(50));
 
-    let header = span1.iter_headers().next().unwrap();
+    let headers = match sentry::Hub::current().get_span() {
+        Some(span) => vec![span.iter_headers().next().unwrap()],
+        None => vec![],
+    };
     thread::spawn(move || {
-        let headers = [(header.0, header.1.as_str())];
-
         let transaction =
             sentry::start_transaction(sentry::TransactionContext::continue_from_headers(
                 "background transaction",
                 "root span",
-                headers,
+                headers.iter().map(|(k, v)| (*k, v.as_str())),
             ));
+        sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+
         thread::sleep(Duration::from_millis(50));
 
         let span1 = transaction.start_child("span1");
+        sentry::configure_scope(|scope| scope.set_span(Some(span1.clone().into())));
+
         thread::sleep(Duration::from_millis(200));
+
         span1.finish();
+        sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
 
         transaction.finish();
+        sentry::configure_scope(|scope| scope.set_span(None));
     });
     thread::sleep(Duration::from_millis(100));
 
     let span2 = span1.start_child("span2");
-    sentry::configure_scope(|scope| {
-        scope.set_span(Some(sentry::TransactionOrSpan::Span(span2.clone())))
-    });
+    sentry::configure_scope(|scope| scope.set_span(Some(span2.clone().into())));
+
     sentry::capture_message(
         "A message that should have a trace context",
         sentry::Level::Info,
     );
     thread::sleep(Duration::from_millis(200));
+
     span2.finish();
+    sentry::configure_scope(|scope| scope.set_span(Some(span1.clone().into())));
 
     span1.finish();
+    sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+
     thread::sleep(Duration::from_millis(100));
+
     transaction.finish();
+    sentry::configure_scope(|scope| scope.set_span(None));
 }

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -8,11 +8,29 @@ fn main() {
         ..Default::default()
     });
 
-    let transaction = sentry::start_transaction();
-    let span1 = transaction.start_child();
+    let transaction = sentry::start_transaction("transaction", "root span");
+    let span1 = transaction.start_child("span1");
+    thread::sleep(Duration::from_millis(50));
+
+    let header = span1.iter_headers().next().unwrap();
+    thread::spawn(move || {
+        let headers = [(header.0, header.1.as_str())];
+        let transaction = sentry::Transaction::continue_from_headers(
+            "background transaction",
+            "root span",
+            headers,
+        );
+        thread::sleep(Duration::from_millis(50));
+
+        let span1 = transaction.start_child("span1");
+        thread::sleep(Duration::from_millis(200));
+        span1.finish();
+
+        transaction.finish();
+    });
     thread::sleep(Duration::from_millis(100));
 
-    let span2 = span1.start_child();
+    let span2 = span1.start_child("span2");
     thread::sleep(Duration::from_millis(200));
     span2.finish();
 

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -12,56 +12,78 @@ fn main() {
         sentry::start_transaction(sentry::TransactionContext::new("transaction", "root span"));
     sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
 
-    let span1 = transaction.start_child("span1");
-    sentry::configure_scope(|scope| scope.set_span(Some(span1.clone().into())));
-
-    thread::sleep(Duration::from_millis(50));
-
-    let headers = match sentry::configure_scope(|scope| scope.get_span()) {
-        Some(span) => vec![span.iter_headers().next().unwrap()],
-        None => vec![],
-    };
-    thread::spawn(move || {
-        let transaction =
-            sentry::start_transaction(sentry::TransactionContext::continue_from_headers(
-                "background transaction",
-                "root span",
-                headers.iter().map(|(k, v)| (*k, v.as_str())),
-            ));
-        sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-
-        thread::sleep(Duration::from_millis(50));
-
-        let span1 = transaction.start_child("span1");
-        sentry::configure_scope(|scope| scope.set_span(Some(span1.clone().into())));
-
-        thread::sleep(Duration::from_millis(200));
-
-        span1.finish();
-        sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
-
-        transaction.finish();
-        sentry::configure_scope(|scope| scope.set_span(None));
-    });
-    thread::sleep(Duration::from_millis(100));
-
-    let span2 = span1.start_child("span2");
-    sentry::configure_scope(|scope| scope.set_span(Some(span2.clone().into())));
-
-    sentry::capture_message(
-        "A message that should have a trace context",
-        sentry::Level::Info,
-    );
-    thread::sleep(Duration::from_millis(200));
-
-    span2.finish();
-    sentry::configure_scope(|scope| scope.set_span(Some(span1.clone().into())));
-
-    span1.finish();
-    sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+    main_span1();
 
     thread::sleep(Duration::from_millis(100));
 
     transaction.finish();
     sentry::configure_scope(|scope| scope.set_span(None));
+}
+
+fn main_span1() {
+    wrap_in_span("default", "span1", || {
+        thread::sleep(Duration::from_millis(50));
+
+        let headers = match sentry::configure_scope(|scope| scope.get_span()) {
+            Some(span) => vec![span.iter_headers().next().unwrap()],
+            None => vec![],
+        };
+        thread::spawn(move || {
+            let transaction =
+                sentry::start_transaction(sentry::TransactionContext::continue_from_headers(
+                    "background transaction",
+                    "root span",
+                    headers.iter().map(|(k, v)| (*k, v.as_str())),
+                ));
+            sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+
+            thread::sleep(Duration::from_millis(50));
+
+            thread_span1();
+
+            transaction.finish();
+            sentry::configure_scope(|scope| scope.set_span(None));
+        });
+        thread::sleep(Duration::from_millis(100));
+
+        main_span2()
+    });
+}
+
+fn thread_span1() {
+    wrap_in_span("default", "span1", || {
+        thread::sleep(Duration::from_millis(200));
+    })
+}
+
+fn main_span2() {
+    wrap_in_span("default", "span2", || {
+        sentry::capture_message(
+            "A message that should have a trace context",
+            sentry::Level::Info,
+        );
+        thread::sleep(Duration::from_millis(200));
+    })
+}
+
+fn wrap_in_span<F, R>(op: &str, description: &str, f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let parent = sentry::configure_scope(|scope| scope.get_span());
+    let span1: sentry::TransactionOrSpan = match &parent {
+        Some(parent) => parent.start_child(op, description).into(),
+        None => {
+            let ctx = sentry::TransactionContext::new(description, op);
+            sentry::start_transaction(ctx).into()
+        }
+    };
+    sentry::configure_scope(|scope| scope.set_span(Some(span1.clone())));
+
+    let rv = f();
+
+    span1.finish();
+    sentry::configure_scope(|scope| scope.set_span(parent));
+
+    rv
 }

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -17,7 +17,7 @@ fn main() {
 
     thread::sleep(Duration::from_millis(50));
 
-    let headers = match sentry::Hub::current().get_span() {
+    let headers = match sentry::configure_scope(|scope| scope.get_span()) {
         Some(span) => vec![span.iter_headers().next().unwrap()],
         None => vec![],
     };

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 fn main() {
     let _sentry = sentry::init(sentry::ClientOptions {
         release: sentry::release_name!(),
+        traces_sample_rate: 1.0,
+        debug: true,
         ..Default::default()
     });
 

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -21,7 +21,7 @@ fn main() {
 }
 
 fn main_span1() {
-    wrap_in_span("default", "span1", || {
+    wrap_in_span("span1", "", || {
         thread::sleep(Duration::from_millis(50));
 
         let headers = match sentry::configure_scope(|scope| scope.get_span()) {
@@ -51,13 +51,13 @@ fn main_span1() {
 }
 
 fn thread_span1() {
-    wrap_in_span("default", "span1", || {
+    wrap_in_span("span1", "", || {
         thread::sleep(Duration::from_millis(200));
     })
 }
 
 fn main_span2() {
-    wrap_in_span("default", "span2", || {
+    wrap_in_span("span2", "", || {
         sentry::capture_message(
             "A message that should have a trace context",
             sentry::Level::Info,

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -8,18 +8,21 @@ fn main() {
         ..Default::default()
     });
 
-    let transaction = sentry::start_transaction("transaction", "root span");
+    let transaction =
+        sentry::start_transaction(sentry::TransactionContext::new("transaction", "root span"));
     let span1 = transaction.start_child("span1");
     thread::sleep(Duration::from_millis(50));
 
     let header = span1.iter_headers().next().unwrap();
     thread::spawn(move || {
         let headers = [(header.0, header.1.as_str())];
-        let transaction = sentry::Transaction::continue_from_headers(
-            "background transaction",
-            "root span",
-            headers,
-        );
+
+        let transaction =
+            sentry::start_transaction(sentry::TransactionContext::continue_from_headers(
+                "background transaction",
+                "root span",
+                headers,
+            ));
         thread::sleep(Duration::from_millis(50));
 
         let span1 = transaction.start_child("span1");

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -34,6 +34,13 @@ fn main() {
     thread::sleep(Duration::from_millis(100));
 
     let span2 = span1.start_child("span2");
+    sentry::configure_scope(|scope| {
+        scope.set_span(Some(sentry::TransactionOrSpan::Span(span2.clone())))
+    });
+    sentry::capture_message(
+        "A message that should have a trace context",
+        sentry::Level::Info,
+    );
     thread::sleep(Duration::from_millis(200));
     span2.finish();
 

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -1,0 +1,22 @@
+use std::thread;
+use std::time::Duration;
+
+// cargo run --example performance-demo
+fn main() {
+    let _sentry = sentry::init(sentry::ClientOptions {
+        release: sentry::release_name!(),
+        ..Default::default()
+    });
+
+    let transaction = sentry::start_transaction();
+    let span1 = transaction.start_child();
+    thread::sleep(Duration::from_millis(100));
+
+    let span2 = span1.start_child();
+    thread::sleep(Duration::from_millis(200));
+    span2.finish();
+
+    span1.finish();
+    thread::sleep(Duration::from_millis(100));
+    transaction.finish();
+}


### PR DESCRIPTION
This implements a manual performance monitoring API, which tries to follow the unified API spec.

One can start a transaction on its own, or based on a distributed tracing header (or another Span), as well as start new child Spans.

Hooking this up to other external services downstream should be possible via an `iter_headers` that allows attaching the headers to outgoing Http requests.

Spans are recorded as part of the transaction they ultimately belong to on `finish`.
Transactions are being sent to sentry properly when they are being `finish`ed.

A Span can be attached to the scope as the *current* span, and queried via `Scope::set_span/get_span`.
This makes it possible to for example query for distributed tracing headers anywhere in the application, or create a child span anywhere.
The *current* span is also used to attach the trace context to any event that is being captured as long as a *current* span exists.

What is currently missing is the ability to add more attrs/metadata to a span after it was created, and the API as a whole would need some polishing down the road, however this implementation is enough to consider this feature "done" and to ship it to customers (and possibly dogfood it ourselves in symbolicator).