### PR TITLE
feat: Implement Envelope::from_path and Envelope::from_slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
-## 0.27.0
+## Unreleased
 
 **Breaking Changes**:
 
 - The minium supported Rust version was bumped to **1.57.0** due to requirements from dependencies. ([#472](https://github.com/getsentry/sentry-rust/pull/472))
 - Add the `rust-version` field to the manifest. ([#473](https://github.com/getsentry/sentry-rust/pull/473))
 - Update to edition 2021. ([#473](https://github.com/getsentry/sentry-rust/pull/473))
+
+**Features**:
+
+- feat: Implement `Envelope::from_path` and `Envelope::from_slice`. ([#456](https://github.com/getsentry/sentry-rust/pull/456))
 
 ## 0.26.0
 

--- a/sentry-types/src/protocol/attachment.rs
+++ b/sentry-types/src/protocol/attachment.rs
@@ -1,20 +1,27 @@
 use std::fmt;
 
+use serde::Deserialize;
+
 /// The different types an attachment can have.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize)]
 pub enum AttachmentType {
+    #[serde(rename = "event.attachment")]
     /// (default) A standard attachment without special meaning.
     Attachment,
     /// A minidump file that creates an error event and is symbolicated. The
     /// file should start with the `MDMP` magic bytes.
+    #[serde(rename = "event.minidump")]
     Minidump,
     /// An Apple crash report file that creates an error event and is symbolicated.
+    #[serde(rename = "event.applecrashreport")]
     AppleCrashReport,
     /// An XML file containing UE4 crash meta data. During event ingestion,
     /// event contexts and extra fields are extracted from this file.
+    #[serde(rename = "unreal.context")]
     UnrealContext,
     /// A plain-text log file obtained from UE4 crashes. During event ingestion,
     /// the last logs are extracted into event breadcrumbs.
+    #[serde(rename = "unreal.logs")]
     UnrealLogs,
 }
 


### PR DESCRIPTION
The implementation is highly inspired by https://github.com/getsentry/relay/blob/master/relay-server/src/envelope.rs and it includes most its deserialization tests.

We do not handle unknown item types for now, as it would require significant changes in how serializing works and how we store the envelopes. Thus we decided to skip it, for now, to support only item types that `sentry-rust` implements and enhance this feature in the future.

This will be enough to unblock https://github.com/getsentry/sentry-cli/issues/703 anywya.
Closes https://github.com/getsentry/sentry-rust/issues/381