### PR TITLE
build(backtrace): Update regex to 1.5.5

### DIFF
--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -15,4 +15,4 @@ edition = "2018"
 sentry-core = { version = "0.25.0", path = "../sentry-core" }
 lazy_static = "1.4.0"
 backtrace = "0.3.44"
-regex = "1.3.4"
+regex = "1.5.5"


### PR DESCRIPTION
This fixes a security vulnerability. https://github.com/rust-lang/regex/commit/ae70b41d4f46641dbc45c7a4f87954aea356283e