### PR TITLE
Take advantage of weak features in Rust 1.60 for TLS enablement

### DIFF
--- a/sentry-contexts/src/utils.rs
+++ b/sentry-contexts/src/utils.rs
@@ -197,10 +197,10 @@ pub fn device_context() -> Context {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     #[cfg(windows)]
     #[test]
     fn windows_os_version_not_empty() {
+        use super::*;
         let context = os_context();
         match context {
             Some(Context::Os(os_context)) => {

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -24,13 +24,13 @@ default = []
 client = ["rand"]
 # I would love to just have a `log` feature, but this is used inside a macro,
 # and macros actually expand features (and extern crate) where they are used!
-debug-logs = ["log_"]
+debug-logs = ["dep:log"]
 test = ["client"]
 profiling = ["pprof", "build_id", "uuid", "sys-info", "findshlibs", "rustc_version_runtime", "libc", "indexmap"]
 frame-pointer = ["pprof?/frame-pointer"]
 
 [dependencies]
-log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
+log = { version = "0.4.8", optional = true, features = ["std"] }
 once_cell = "1"
 rand = { version = "0.8.1", optional = true }
 sentry-types = { version = "0.27.0", path = "../sentry-types" }

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -56,7 +56,7 @@ macro_rules! with_client_impl {
 macro_rules! sentry_debug {
     ($($arg:tt)*) => {
         #[cfg(feature = "debug-logs")] {
-            ::log_::debug!(target: "sentry", $($arg)*);
+            ::log::debug!(target: "sentry", $($arg)*);
         }
         #[cfg(not(feature = "debug-logs"))] {
             $crate::Hub::with(|hub| {

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2021"
 rust-version = "1.60"
 
 [features]
-http = ["http_", "pin-project", "url"]
+http = ["dep:http", "pin-project", "url"]
 
 [dependencies]
 tower-layer = "0.3"
 tower-service = "0.3"
-http_ = { package = "http", version = "0.2.6", optional = true }
+http = { version = "0.2.6", optional = true }
 pin-project = { version = "1.0.10", optional = true }
 sentry-core = { version = "0.27.0", path = "../sentry-core", default-features = false, features = ["client"] }
 url = { version = "2.2.2", optional = true }

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use http_::{header, uri, Request, Response, StatusCode};
+use http::{header, uri, Request, Response, StatusCode};
 use sentry_core::protocol;
 use tower_layer::Layer;
 use tower_service::Service;

--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -121,7 +121,7 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "http")] {
-//! # type Request = http_::Request<String>;
+//! # type Request = http::Request<String>;
 //! let layer = tower::ServiceBuilder::new()
 //!     .layer(sentry_tower::NewSentryLayer::<Request>::new_from_top())
 //!     .layer(sentry_tower::SentryHttpLayer::with_transaction());
@@ -145,7 +145,7 @@ use tower_service::Service;
 #[cfg(feature = "http")]
 mod http;
 #[cfg(feature = "http")]
-pub use http::*;
+pub use crate::http::*;
 
 /// Provides a hub for each request
 pub trait HubProvider<H, Request>

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -39,17 +39,17 @@ profiling = ["sentry-core/profiling"]
 frame-pointer = ["sentry-core/frame-pointer"]
 # other features
 test = ["sentry-core/test"]
-debug-logs = ["log_", "sentry-core/debug-logs"]
+debug-logs = ["dep:log", "sentry-core/debug-logs"]
 # transports
 transport = ["reqwest", "native-tls"]
-reqwest = ["reqwest_", "httpdate", "tokio"]
-curl = ["curl_", "httpdate"]
-surf-h1 = ["surf_/h1-client", "httpdate"]
-surf = ["surf_/curl-client", "http-client", "httpdate", "isahc", "tokio"]
-native-tls = ["reqwest_/default-tls", "native-tls_", "ureq-native-tls"]
-rustls = ["reqwest_/rustls-tls", "rustls_", "webpki-roots"]
-ureq = ["ureq_/tls", "httpdate", "rustls_", "webpki-roots"]
-ureq-native-tls = ["ureq_/native-tls", "httpdate", "native-tls_"]
+reqwest = ["dep:reqwest", "httpdate", "tokio"]
+curl = ["dep:curl", "httpdate"]
+surf-h1 = ["surf/h1-client", "httpdate"]
+surf = ["surf/curl-client", "http-client", "httpdate", "isahc", "tokio"]
+ureq = ["dep:ureq", "httpdate"]
+# transport settings
+native-tls = ["dep:native-tls", "reqwest?/default-tls", "ureq?/native-tls"]
+rustls =     ["dep:rustls",     "reqwest?/rustls-tls",  "ureq?/tls",        "webpki-roots"]
 
 [dependencies]
 sentry-core = { version = "0.27.0", path = "../sentry-core", features = ["client"] }
@@ -62,18 +62,18 @@ sentry-panic = { version = "0.27.0", path = "../sentry-panic", optional = true }
 sentry-slog = { version = "0.27.0", path = "../sentry-slog", optional = true }
 sentry-tower = { version = "0.27.0", path = "../sentry-tower", optional = true }
 sentry-tracing = { version = "0.27.0", path = "../sentry-tracing", optional = true }
-log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
-reqwest_ = { package = "reqwest", version = "0.11", optional = true, features = ["blocking", "json"], default-features = false }
-curl_ = { package = "curl", version = "0.4.25", optional = true }
+log = { version = "0.4.8", optional = true, features = ["std"] }
+reqwest = { version = "0.11", optional = true, features = ["blocking", "json"], default-features = false }
+curl = { version = "0.4.25", optional = true }
 httpdate = { version = "1.0.0", optional = true }
-surf_ = { package = "surf", version = "2.0.0", optional = true, default-features = false }
+surf = { version = "2.0.0", optional = true, default-features = false }
 http-client = { version = "6.5.3", optional = true }
 isahc = { version = "0.9.14", optional = true }
 serde_json = { version = "1.0.48", optional = true }
 tokio = { version = "1.0", features = ["rt"], optional = true }
-ureq_ = { package = "ureq", version = "2.3.0", optional = true, default-features = false }
-native-tls_ = { package = "native-tls", version = "0.2.8", optional = true }
-rustls_ = { package = "rustls", version = "0.20.6", optional = true, features = ["dangerous_configuration"] }
+ureq = { version = "2.3.0", optional = true, default-features = false }
+native-tls = { version = "0.2.8", optional = true }
+rustls = { version = "0.20.6", optional = true, features = ["dangerous_configuration"] }
 webpki-roots = { version = "0.22.5", optional = true }
 
 [dev-dependencies]
@@ -83,11 +83,11 @@ sentry-slog = { path = "../sentry-slog" }
 sentry-tower = { path = "../sentry-tower" }
 sentry-tracing = { path = "../sentry-tracing" }
 actix-web = { version = "4", default-features = false }
-anyhow_ = { package = "anyhow", version = "1.0.30" }
-log_ = { package = "log", version = "0.4.8", features = ["std"] }
+anyhow = { version = "1.0.30" }
+log = { version = "0.4.8", features = ["std"] }
 pretty_env_logger = "0.4.0"
-slog_ = { package = "slog", version = "2.5.2" }
+slog = {version = "2.5.2" }
 tokio = { version = "1.0", features = ["macros"] }
-tower_ = { package = "tower", version = "0.4", features = ["util"] }
-tracing_ = { package = "tracing", version = "0.1" }
+tower = { version = "0.4", features = ["util"] }
+tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt", "tracing-log"] }

--- a/sentry/examples/anyhow-demo.rs
+++ b/sentry/examples/anyhow-demo.rs
@@ -1,5 +1,3 @@
-use anyhow_ as anyhow;
-
 fn execute() -> anyhow::Result<usize> {
     let parsed = "NaN".parse()?;
     Ok(parsed)

--- a/sentry/examples/log-demo.rs
+++ b/sentry/examples/log-demo.rs
@@ -1,5 +1,4 @@
 use log::{debug, error, info, warn};
-use log_ as log;
 
 fn main() {
     init_log();

--- a/sentry/examples/thread-demo.rs
+++ b/sentry/examples/thread-demo.rs
@@ -1,4 +1,3 @@
-use log_ as log;
 use std::sync::Arc;
 use std::thread;
 

--- a/sentry/examples/tracing-demo.rs
+++ b/sentry/examples/tracing-demo.rs
@@ -1,7 +1,6 @@
 use std::thread;
 use std::time::Duration;
 
-use tracing_ as tracing;
 use tracing_subscriber::prelude::*;
 
 // cargo run --example tracing-demo

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -1,7 +1,7 @@
 use std::io::{Cursor, Read};
 use std::time::Duration;
 
-use curl_::{self as curl, easy::Easy as CurlClient};
+use curl::easy::Easy as CurlClient;
 
 use super::thread::TransportThread;
 

--- a/sentry/src/transports/mod.rs
+++ b/sentry/src/transports/mod.rs
@@ -16,22 +16,22 @@ mod tokio_thread;
 #[cfg(feature = "reqwest")]
 mod reqwest;
 #[cfg(feature = "reqwest")]
-pub use reqwest::ReqwestHttpTransport;
+pub use self::reqwest::ReqwestHttpTransport;
 
 #[cfg(feature = "curl")]
 mod curl;
 #[cfg(feature = "curl")]
-pub use curl::CurlHttpTransport;
+pub use self::curl::CurlHttpTransport;
 
 #[cfg(feature = "surf")]
 mod surf;
 #[cfg(feature = "surf")]
-pub use surf::SurfHttpTransport;
+pub use self::surf::SurfHttpTransport;
 
 #[cfg(feature = "ureq")]
 mod ureq;
 #[cfg(feature = "ureq")]
-pub use ureq::UreqHttpTransport;
+pub use self::ureq::UreqHttpTransport;
 
 #[cfg(feature = "reqwest")]
 type DefaultTransport = ReqwestHttpTransport;

--- a/sentry/src/transports/reqwest.rs
+++ b/sentry/src/transports/reqwest.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use reqwest_::{header as ReqwestHeaders, Client as ReqwestClient, Proxy, StatusCode};
+use reqwest::{header as ReqwestHeaders, Client as ReqwestClient, Proxy, StatusCode};
 
 use super::tokio_thread::TransportThread;
 
@@ -11,8 +11,6 @@ use crate::{sentry_debug, ClientOptions, Envelope, Transport};
 /// When the `transport` feature is enabled this will currently
 /// be the default transport.  This is separately enabled by the
 /// `reqwest` feature flag.
-///
-/// [`reqwest`]: reqwest_
 #[cfg_attr(doc_cfg, doc(cfg(feature = "reqwest")))]
 pub struct ReqwestHttpTransport {
     thread: TransportThread,
@@ -31,7 +29,7 @@ impl ReqwestHttpTransport {
 
     fn new_internal(options: &ClientOptions, client: Option<ReqwestClient>) -> Self {
         let client = client.unwrap_or_else(|| {
-            let mut builder = reqwest_::Client::builder();
+            let mut builder = reqwest::Client::builder();
             if options.accept_invalid_certs {
                 builder = builder.danger_accept_invalid_certs(true);
             }

--- a/sentry/src/transports/surf.rs
+++ b/sentry/src/transports/surf.rs
@@ -4,7 +4,7 @@ use isahc::{
     config::{Configurable, SslOption},
     HttpClient,
 };
-use surf_::{http::headers as SurfHeaders, Client as SurfClient, StatusCode};
+use surf::{http::headers as SurfHeaders, Client as SurfClient, StatusCode};
 
 use super::tokio_thread::TransportThread;
 

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -4,15 +4,13 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 #[cfg(feature = "native-tls")]
-use native_tls_::TlsConnector;
+use native_tls::TlsConnector;
 #[cfg(feature = "rustls")]
-use rustls_::{
+use rustls::{
     client::{ServerCertVerified, ServerCertVerifier},
     Certificate, ClientConfig, Error, OwnedTrustAnchor, RootCertStore, ServerName,
 };
-#[cfg(doc)]
-use ureq_ as ureq;
-use ureq_::{Agent, AgentBuilder, Proxy};
+use ureq::{Agent, AgentBuilder, Proxy};
 #[cfg(feature = "rustls")]
 use webpki_roots::TLS_SERVER_ROOTS;
 

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -143,8 +143,6 @@ fn test_reentrant_configure_scope() {
 
 #[test]
 fn test_attached_stacktrace() {
-    use log_ as log;
-
     let logger = sentry_log::SentryLogger::new();
 
     log::set_boxed_logger(Box::new(logger))

--- a/sentry/tests/test_log.rs
+++ b/sentry/tests/test_log.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "test")]
 
-use log_ as log;
-use slog_ as slog;
-
 #[test]
 fn test_log() {
     let logger = sentry_log::SentryLogger::new();

--- a/sentry/tests/test_tower.rs
+++ b/sentry/tests/test_tower.rs
@@ -8,7 +8,7 @@ use sentry::{
     ClientOptions, Hub,
 };
 use sentry_tower::SentryLayer;
-use tower_::{ServiceBuilder, ServiceExt};
+use tower::{ServiceBuilder, ServiceExt};
 
 #[test]
 fn test_tower_hub() {

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test")]
 
-use log_ as log;
 use sentry::protocol::{Context, Request, Value};
-use tracing_ as tracing;
 use tracing_subscriber::prelude::*;
 
 #[test]


### PR DESCRIPTION
Previously it was impossible to have a unified feature named `rustls` or `native-tls` that would turn on the respective TLS backend in the chosen transport (`reqwest` or `ureq`) as a feature of `<crate>/tls` would implicitly turn on `<crate>`.  Since Rust 1.60 it is now possible to specify this crate-feature enablement through the use of the question mark in `<crate>?/tls`, which will only enable the `tls` feature if `<crate>` was enabled through other means (another feature).

Secondly we can now also let optional crates have the same name as a feature, and use `dep:<crate>` to refer to the crate instead of the dependency, making for a more pleasant experience without renames to underscore suffixes.

---

Filing this as draft just to get the word out and discuss this for a bit, as it will only be mergeable in 6 months in accordance with the MSRV policy.  It goes without saying that this is a breaking change.

Also note that I haven't renamed other optional crates like `anyhow_`, `log_` etc yet, until this is accepted as a (future) solution.
