### PR TITLE
fix: Do not panic on invalid Proxy

### DIFF
--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -46,10 +46,14 @@ impl CurlHttpTransport {
 
             match (scheme, &http_proxy, &https_proxy) {
                 (Scheme::Https, _, &Some(ref proxy)) => {
-                    handle.proxy(proxy).unwrap();
+                    if let Err(err) = handle.proxy(proxy) {
+                        sentry_debug!("invalid proxy: {:?}", err);
+                    }
                 }
                 (_, &Some(ref proxy), _) => {
-                    handle.proxy(proxy).unwrap();
+                    if let Err(err) = handle.proxy(proxy) {
+                        sentry_debug!("invalid proxy: {:?}", err);
+                    }
                 }
                 _ => {}
             }

--- a/sentry/src/transports/reqwest.rs
+++ b/sentry/src/transports/reqwest.rs
@@ -33,10 +33,24 @@ impl ReqwestHttpTransport {
         let client = client.unwrap_or_else(|| {
             let mut builder = reqwest_::Client::builder();
             if let Some(url) = options.http_proxy.as_ref() {
-                builder = builder.proxy(Proxy::http(url.as_ref()).unwrap());
+                match Proxy::http(url.as_ref()) {
+                    Ok(proxy) => {
+                        builder = builder.proxy(proxy);
+                    }
+                    Err(err) => {
+                        sentry_debug!("invalid proxy: {:?}", err);
+                    }
+                }
             };
             if let Some(url) = options.https_proxy.as_ref() {
-                builder = builder.proxy(Proxy::https(url.as_ref()).unwrap());
+                match Proxy::https(url.as_ref()) {
+                    Ok(proxy) => {
+                        builder = builder.proxy(proxy);
+                    }
+                    Err(err) => {
+                        sentry_debug!("invalid proxy: {:?}", err);
+                    }
+                }
             };
             builder.build().unwrap()
         });

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -36,12 +36,22 @@ impl UreqHttpTransport {
             let mut builder = AgentBuilder::new();
 
             match (scheme, &options.http_proxy, &options.https_proxy) {
-                (Scheme::Https, _, &Some(ref proxy)) => {
-                    builder = builder.proxy(Proxy::new(proxy).unwrap());
-                }
-                (_, &Some(ref proxy), _) => {
-                    builder = builder.proxy(Proxy::new(proxy).unwrap());
-                }
+                (Scheme::Https, _, &Some(ref proxy)) => match Proxy::new(proxy) {
+                    Ok(proxy) => {
+                        builder = builder.proxy(proxy);
+                    }
+                    Err(err) => {
+                        sentry_debug!("invalid proxy: {:?}", err);
+                    }
+                },
+                (_, &Some(ref proxy), _) => match Proxy::new(proxy) {
+                    Ok(proxy) => {
+                        builder = builder.proxy(proxy);
+                    }
+                    Err(err) => {
+                        sentry_debug!("invalid proxy: {:?}", err);
+                    }
+                },
                 _ => {}
             }
 

--- a/sentry/tests/test_client.rs
+++ b/sentry/tests/test_client.rs
@@ -71,3 +71,11 @@ fn test_concurrent_init() {
     .join()
     .unwrap();
 }
+
+#[test]
+fn test_invalid_proxy() {
+    let _guard = sentry::init(sentry::ClientOptions {
+        https_proxy: Some("".into()),
+        ..Default::default()
+    });
+}


### PR DESCRIPTION
Interestingly, the `surf` transport does not support proxy settings at all.

fixes #447 and fixes #448 