### PR TITLE
feat(contexts): Report macOS version instead of Darwin kernel version

### DIFF
--- a/sentry-contexts/src/utils.rs
+++ b/sentry-contexts/src/utils.rs
@@ -119,15 +119,31 @@ pub fn os_context() -> Option<Context> {
     {
         use uname::uname;
         if let Ok(info) = uname() {
-            Some(
-                OsContext {
-                    name: Some(info.sysname),
-                    kernel_version: Some(info.version),
-                    version: Some(info.release),
-                    ..Default::default()
-                }
-                .into(),
-            )
+            #[cfg(target_os = "macos")]
+            {
+                Some(
+                    OsContext {
+                        name: Some("macOS".into()),
+                        kernel_version: Some(info.version),
+                        version: model_support::get_macos_version(),
+                        build: model_support::get_macos_build(),
+                        ..Default::default()
+                    }
+                    .into(),
+                )
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                Some(
+                    OsContext {
+                        name: Some(info.sysname),
+                        kernel_version: Some(info.version),
+                        version: Some(info.release),
+                        ..Default::default()
+                    }
+                    .into(),
+                )
+            }
         } else {
             None
         }

--- a/sentry-contexts/src/utils.rs
+++ b/sentry-contexts/src/utils.rs
@@ -52,6 +52,14 @@ mod model_support {
         sysctlbyname_call("hw.model")
     }
 
+    pub fn get_macos_version() -> Option<String> {
+        sysctlbyname_call("kern.osproductversion")
+    }
+
+    pub fn get_macos_build() -> Option<String> {
+        sysctlbyname_call("kern.osversion")
+    }
+
     pub fn get_family() -> Option<String> {
         get_model().map(|mut s| {
             let len = s
@@ -71,6 +79,14 @@ mod model_support {
         let f = get_family().unwrap();
         assert!(f.chars().all(|c| !c.is_digit(10)));
     }
+
+    #[test]
+    fn test_macos_version_and_build() {
+        let v = get_macos_version().unwrap();
+        assert!(v.chars().all(|c| c.is_digit(10) || c == '.'));
+        let b = get_macos_build().unwrap();
+        assert!(b.chars().all(|c| c.is_ascii_alphabetic() || c.is_digit(10)));
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -80,6 +96,14 @@ mod model_support {
     }
 
     pub fn get_family() -> Option<String> {
+        None
+    }
+
+    pub fn get_macos_version() -> Option<String> {
+        None
+    }
+
+    pub fn get_macos_build() -> Option<String> {
         None
     }
 }


### PR DESCRIPTION
In line with the other Sentry SDKs, the Rust SDK should report the macOS name ("macOS" instead of "Darwin"), version, and build. This PR uses the [approach](https://github.com/getsentry/sentry-native/blob/9eecb1bdf2c7762ba7babe9ea437545a1f759bdc/src/sentry_os.c#L130-L151) from `sentry-native` by calling `sysctlbyname` with`kern.osproductversion` and `kern.osversion`.

Closes #449 