### PR TITLE
ref(session): Change session update logic to follow the spec

### DIFF
--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -439,8 +439,9 @@ mod tests {
                     sentry::start_session();
                 }
 
-                // this error will be discarded because of the event processor,
-                // but the session will still be updated accordingly.
+                // This error will be discarded because of the event processor,
+                // and session will not be updated.
+                // Only events dropped due to sampling should update the session.
                 let err = "NaN".parse::<usize>().unwrap_err();
                 sentry::capture_error(&err);
             },
@@ -469,11 +470,10 @@ mod tests {
 
             assert_eq!(aggregates[0].distinct_id, None);
             assert_eq!(aggregates[0].exited, 50);
-            assert_eq!(aggregates[1].errored, 1);
 
+            assert_eq!(aggregates[1].errored, 0);
             assert_eq!(aggregates[1].distinct_id, Some("foo-bar".into()));
-            assert_eq!(aggregates[1].exited, 49);
-            assert_eq!(aggregates[1].errored, 1);
+            assert_eq!(aggregates[1].exited, 50);
         } else {
             panic!("expected session");
         }


### PR DESCRIPTION
This changes the ordering of filters applied to the event, as well as when a session update happens. This is done in order to follow our unified spec:

```
### Session update filtering

Events may be dropped by our filtering mechanisms (sample rate, beforeSend, event processors or ignored exception types). Only events dropped due to sampling should update the session despite being dropped as we assume the event was dropped to save quota but would have been something the developer cares about. Events dropped due to other reasons should not update the session as we assume they are more likely to be dropped because the developer chooses to ignore them.

#### Filter order

The python SDK shall serve as a reference here. The order for filtering error events is:
1. Check for ignored exception types (a.k.a `ignore_errors`)
3. Apply scoped `event_processor` (a.k.a `error_processor`)
4. Apply global `event_processor`
2. Apply `before_send`
5. Update the session if an event made it this far
6. Apply sampling rate
```

Closes https://github.com/getsentry/sentry-rust/issues/461