### PR TITLE
fix: Handle #[instrument(err)] by extracting the error message

### DIFF
--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -26,6 +26,9 @@ fn extract_event_data(event: &tracing_core::Event) -> (Option<String>, FieldVisi
     let message = visitor
         .json_values
         .remove("message")
+        // When #[instrument(err)] is used the event does not have a message attached to it.
+        // the error message is attached to the field "error".
+        .or_else(|| visitor.json_values.remove("error"))
         .and_then(|v| v.as_str().map(|s| s.to_owned()));
 
     (message, visitor)


### PR DESCRIPTION
When using `#[tracing::instrument(err)]` to emit error events when the wrapped function returns an error. Sentry logs show the event as an "unlabled event" 

![image](https://user-images.githubusercontent.com/6581079/161176501-ec23b062-9d42-401a-908a-6847200dc499.png)

This PR extracts the error message as a string when the message cannot be found.
