### PR TITLE
fix: Prevent Memory leaks from sentry-tower

### DIFF
--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -253,8 +253,9 @@ where
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        let hub = self.provider.hub(&request);
-        self.service.call(request).bind_hub(hub)
+        let hub = self.provider.hub(&request).into();
+        let fut = Hub::run(hub.clone(), || self.service.call(request));
+        fut.bind_hub(hub)
     }
 }
 

--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -110,8 +110,9 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "http")] {
+//! # type Request = http_::Request<String>;
 //! let layer = tower::ServiceBuilder::new()
-//!     .layer(sentry_tower::NewSentryLayer::new_from_top())
+//!     .layer(sentry_tower::NewSentryLayer::<Request>::new_from_top())
 //!     .layer(sentry_tower::SentryHttpLayer::with_transaction());
 //! # }
 //! ```

--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -97,6 +97,24 @@
 //! #     Ok(())
 //! # }
 //! ```
+//!
+//! ## Usage with `tower-http`
+//!
+//! The `http` feature offers another layer which will attach request details
+//! onto captured events, and optionally start a new performance monitoring
+//! transaction based on the incoming HTTP headers.
+//!
+//! When combining both layers, take care of the ordering of both. For example
+//! with [`tower::ServiceBuilder`], always define the `Hub` layer before the `Http`
+//! one, like so:
+//!
+//! ```rust
+//! # #[cfg(feature = "http")] {
+//! let layer = tower::ServiceBuilder::new()
+//!     .layer(sentry_tower::NewSentryLayer::new_from_top())
+//!     .layer(sentry_tower::SentryHttpLayer::with_transaction());
+//! # }
+//! ```
 
 #![doc(html_favicon_url = "https://sentry-brand.storage.googleapis.com/favicon.ico")]
 #![doc(html_logo_url = "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png")]


### PR DESCRIPTION
The TowerService::call seems to just create futures, and is not running in the context of a parent layers future. Also the other way around, `SentryService` didn’t wrap the `call` in a `Hub` either.