### PR TITLE
feat: Support errors in tracing integration (NATIVE-310)

### DIFF
--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 
 [dependencies]
 sentry-core = { version = "0.23.0", path = "../sentry-core", features = ["client"] }
-sentry-backtrace = { version = "0.23.0", path = "../sentry-backtrace" }
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
 

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -12,7 +12,8 @@ Sentry integration for tracing and tracing-subscriber crates.
 edition = "2018"
 
 [dependencies]
-sentry-core = { version = "0.23.0", path = "../sentry-core" }
+sentry-core = { version = "0.23.0", path = "../sentry-core", features = ["client"] }
+sentry-backtrace = { version = "0.23.0", path = "../sentry-backtrace" }
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
 

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -144,7 +144,6 @@ where
             ty,
             value,
             module: event.metadata().module_path().map(String::from),
-            stacktrace: sentry_backtrace::current_stacktrace(),
             ..Default::default()
         }]
     } else {

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -217,10 +217,10 @@ where
             _ => return,
         };
 
-        let mut data = BTreeMapRecorder::default();
+        let mut data = FieldVisitor::default();
         values.record(&mut data);
 
-        for (key, value) in data.0 {
+        for (key, value) in data.json_values {
             span.set_data(&key, value);
         }
     }

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -21,9 +21,13 @@ fn test_tracing() {
 
         log::info!("Hello Logging World!");
         log::error!("Shit's on fire yo");
+
+        let err = "NaN".parse::<usize>().unwrap_err();
+        let err: &dyn std::error::Error = &err;
+        tracing::error!(err);
     });
 
-    assert_eq!(events.len(), 2);
+    assert_eq!(events.len(), 3);
     let mut events = events.into_iter();
 
     let event = events.next().unwrap();
@@ -51,6 +55,14 @@ fn test_tracing() {
     assert_eq!(
         event.breadcrumbs[1].message,
         Some("Hello Logging World!".into())
+    );
+
+    let event = events.next().unwrap();
+    assert!(!event.exception.is_empty());
+    assert_eq!(event.exception[0].ty, "ParseIntError");
+    assert_eq!(
+        event.exception[0].value,
+        Some("invalid digit found in string".into())
     );
 }
 


### PR DESCRIPTION
This supercedes #359 and merges it with the latest changes to the tracing integration.

It also adds another test for capturing `&dyn Error` via `tracing::error!()`, which this should all be about.