### PR TITLE
meta: Add #519 (`ureq` transport support) to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Added `ureq` transport support ([#419](https://github.com/getsentry/sentry-rust/pull/419))
+
 **Fixes**:
 
 - Remove unused `serde_json` feature from `curl` dependency. ([#420](http://github.com/getsentry/sentry-rust/pull/420))


### PR DESCRIPTION
The previous `meta` PR(s) for the changelog seemed autogenerated, but given recent commits I thought I should at least add my own items to the list to save you the hassle ;)