### PR TITLE
fix: Add items missing from Scope debug impl

### DIFF
--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -62,6 +62,8 @@ impl fmt::Debug for Scope {
             .field("contexts", &self.contexts)
             .field("event_processors", &self.event_processors.len())
             .field("session", &self.session)
+            .field("span", &self.span)
+            .field("attachments", &self.attachments.len())
             .finish()
     }
 }


### PR DESCRIPTION
Noticed these were missing after #466 