### PR TITLE
fix: Make building without client feature work again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "sentry",
     "sentry-actix",

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ check-default-features:
 
 check-no-default-features:
 	@echo 'NO DEFAULT FEATURES'
-	@cd sentry && RUSTFLAGS=-Dwarnings cargo check --no-default-features
+	@cd sentry-core && RUSTFLAGS=-Dwarnings cargo check --no-default-features
 .PHONY: check-no-default-features
 
 check-panic:

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -12,7 +12,7 @@ Sentry client extension for actix-web 3.
 edition = "2018"
 
 [dependencies]
-sentry-core = { version = "0.24.1", path = "../sentry-core", default-features = false }
+sentry-core = { version = "0.24.1", path = "../sentry-core", default-features = false, features = ["client"] }
 actix-web = { version = "3", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
 

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crate::protocol::{Context, Event, Level, User, Value};
+use crate::TransactionOrSpan;
 
 /// A minimal API scope guard.
 ///
@@ -111,6 +112,7 @@ impl Scope {
 
     /// Set the given [`TransactionOrSpan`] as the active span for this scope.
     pub fn set_span(&mut self, span: Option<TransactionOrSpan>) {
+        let _ = span;
         minimal_unreachable!();
     }
 


### PR DESCRIPTION
We weren't testing this in CI previously. And it would seem that this was broken
in the monorepo anyway, since it requires `resolver = "2"` in order not to unify
features.

supercedes #415, as we still want the API (and trace propagation via headers) to work in such cases.