### PR TITLE
ref: Forward set_transaction to a running Transaction

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -257,12 +257,12 @@ impl TransactionOrSpan {
 }
 
 #[derive(Debug)]
-struct TransactionInner {
+pub(crate) struct TransactionInner {
     #[cfg(feature = "client")]
     client: Option<Arc<Client>>,
     sampled: bool,
     context: protocol::TraceContext,
-    transaction: Option<protocol::Transaction<'static>>,
+    pub(crate) transaction: Option<protocol::Transaction<'static>>,
 }
 
 type TransactionArc = Arc<Mutex<TransactionInner>>;
@@ -274,7 +274,7 @@ type TransactionArc = Arc<Mutex<TransactionInner>>;
 /// to Sentry.
 #[derive(Clone, Debug)]
 pub struct Transaction {
-    inner: TransactionArc,
+    pub(crate) inner: TransactionArc,
 }
 
 impl Transaction {
@@ -428,7 +428,7 @@ impl Transaction {
 /// will not be sent to Sentry.
 #[derive(Clone, Debug)]
 pub struct Span {
-    transaction: TransactionArc,
+    pub(crate) transaction: TransactionArc,
     sampled: bool,
     span: SpanArc,
 }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -160,6 +160,17 @@ impl Scope {
     /// Sets the transaction.
     pub fn set_transaction(&mut self, transaction: Option<&str>) {
         self.transaction = transaction.map(Arc::from);
+        if let Some(name) = transaction {
+            let trx = match self.span.as_ref() {
+                Some(TransactionOrSpan::Span(span)) => &span.transaction,
+                Some(TransactionOrSpan::Transaction(trx)) => &trx.inner,
+                _ => return,
+            };
+
+            if let Some(trx) = trx.lock().unwrap().transaction.as_mut() {
+                trx.name = Some(name.into());
+            }
+        }
     }
 
     /// Sets the user for the current scope.


### PR DESCRIPTION
A call to `Scope::set_transaction` will now also forward the given name to the currently running performance monitoring transaction to override the `name` it was started with.