### PR TITLE
ci/weekly: Only run scheduled jobs on the upstream repository

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -11,6 +11,7 @@ jobs:
   weekly-clippy-beta:
     name: Clippy Beta
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'getsentry'
 
     steps:
       - uses: actions/checkout@v2
@@ -35,6 +36,7 @@ jobs:
   weekly-audit:
     name: Audit
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'getsentry'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
With the workflow being to create a fork in order to contribute to this project, this fork shouldn't automatically run scheduled linting jobs on the main branch (wherever that happened to be when the fork was cloned/created) and bothering the fork-er with it if it's non-compliant.

Note: I'd love to have this `if` in the `on:` configuration to not even add `Weekly CI` to the GH actions overview (with 2 skipped jobs), but this does not seem possible according to https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions. Suggestions welcome!
