### PR TITLE
feat: Add a Http Service integration with trace propagation (NATIVE-314) 

### DIFF
--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -11,9 +11,13 @@ Sentry integration for tower-based crates.
 """
 edition = "2018"
 
+[features]
+http = []
+
 [dependencies]
 tower-layer = "0.3"
 tower-service = "0.3"
+http = { version = "0.2.6", optional = true }
 sentry-core = { version = "0.23.0", path = "../sentry-core", default-features = false, features = ["client"] }
 
 [dev-dependencies]

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -12,12 +12,13 @@ Sentry integration for tower-based crates.
 edition = "2018"
 
 [features]
-http = []
+http = ["http_", "pin-project"]
 
 [dependencies]
 tower-layer = "0.3"
 tower-service = "0.3"
-http = { version = "0.2.6", optional = true }
+http_ = { package = "http", version = "0.2.6", optional = true }
+pin-project = { version = "1.0.10", optional = true }
 sentry-core = { version = "0.23.0", path = "../sentry-core", default-features = false, features = ["client"] }
 
 [dev-dependencies]

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tower_layer::Layer;
+use tower_service::Service;
+
+#[derive(Clone)]
+pub struct SentryHttpLayer;
+
+#[derive(Clone)]
+pub struct SentryHttpService<S> {
+    service: S,
+}
+
+impl<S> Layer<S> for SentryHttpLayer {
+    type Service = SentryHttpService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        Self::Service { service }
+    }
+}
+
+pub struct SentryHttpFuture<F> {
+    transaction: Option<sentry_core::Transaction>,
+    future: F,
+}
+
+impl Future for SentryHttpFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // https://doc.rust-lang.org/std/pin/index.html#pinning-is-structural-for-field
+        let future = unsafe { self.map_unchecked_mut(|s| &mut s.future) };
+        match future.poll(cx) {
+            Poll::Ready(res) => {
+                if let Some(transaction) = self.transaction.take() {
+                    transaction.finish();
+                }
+                Poll::Ready(res)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S, Body> Service<Request<Body>> for SentryHttpService<S>
+where
+    S: Service<Request<Body>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = SentryHttpFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let transaction = sentry::configure_scope(|scope| {
+            // https://develop.sentry.dev/sdk/event-payloads/request/
+            let mut ctx = BTreeMap::new();
+
+            // TODO: method, url, query_string
+
+            // headers
+            let mut headers = BTreeMap::new();
+            for (header, value) in request.headers() {
+                headers.insert(
+                    header.to_string(),
+                    value.to_str().unwrap_or("<Opaque header value>").into(),
+                );
+            }
+            ctx.insert("headers".into(), headers);
+
+            scope.set_context("request", sentry_core::protocol::Context::Other(ctx));
+
+            // TODO: maybe make transaction creation optional?
+            let transaction = if true {
+                let tx_ctx = sentry_core::TransactionContext::continue_from_headers(
+                    // TODO: whats the name here?
+                    "",
+                    "http",
+                    request.headers(),
+                );
+                Some(sentry_core::start_transaction(tx_ctx))
+            } else {
+                None
+            };
+
+            scope.set_span(transaction.clone());
+            transaction
+        });
+
+        SentryHttpFuture {
+            transaction,
+            future: self.service.call(request),
+        }
+    }
+}

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -122,9 +122,11 @@ where
                 let headers = request.headers().into_iter().flat_map(|(header, value)| {
                     value.to_str().ok().map(|value| (header.as_str(), value))
                 });
+                let tx_name = format!("{} {}", request.method(), request.uri().path());
                 let tx_ctx = sentry_core::TransactionContext::continue_from_headers(
-                    // TODO: whats the name here?
-                    "", "http", headers,
+                    &tx_name,
+                    "http.server",
+                    headers,
                 );
                 let transaction: sentry_core::TransactionOrSpan =
                     sentry_core::start_transaction(tx_ctx).into();

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -8,8 +8,9 @@ use tower_service::Service;
 
 /// Tower Layer that logs Http Request Headers.
 ///
-/// The Layer can also optionally start a new performance monitoring transaction
-/// based on incoming distributed tracing headers.
+/// The Service created by this Layer can also optionally start a new
+/// performance monitoring transaction for each incoming request,
+/// continuing the trace based on incoming distributed tracing headers.
 #[derive(Clone, Default)]
 pub struct SentryHttpLayer {
     start_transaction: bool,
@@ -21,7 +22,8 @@ impl SentryHttpLayer {
         Self::default()
     }
 
-    /// Creates a new Layer that also starts a new performance monitoring transaction.
+    /// Creates a new Layer which starts a new performance monitoring transaction
+    /// for each incoming request.
     pub fn with_transaction() -> Self {
         Self {
             start_transaction: true,
@@ -32,7 +34,8 @@ impl SentryHttpLayer {
 /// Tower Service that logs Http Request Headers.
 ///
 /// The Service can also optionally start a new performance monitoring transaction
-/// based on incoming distributed tracing headers.
+/// for each incoming request, continuing the trace based on incoming
+/// distributed tracing headers.
 #[derive(Clone)]
 pub struct SentryHttpService<S> {
     service: S,
@@ -50,7 +53,7 @@ impl<S> Layer<S> for SentryHttpLayer {
     }
 }
 
-/// The Future returned from [`SentryHttpService`]
+/// The Future returned from [`SentryHttpService`].
 #[pin_project::pin_project]
 pub struct SentryHttpFuture<F> {
     transaction: Option<(

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -1,11 +1,8 @@
 use std::future::Future;
-use std::iter::FromIterator;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use http_::Request;
-use sentry_core::protocol::value::Map as ValueMap;
-use sentry_core::protocol::{Map as SentryMap, Value};
 use tower_layer::Layer;
 use tower_service::Service;
 

--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -112,6 +112,8 @@ use tower_service::Service;
 
 #[cfg(feature = "http")]
 mod http;
+#[cfg(feature = "http")]
+pub use http::*;
 
 /// Provides a hub for each request
 pub trait HubProvider<H, Request>

--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -102,12 +102,16 @@
 #![doc(html_logo_url = "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png")]
 #![warn(missing_docs)]
 
-use sentry_core::{Hub, SentryFuture, SentryFutureExt};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+
+use sentry_core::{Hub, SentryFuture, SentryFutureExt};
 use tower_layer::Layer;
 use tower_service::Service;
+
+#[cfg(feature = "http")]
+mod http;
 
 /// Provides a hub for each request
 pub trait HubProvider<H, Request>
@@ -140,7 +144,7 @@ pub struct NewFromTopProvider;
 
 impl<Request> HubProvider<Arc<Hub>, Request> for NewFromTopProvider {
     fn hub(&self, _request: &Request) -> Arc<Hub> {
-        // The Clippy lint here is a falste positive, the suggestion to write
+        // The Clippy lint here is a false positive, the suggestion to write
         // `Hub::with(Hub::new_from_top)` does not compiles:
         //     143 |         Hub::with(Hub::new_from_top).into()
         //         |         ^^^^^^^^^ implementation of `std::ops::FnOnce` is not general enough

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -46,7 +46,7 @@ pub mod debugid {
 /// An arbitrary (JSON) value.
 pub use self::value::Value;
 
-/// The internally useed map type.
+/// The internally used map type.
 pub use self::map::Map;
 
 /// A wrapper type for collections with attached meta data.


### PR DESCRIPTION
Based on #395, this creates a new sentry-tower feature, which enables a new tower `Layer`, which will start a new transaction for each Http request, using the incoming headers for distributed trace propagation.