### PR TITLE
docs: Advise users to override automatic transaction name

### DIFF
--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -12,6 +12,12 @@ use tower_service::Service;
 /// The Service created by this Layer can also optionally start a new
 /// performance monitoring transaction for each incoming request,
 /// continuing the trace based on incoming distributed tracing headers.
+///
+/// The created transaction will automatically use the request URI as its name.
+/// This is sometimes not desirable in case the request URI contains unique IDs
+/// or similar. In this case, users should manually override the transaction name
+/// in the request handler using the [`Scope::set_transaction`](sentry_core::Scope::set_transaction)
+/// method.
 #[derive(Clone, Default)]
 pub struct SentryHttpLayer {
     start_transaction: bool,

--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -104,6 +104,12 @@
 //! onto captured events, and optionally start a new performance monitoring
 //! transaction based on the incoming HTTP headers.
 //!
+//! The created transaction will automatically use the request URI as its name.
+//! This is sometimes not desirable in case the request URI contains unique IDs
+//! or similar. In this case, users should manually override the transaction name
+//! in the request handler using the [`Scope::set_transaction`](sentry_core::Scope::set_transaction)
+//! method.
+//!
 //! When combining both layers, take care of the ordering of both. For example
 //! with [`tower::ServiceBuilder`], always define the `Hub` layer before the `Http`
 //! one, like so:


### PR DESCRIPTION
See https://github.com/getsentry/symbolicator/pull/687#issuecomment-1048694346 for some context.