### PR TITLE
meta: Remove serde_json feature from `curl`

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -39,7 +39,7 @@ debug-logs = ["log_", "sentry-core/debug-logs"]
 # transports
 transport = ["reqwest", "native-tls"]
 reqwest = ["reqwest_", "httpdate", "tokio"]
-curl = ["curl_", "httpdate", "serde_json", "tokio"]
+curl = ["curl_", "httpdate", "tokio"]
 surf-h1 = ["surf_/h1-client", "httpdate"]
 surf = ["surf_/curl-client", "httpdate", "tokio"]
 native-tls = ["reqwest_/default-tls"]

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -63,7 +63,6 @@ impl CurlHttpTransport {
             let mut headers = curl::easy::List::new();
             headers.append(&format!("X-Sentry-Auth: {}", auth)).unwrap();
             headers.append("Expect:").unwrap();
-            headers.append("Content-Type: application/json").unwrap();
             handle.http_headers(headers).unwrap();
             handle.upload(true).unwrap();
             handle.in_filesize(body.get_ref().len() as u64).unwrap();


### PR DESCRIPTION
Curl doesn't need `serde_json` support since Sentry already serializes envelopes to a vector of bytes internally.  Likewise no other transport sets the `Content-Type: application/json` header, presumably because the data is multiple json objects concatenated together.
