### PR TITLE
ci: Add rust-version and update edition to 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 **Breaking Changes**:
 
-- The minium supported Rust version was bumped to **1.57.0** due to requirements from dependencies.
+- The minium supported Rust version was bumped to **1.57.0** due to requirements from dependencies. ([#472](https://github.com/getsentry/sentry-rust/pull/472))
+- Add the `rust-version` field to the manifest. ([#473](https://github.com/getsentry/sentry-rust/pull/473))
+- Update to edition 2021. ([#473](https://github.com/getsentry/sentry-rust/pull/473))
 
 ## 0.26.0
 

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry client extension for actix-web 3.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 actix-web = { version = "4", default-features = false }

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration for anyhow.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [features]
 default = ["backtrace"]

--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration and utilities for dealing with stacktraces.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 backtrace = "0.3.44"

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -10,7 +10,8 @@ description = """
 Sentry integration for os, device, and rust contexts.
 """
 build = "build.rs"
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 sentry-core = { version = "0.26.0", path = "../sentry-core" }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Core sentry library used for instrumentation and integration development.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration that adds the list of loaded libraries to events.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 findshlibs = "=0.10.2"

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration for log and env_logger crates.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 sentry-core = { version = "0.26.0", path = "../sentry-core" }

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration for capturing panics.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 sentry-core = { version = "0.26.0", path = "../sentry-core" }

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration for the slog crate.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 sentry-core = { version = "0.26.0", path = "../sentry-core" }

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration for tower-based crates.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [features]
 http = ["http_", "pin-project", "url"]

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry integration for tracing and tracing-subscriber crates.
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 sentry-core = { version = "0.26.0", path = "../sentry-core", features = ["client"] }

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -10,7 +10,8 @@ description = """
 Common reusable types for implementing the sentry.io protocol.
 """
 keywords = ["sentry", "protocol"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://sentry.io/welcome/"
 description = """
 Sentry (getsentry.com) client for rust ;)
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 autoexamples = true
 
 # To build locally:


### PR DESCRIPTION
> Two other interesting things we could do after this MSRV bump:
> Add the rust-version field to the manifest, which was added in 56: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
> As well as update to edition 2021, which was also added in 56 🎉

https://github.com/getsentry/sentry-rust/pull/472#pullrequestreview-1010385880