### PR TITLE
add request to transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Request data can now be attached to Transactions and Spans via `set_transaction`. ([#439](https://github.com/getsentry/sentry-rust/pull/439))
+
+**Thank you**:
+
+Features, fixes and improvements in this release have been contributed by:
+
+- [@jessfraz](https://github.com/jessfraz)
+
 ## 0.25.0
 
 **Breaking Changes**:

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -202,6 +202,14 @@ impl TransactionOrSpan {
         }
     }
 
+    /// Set the HTTP request information for this Transaction/Span.
+    pub fn set_request(&self, request: protocol::Request) {
+        match self {
+            TransactionOrSpan::Transaction(transaction) => transaction.set_request(request),
+            TransactionOrSpan::Span(span) => span.set_request(request),
+        }
+    }
+
     /// Returns the headers needed for distributed tracing.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         match self {
@@ -355,6 +363,14 @@ impl Transaction {
         inner.context.status = Some(status);
     }
 
+    /// Set the HTTP request information for this Transaction.
+    pub fn set_request(&self, request: protocol::Request) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(transaction) = inner.transaction.as_mut() {
+            transaction.request = Some(request);
+        }
+    }
+
     /// Returns the headers needed for distributed tracing.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let inner = self.inner.lock().unwrap();
@@ -452,6 +468,12 @@ impl Span {
     pub fn set_status(&self, status: protocol::SpanStatus) {
         let mut span = self.span.lock().unwrap();
         span.status = Some(status);
+    }
+
+    /// Set the HTTP request information for this Span.
+    pub fn set_request(&self, request: protocol::Request) {
+        let mut span = self.span.lock().unwrap();
+        span.request = Some(request);
     }
 
     /// Returns the headers needed for distributed tracing.

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -482,7 +482,7 @@ impl Span {
         }
         if let Some(data) = request.data {
             if let Ok(data) = serde_json::from_str::<serde_json::Value>(&data) {
-                span.data.insert("data".into(), data.into());
+                span.data.insert("data".into(), data);
             } else {
                 span.data.insert("data".into(), data.into());
             }
@@ -495,12 +495,12 @@ impl Span {
         }
         if !request.headers.is_empty() {
             if let Ok(headers) = serde_json::to_value(request.headers) {
-                span.data.insert("headers".into(), headers.into());
+                span.data.insert("headers".into(), headers);
             }
         }
         if !request.env.is_empty() {
             if let Ok(env) = serde_json::to_value(request.env) {
-                span.data.insert("env".into(), env.into());
+                span.data.insert("env".into(), env);
             }
         }
     }

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1737,9 +1737,6 @@ pub struct Span {
     /// Optional extra information to be sent with the span.
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub data: Map<String, Value>,
-    /// Optionally HTTP request data to be sent along.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub request: Option<Request>,
 }
 
 impl Default for Span {
@@ -1756,7 +1753,6 @@ impl Default for Span {
             same_process_as_parent: Default::default(),
             op: Default::default(),
             data: Default::default(),
-            request: Default::default(),
         }
     }
 }

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -15,7 +15,7 @@ use std::ops;
 use std::str;
 use std::time::SystemTime;
 
-use ::debugid::{CodeId, DebugId};
+use self::debugid::{CodeId, DebugId};
 use serde::Serializer;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -1737,6 +1737,9 @@ pub struct Span {
     /// Optional extra information to be sent with the span.
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub data: Map<String, Value>,
+    /// Optionally HTTP request data to be sent along.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request: Option<Request>,
 }
 
 impl Default for Span {
@@ -1753,6 +1756,7 @@ impl Default for Span {
             same_process_as_parent: Default::default(),
             op: Default::default(),
             data: Default::default(),
+            request: Default::default(),
         }
     }
 }
@@ -1942,6 +1946,9 @@ pub struct Transaction<'a> {
     /// Optional contexts.
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub contexts: Map<String, Context>,
+    /// Optionally HTTP request data to be sent along.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request: Option<Request>,
 }
 
 impl<'a> Default for Transaction<'a> {
@@ -1959,6 +1966,7 @@ impl<'a> Default for Transaction<'a> {
             start_timestamp: SystemTime::now(),
             spans: Default::default(),
             contexts: Default::default(),
+            request: Default::default(),
         }
     }
 }
@@ -1984,6 +1992,7 @@ impl<'a> Transaction<'a> {
             start_timestamp: self.start_timestamp,
             spans: self.spans,
             contexts: self.contexts,
+            request: self.request,
         }
     }
 

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -1,6 +1,8 @@
 use std::thread;
 use std::time::Duration;
 
+use sentry::protocol::Request;
+
 // cargo run --example performance-demo
 fn main() {
     let _sentry = sentry::init(sentry::ClientOptions {
@@ -12,6 +14,12 @@ fn main() {
 
     let transaction =
         sentry::start_transaction(sentry::TransactionContext::new("transaction", "root span"));
+    let tx_request = Request {
+        url: Some("https://honk.beep".parse().unwrap()),
+        method: Some("GET".to_string()),
+        ..Request::default()
+    };
+    transaction.set_request(tx_request);
     sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
 
     main_span1();
@@ -76,6 +84,12 @@ where
             sentry::start_transaction(ctx).into()
         }
     };
+    let span_request = Request {
+        url: Some("https://beep.beep".parse().unwrap()),
+        method: Some("GET".to_string()),
+        ..Request::default()
+    };
+    span1.set_request(span_request);
     sentry::configure_scope(|scope| scope.set_span(Some(span1.clone())));
 
     let rv = f();

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test")]
 
 use log_ as log;
-use sentry::protocol::{Context, Value};
+use sentry::protocol::{Context, Request, Value};
 use tracing_ as tracing;
 use tracing_subscriber::prelude::*;
 
@@ -146,6 +146,13 @@ fn test_set_transaction() {
         || {
             let ctx = sentry::TransactionContext::new("old name", "ye, whatever");
             let trx = sentry::start_transaction(ctx);
+            let request = Request {
+                url: Some("https://honk.beep".parse().unwrap()),
+                method: Some("GET".to_string()),
+                ..Request::default()
+            };
+            trx.set_request(request);
+
             sentry::configure_scope(|scope| scope.set_span(Some(trx.clone().into())));
 
             sentry::configure_scope(|scope| scope.set_transaction(Some("new name")));
@@ -164,4 +171,5 @@ fn test_set_transaction() {
     };
 
     assert_eq!(transaction.name.as_deref().unwrap(), "new name");
+    assert!(transaction.request.is_some());
 }


### PR DESCRIPTION
This allows the request information to be sent with the transaction data, which then means `http.method` etc automatically get populated on the Sentry side. Let me know if you want this to be a different way or if I am missing something. Like I was unsure what to do about `Span` and I'm not sure this is correct but I know it works for Transaction