### PR TITLE
Replace ancient `lazy_static` crate with `once_cell` or `const` slices

### DIFF
--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -12,7 +12,7 @@ Sentry integration and utilities for dealing with stacktraces.
 edition = "2018"
 
 [dependencies]
-sentry-core = { version = "0.26.0", path = "../sentry-core" }
-lazy_static = "1.4.0"
 backtrace = "0.3.44"
+once_cell = "1"
 regex = "1.5.5"
+sentry-core = { version = "0.26.0", path = "../sentry-core" }

--- a/sentry-backtrace/src/parse.rs
+++ b/sentry-backtrace/src/parse.rs
@@ -1,10 +1,12 @@
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::utils::{demangle_symbol, filename, strip_symbol};
 use crate::{Frame, Stacktrace};
 
-lazy_static::lazy_static! {
-    static ref FRAME_RE: Regex = Regex::new(r#"(?xm)
+static FRAME_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?xm)
         ^
             \s*(?:\d+:)?\s*                      # frame number (missing for inline)
 
@@ -27,8 +29,10 @@ lazy_static::lazy_static! {
                 (?::(?P<colno>\d+))?             # optional source column
             )?
         $
-    "#).unwrap();
-}
+    "#,
+    )
+    .unwrap()
+});
 
 /// Parses a backtrace string into a Sentry `Stacktrace`.
 pub fn parse_stacktrace(bt: &str) -> Option<Stacktrace> {

--- a/sentry-backtrace/src/trim.rs
+++ b/sentry-backtrace/src/trim.rs
@@ -2,31 +2,29 @@ use sentry_core::protocol::{Frame, Stacktrace};
 
 use crate::utils::function_starts_with;
 
-lazy_static::lazy_static! {
-    static ref WELL_KNOWN_SYS_MODULES: Vec<&'static str> = vec![
-        "std::",
-        "core::",
-        "alloc::",
-        "backtrace::",
-        "sentry::",
-        "sentry_core::",
-        "sentry_types::",
-        // these are not modules but things like __rust_maybe_catch_panic
-        "__rust_",
-        "___rust_",
-        // these are well-known library frames
-        "anyhow::",
-        "log::",
-    ];
+const WELL_KNOWN_SYS_MODULES: &[&str] = &[
+    "std::",
+    "core::",
+    "alloc::",
+    "backtrace::",
+    "sentry::",
+    "sentry_core::",
+    "sentry_types::",
+    // these are not modules but things like __rust_maybe_catch_panic
+    "__rust_",
+    "___rust_",
+    // these are well-known library frames
+    "anyhow::",
+    "log::",
+];
 
-    static ref WELL_KNOWN_BORDER_FRAMES: Vec<&'static str> = vec![
-        "std::panicking::begin_panic",
-        "core::panicking::panic",
-        // well-known library frames
-        "anyhow::",
-        "<sentry_log::Logger as log::Log>::log",
-    ];
-}
+const WELL_KNOWN_BORDER_FRAMES: &[&str] = &[
+    "std::panicking::begin_panic",
+    "core::panicking::panic",
+    // well-known library frames
+    "anyhow::",
+    "<sentry_log::Logger as log::Log>::log",
+];
 
 /// A helper function to trim a stacktrace.
 pub fn trim_stacktrace<F>(stacktrace: &mut Stacktrace, f: F)

--- a/sentry-backtrace/src/utils.rs
+++ b/sentry-backtrace/src/utils.rs
@@ -1,25 +1,39 @@
+use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 
-lazy_static::lazy_static! {
-    static ref HASH_FUNC_RE: Regex = Regex::new(r#"(?x)
+static HASH_FUNC_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?x)
         ^(.*)::h[a-f0-9]{16}$
-    "#).unwrap();
+    "#,
+    )
+    .unwrap()
+});
 
-    static ref CRATE_RE: Regex = Regex::new(r#"(?x)
+static CRATE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?x)
         ^
         (?:_?<)?           # trait impl syntax
         (?:\w+\ as \ )?    # anonymous implementor
         ([a-zA-Z0-9_]+?)   # crate name
         (?:\.\.|::)        # crate delimiter (.. or ::)
-    "#).unwrap();
+    "#,
+    )
+    .unwrap()
+});
 
-    static ref COMMON_RUST_SYMBOL_ESCAPES_RE: Regex = Regex::new(r#"(?x)
+static COMMON_RUST_SYMBOL_ESCAPES_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?x)
         \$
             (SP|BP|RF|LT|GT|LP|RP|C|
                 u7e|u20|u27|u5b|u5d|u7b|u7d|u3b|u2b|u22)
         \$
-    "#).unwrap();
-}
+    "#,
+    )
+    .unwrap()
+});
 
 /// Tries to parse the rust crate from a function name.
 pub fn parse_crate_name(func_name: &str) -> Option<String> {

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -27,12 +27,12 @@ debug-logs = ["log_"]
 test = ["client"]
 
 [dependencies]
+log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
+once_cell = "1"
+rand = { version = "0.8.1", optional = true }
 sentry-types = { version = "0.26.0", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
-lazy_static = "1.4.0"
-rand = { version = "0.8.1", optional = true }
 serde_json = "1.0.46"
-log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
 
 [dev-dependencies]
 # Because we re-export all the public API in `sentry`, we actually run all the

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -233,7 +233,7 @@ impl Default for ClientOptions {
             session_mode: SessionMode::Application,
             extra_border_frames: vec![],
             trim_backtraces: true,
-            user_agent: Cow::Borrowed(&USER_AGENT),
+            user_agent: Cow::Borrowed(USER_AGENT),
         }
     }
 }

