### PR TITLE
feat: Add scope listener API

### DIFF
--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -427,17 +427,14 @@ impl Hub {
                 if let Some(ref client) = top.client {
                     let scope = Arc::make_mut(&mut top.scope);
                     let options = client.options();
-                    let breadcrumbs = Arc::make_mut(&mut scope.breadcrumbs);
                     for breadcrumb in breadcrumb.into_breadcrumbs() {
                         let breadcrumb_opt = match options.before_breadcrumb {
                             Some(ref callback) => callback(breadcrumb),
                             None => Some(breadcrumb)
                         };
+
                         if let Some(breadcrumb) = breadcrumb_opt {
-                            breadcrumbs.push_back(breadcrumb);
-                        }
-                        while breadcrumbs.len() > options.max_breadcrumbs {
-                            breadcrumbs.pop_front();
+                           scope.add_breadcrumb(breadcrumb, options.max_breadcrumbs);
                         }
                     }
                 }


### PR DESCRIPTION
I've been [messing around](https://github.com/timfish/sentry-rust-minidump) with the `minidumper` and `crash-handler` crates and now I seem to have minidumps being captured in pure Rust and sent via Sentry Rust.

Minidumps are sent from a separate process for reliability but this means for now they are missing all the scope context from the main app process. Adding a "scope updater listener" API would allow subscribing to scope updates and passing them to the crash reporter process to be included with minidump submissions.

I haven't checked all the SDKs, but in the JavaScript SDK there is an `scope.addScopeListener()` method that lets you subscribe to scope updates. We've made use of this in the Electron SDK to intercept, send and synchronise scope between the multiple processes.

This is in no way a finished PR, more a "is this likely to be accepted" and if so, "am I going in the right direction" PR 😊