### PR TITLE
feat(tracing): Add line information from tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Remove unused `serde_json` feature from `curl` dependency. ([#420](http://github.com/getsentry/sentry-rust/pull/420))
 - `sentry-tracing`: When converting a `tracing` event to a `sentry` event, don't create an exception if the original event doesn't have one ([#423](https://github.com/getsentry/sentry-rust/pull/423))
+- `sentry-tracing`: Add line numbers and tags into custom Contexts sections. ([#430](http://github.com/getsentry/sentry-rust/pull/430))
 
 **Thank you**:
 

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -103,6 +103,36 @@ pub fn breadcrumb_from_event(event: &tracing_core::Event) -> Breadcrumb {
     }
 }
 
+fn contexts_from_event(
+    event: &tracing_core::Event,
+    event_tags: BTreeMap<String, Value>,
+) -> BTreeMap<String, sentry_core::protocol::Context> {
+    let event_meta = event.metadata();
+    let mut location_map = BTreeMap::new();
+    if let Some(module_path) = event_meta.module_path() {
+        location_map.insert("module_path".to_string(), module_path.into());
+    }
+    if let Some(file) = event_meta.file() {
+        location_map.insert("file".to_string(), file.into());
+    }
+    if let Some(line) = event_meta.line() {
+        location_map.insert("line".to_string(), line.into());
+    }
+
+    let mut context = BTreeMap::new();
+    context.insert(
+        "Rust Tracing Tags".to_string(),
+        sentry_core::protocol::Context::Other(event_tags),
+    );
+    if !location_map.is_empty() {
+        context.insert(
+            "Rust Tracing Location".to_string(),
+            sentry_core::protocol::Context::Other(location_map),
+        );
+    }
+    context
+}
+
 /// Creates an [`Event`] from a given [`tracing_core::Event`]
 pub fn event_from_event<S>(event: &tracing_core::Event, _ctx: Context<S>) -> Event<'static>
 where
@@ -114,7 +144,7 @@ where
         logger: Some(event.metadata().target().to_owned()),
         level: convert_tracing_level(event.metadata().level()),
         message,
-        extra: visitor.json_values,
+        contexts: contexts_from_event(event, visitor.json_values),
         ..Default::default()
     }
 }
@@ -133,8 +163,8 @@ where
         logger: Some(event.metadata().target().to_owned()),
         level: convert_tracing_level(event.metadata().level()),
         message,
-        extra: visitor.json_values,
         exception: visitor.exceptions.into(),
+        contexts: contexts_from_event(event, visitor.json_values),
         ..Default::default()
     }
 }

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -120,10 +120,12 @@ fn contexts_from_event(
     }
 
     let mut context = BTreeMap::new();
-    context.insert(
-        "Rust Tracing Tags".to_string(),
-        sentry_core::protocol::Context::Other(event_tags),
-    );
+    if !event_tags.is_empty() {
+        context.insert(
+            "Rust Tracing Tags".to_string(),
+            sentry_core::protocol::Context::Other(event_tags),
+        );
+    }
     if !location_map.is_empty() {
         context.insert(
             "Rust Tracing Location".to_string(),


### PR DESCRIPTION
This adds the line information that tracing provides back into the
event.  It also moves around the tags into a custom context instead of
the "extra" grab-bag as this is less likely to step on the user's
ad-hoc toes.

Related to #427 