--- a/sentry-core/src/constants.rs
+++ b/sentry-core/src/constants.rs
@@ -1,17 +1,20 @@
+// Not all constants are used when building without the "client" feature
+#![allow(dead_code)]
+
+use once_cell::sync::Lazy;
+
 use crate::protocol::{ClientSdkInfo, ClientSdkPackage};
 
 /// The version of the library
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const USER_AGENT: &str = concat!("sentry.rust/", env!("CARGO_PKG_VERSION"));
 
-lazy_static::lazy_static! {
-    pub static ref USER_AGENT: String = format!("sentry.rust/{}", VERSION);
-    pub static ref SDK_INFO: ClientSdkInfo = ClientSdkInfo {
-        name: "sentry.rust".into(),
+pub(crate) static SDK_INFO: Lazy<ClientSdkInfo> = Lazy::new(|| ClientSdkInfo {
+    name: "sentry.rust".into(),
+    version: VERSION.into(),
+    packages: vec![ClientSdkPackage {
+        name: "cargo:sentry".into(),
         version: VERSION.into(),
-        packages: vec![ClientSdkPackage {
-            name: "cargo:sentry".into(),
-            version: VERSION.into(),
-        }],
-        integrations: vec![],
-    };
-}
+    }],
+    integrations: vec![],
+});

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -8,6 +8,9 @@ use std::sync::{Arc, Mutex, PoisonError, RwLock, TryLockError};
 use std::thread;
 use std::time::Duration;
 
+#[cfg(feature = "client")]
+use once_cell::sync::Lazy;
+
 use crate::protocol::{Breadcrumb, Event, Level, SessionStatus};
 use crate::types::Uuid;
 use crate::{event_from_error, Integration, IntoBreadcrumbs, Scope, ScopeGuard};
@@ -15,12 +18,12 @@ use crate::{event_from_error, Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 use crate::{scope::Stack, session::Session, Client, Envelope};
 
 #[cfg(feature = "client")]
-lazy_static::lazy_static! {
-    static ref PROCESS_HUB: (Arc<Hub>, thread::ThreadId) = (
+static PROCESS_HUB: Lazy<(Arc<Hub>, thread::ThreadId)> = Lazy::new(|| {
+    (
         Arc::new(Hub::new(None, Arc::new(Default::default()))),
-        thread::current().id()
-    );
-}
+        thread::current().id(),
+    )
+});
 
 #[cfg(feature = "client")]
 thread_local! {

--- a/sentry-core/src/test.rs
+++ b/sentry-core/src/test.rs
@@ -21,13 +21,13 @@
 
 use std::sync::{Arc, Mutex};
 
+use once_cell::sync::Lazy;
+
 use crate::protocol::Event;
 use crate::types::Dsn;
 use crate::{ClientOptions, Envelope, Hub, Transport};
 
-lazy_static::lazy_static! {
-    static ref TEST_DSN: Dsn = "https://public@sentry.invalid/1".parse().unwrap();
-}
+static TEST_DSN: Lazy<Dsn> = Lazy::new(|| "https://public@sentry.invalid/1".parse().unwrap());
 
 /// Collects events instead of sending them.
 ///

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -12,6 +12,6 @@ Sentry integration that adds the list of loaded libraries to events.
 edition = "2018"
 
 [dependencies]
-sentry-core = { version = "0.26.0", path = "../sentry-core" }
-lazy_static = "1.4.0"
 findshlibs = "=0.10.2"
+once_cell = "1"
+sentry-core = { version = "0.26.0", path = "../sentry-core" }

--- a/sentry-debug-images/src/integration.rs
+++ b/sentry-debug-images/src/integration.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use once_cell::sync::Lazy;
 use sentry_core::protocol::{DebugMeta, Event};
 use sentry_core::{ClientOptions, Integration};
 
@@ -55,12 +56,10 @@ impl Integration for DebugImagesIntegration {
         mut event: Event<'static>,
         _opts: &ClientOptions,
     ) -> Option<Event<'static>> {
-        lazy_static::lazy_static! {
-            static ref DEBUG_META: DebugMeta = DebugMeta {
-                images: crate::debug_images(),
-                ..Default::default()
-            };
-        }
+        static DEBUG_META: Lazy<DebugMeta> = Lazy::new(|| DebugMeta {
+            images: crate::debug_images(),
+            ..Default::default()
+        });
 
         if event.debug_meta.is_empty() && (self.filter)(&event) {
             event.debug_meta = Cow::Borrowed(&DEBUG_META);


### PR DESCRIPTION
Piggybacking on the [motivation in winit]: `lazy_static!` is a macro whereas `once_cell` achieves the same using generics.  Its implementation has also been [proposed for inclusion in `std`], making it easier to switch to a standardized version if/when that happens.  The author of that winit PR is making this change to many more crates, slowly turning the scales in favour of `once_cell` in most dependency trees.  Furthermore `lazy_static` hasn't published any updates for 3 years.

See also [the `once_cell` F.A.Q.].

In addition "constant" `Vec`tor allocations don't need to be wrapped in a `lazy_static!` macro call at all but can be replaced with true `const` slices (or `const` sized arrays, but those are slightly more tedious to construct).

[motivation in winit]: https://github.com/rust-windowing/winit/pull/2313
[proposed for inclusion in `std`]: https://github.com/rust-lang/rust/issues/74465
[the `once_cell` F.A.Q.]: https://docs.rs/once_cell/latest/once_cell/#faq
