### PR TITLE
Fix sentry-tower URL generation

### DIFF
--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -12,7 +12,7 @@ Sentry integration for tower-based crates.
 edition = "2018"
 
 [features]
-http = ["http_", "pin-project"]
+http = ["http_", "pin-project", "url"]
 
 [dependencies]
 tower-layer = "0.3"
@@ -20,6 +20,7 @@ tower-service = "0.3"
 http_ = { package = "http", version = "0.2.6", optional = true }
 pin-project = { version = "1.0.10", optional = true }
 sentry-core = { version = "0.25.0", path = "../sentry-core", default-features = false, features = ["client"] }
+url = { version = "2.2.2", optional = true }
 
 [dev-dependencies]
 anyhow = "1"

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -1,8 +1,9 @@
+use std::convert::TryInto;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use http_::{header, Request, Response, StatusCode};
+use http_::{header, uri, Request, Response, StatusCode};
 use sentry_core::protocol;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -188,11 +189,13 @@ fn map_status(status: StatusCode) -> protocol::SpanStatus {
 }
 
 fn get_url_from_request<B>(request: &Request<B>) -> Option<url::Url> {
-    format!(
-        "http://{}{}",
-        request.headers().get(header::HOST)?.to_str().ok()?,
-        request.uri()
-    )
-    .parse()
-    .ok()
+    let uri = request.uri().clone();
+    let mut uri_parts = uri.into_parts();
+    uri_parts.scheme.get_or_insert(uri::Scheme::HTTP);
+    if uri_parts.authority.is_none() {
+        let host = request.headers().get(header::HOST)?.as_bytes();
+        uri_parts.authority = Some(host.try_into().ok()?);
+    }
+    let uri = uri::Uri::from_parts(uri_parts).ok()?;
+    uri.to_string().parse().ok()
 }


### PR DESCRIPTION
`request.uri()` may contains only relative URI (e.g. `/foo/bar`), but `Url::parse` requires full URL with base (e.g. `http://localhost/foo/bar`). So `request.uri().to_string().parse()` can fail.

This PR adds a fixed `http://` scheme if the scheme does not exist and a host from the `host` header if the authority does not exist before parsing the URL.

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
