### PR TITLE
Disable performance when client feature disabled

### DIFF
--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -63,7 +63,6 @@ mod futures;
 mod hub;
 mod integration;
 mod intodsn;
-mod performance;
 mod scope;
 mod transport;
 
@@ -76,7 +75,6 @@ pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
-pub use crate::performance::*;
 pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 
@@ -84,9 +82,11 @@ pub use crate::transport::{Transport, TransportFactory};
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "client")]
+mod performance;
+#[cfg(feature = "client")]
 mod session;
 #[cfg(feature = "client")]
-pub use crate::client::Client;
+pub use crate::{client::Client, performance::*};
 
 // test utilities
 #[cfg(feature = "test")]

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -108,14 +108,4 @@ impl Scope {
         let _event = event;
         minimal_unreachable!();
     }
-
-    /// Set the given [`TransactionOrSpan`] as the active span for this scope.
-    pub fn set_span(&mut self, span: Option<TransactionOrSpan>) {
-        minimal_unreachable!();
-    }
-
-    /// Returns the currently active span.
-    pub fn get_span(&self) -> Option<TransactionOrSpan> {
-        None
-    }
 }


### PR DESCRIPTION
The new performance features rely on the `client` feature being enabled, and when it's not enabled sentry-core fails to compile, this just gates the entire `performance` module behind the `client` feature for now so that it at least compiles, as it seemed non-trivial to untangle types like `TransactionOrSpan` from `client`.