### PR TITLE
add initial values for functions to the data

### DIFF
--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -162,7 +162,7 @@ where
             return;
         }
 
-        let (description, _data) = extract_span_data(attrs);
+        let (description, data) = extract_span_data(attrs);
         let op = span.name();
 
         // Spans don't always have a description, this ensures our data is not empty,
@@ -184,6 +184,12 @@ where
                 sentry_core::start_transaction(ctx).into()
             }
         };
+        // Add the data from the original span to the sentry span.
+        // This comes from typically the `fields` in `tracing::instrument`.
+        for (key, value) in data {
+            sentry_span.set_data(&key, value);
+        }
+
         sentry_core::configure_scope(|scope| scope.set_span(Some(sentry_span.clone())));
 
         let mut extensions = span.extensions_mut();


### PR DESCRIPTION
this fixes #440 

spans later in the functions were working and showing up in the UI but not the original set of values passed to the function.