### PR TITLE
feat(profiling): Add support for Profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@
 
 **Thank you**:
 
-Features, fixes and improvements in this release have been contributed by:
-
-- [@viglia](https://github.com/viglia)
 
 ## 0.27.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+**Breaking Changes**:
+
+**Features**:
+
+- Add support for Profiling feature. ([#479](https://github.com/getsentry/sentry-rust/pull/479))
+
+**Internal**:
+
+**Thank you**:
+
+Features, fixes and improvements in this release have been contributed by:
+
+- [@viglia](https://github.com/viglia)
+
 ## 0.27.0
 
 **Breaking Changes**:

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -25,7 +25,8 @@ client = ["rand"]
 # I would love to just have a `log` feature, but this is used inside a macro,
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["log_"]
-test = ["client"]
+test = ["client", "profiling"]
+profiling = ["pprof", "lazy_static", "mut_static", "build_id", "uuid", "sys-info", "findshlibs"]
 
 [dependencies]
 log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }
@@ -33,7 +34,14 @@ once_cell = "1"
 rand = { version = "0.8.1", optional = true }
 sentry-types = { version = "0.27.0", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.46"
+serde_json = { version = "1.0.46" }
+lazy_static = { version = "1.4.0", optional = true }
+mut_static = { version = "5.0.0", optional = true }
+pprof = { version = "0.10.0", optional = true }
+uuid = { version = "1.0.0", features = ["v4", "serde"], optional = true }
+sys-info = { version = "0.9.1", optional = true }
+build_id = { version = "0.2.1", optional = true }
+findshlibs = { version = "=0.10.2", optional = true }
 
 [dev-dependencies]
 # Because we re-export all the public API in `sentry`, we actually run all the

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -25,8 +25,8 @@ client = ["rand"]
 # I would love to just have a `log` feature, but this is used inside a macro,
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["log_"]
-test = ["client", "profiling"]
-profiling = ["pprof", "lazy_static", "mut_static", "build_id", "uuid", "sys-info", "findshlibs"]
+test = ["client"]
+profiling = ["pprof", "build_id", "uuid", "sys-info", "findshlibs"]
 
 [dependencies]
 log_ = { package = "log", version = "0.4.8", optional = true, features = ["std"] }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -35,9 +35,6 @@ rand = { version = "0.8.1", optional = true }
 sentry-types = { version = "0.27.0", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0.46" }
-lazy_static = { version = "1.4.0", optional = true }
-mut_static = { version = "5.0.0", optional = true }
-#pprof = { version = "0.10.0", optional = true }
 uuid = { version = "1.0.0", features = ["v4", "serde"], optional = true }
 sys-info = { version = "0.9.1", optional = true }
 build_id = { version = "0.2.1", optional = true }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -37,11 +37,14 @@ serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0.46" }
 lazy_static = { version = "1.4.0", optional = true }
 mut_static = { version = "5.0.0", optional = true }
-pprof = { version = "0.10.0", optional = true }
+#pprof = { version = "0.10.0", optional = true }
 uuid = { version = "1.0.0", features = ["v4", "serde"], optional = true }
 sys-info = { version = "0.9.1", optional = true }
 build_id = { version = "0.2.1", optional = true }
 findshlibs = { version = "=0.10.2", optional = true }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+pprof = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 # Because we re-export all the public API in `sentry`, we actually run all the

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -215,8 +215,8 @@ impl Client {
             scope.update_session_from_event(&event);
         }
 
-        if !self.sample_should_send() {
-            None
+        if !self.sample_should_send(self.options.sample_rate) {
+            return None;
         } else {
             Some(event)
         }
@@ -338,19 +338,9 @@ impl Client {
         }
     }
 
-    fn sample_should_send(&self) -> bool {
-        let rate = self.options.sample_rate;
-        if rate >= 1.0 {
-            true
-        } else {
-            random::<f32>() <= rate
-        }
-    }
-
     /// Returns a random boolean with a probability defined
-    /// by the [`ClientOptions`]'s `traces_sample_rate`
-    pub fn sample_traces_should_send(&self) -> bool {
-        let rate = self.options.traces_sample_rate;
+    /// by rate
+    pub fn sample_should_send(&self, rate: f32) -> bool {
         if rate >= 1.0 {
             true
         } else {

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -216,7 +216,7 @@ impl Client {
         }
 
         if !self.sample_should_send(self.options.sample_rate) {
-            return None;
+            None
         } else {
             Some(event)
         }

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -74,6 +74,14 @@ pub struct ClientOptions {
     pub sample_rate: f32,
     /// The sample rate for tracing transactions. (0.0 - 1.0, defaults to 0.0)
     pub traces_sample_rate: f32,
+    /// Enables profiling
+    pub enable_profiling: bool,
+    /// The sample rate for profiling a transactions. (0.0 - 1.0, defaults to 0.0)
+    ///
+    /// This is dependent on `traces_sample_rate`. The probability of sending a profile
+    /// is given by `traces_sample_rate * profiles_sample_rate`.
+    /// If a given transaction is not sent, then the profile won't be sent neither.
+    pub profiles_sample_rate: f32,
     /// Maximum number of breadcrumbs. (defaults to 100)
     pub max_breadcrumbs: usize,
     /// Attaches stacktraces to messages.
@@ -183,6 +191,8 @@ impl fmt::Debug for ClientOptions {
             .field("environment", &self.environment)
             .field("sample_rate", &self.sample_rate)
             .field("traces_sample_rate", &self.traces_sample_rate)
+            .field("enable_profiling", &self.enable_profiling)
+            .field("profiles_sample_rate", &self.profiles_sample_rate)
             .field("max_breadcrumbs", &self.max_breadcrumbs)
             .field("attach_stacktrace", &self.attach_stacktrace)
             .field("send_default_pii", &self.send_default_pii)
@@ -215,6 +225,8 @@ impl Default for ClientOptions {
             environment: None,
             sample_rate: 1.0,
             traces_sample_rate: 0.0,
+            enable_profiling: false,
+            profiles_sample_rate: 0.0,
             max_breadcrumbs: 100,
             attach_stacktrace: false,
             send_default_pii: false,

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -92,6 +92,9 @@ pub use crate::client::Client;
 #[cfg(feature = "test")]
 pub mod test;
 
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
+mod profiling;
+
 // public api from other crates
 #[doc(inline)]
 pub use sentry_types as types;

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -1,18 +1,18 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use findshlibs::{SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use lazy_static::lazy_static;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use mut_static::MutStatic;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use sentry_types::{CodeId, DebugId, Uuid};
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use sentry_types::protocol::v7::Profile;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use sentry_types::protocol::v7::{
     DebugImage, DebugMeta, RustFrame, Sample, SampledProfile, SymbolicDebugImage, TraceId,
 };
@@ -25,14 +25,14 @@ use crate::Client;
 #[cfg(feature = "client")]
 const MAX_SPANS: usize = 1_000;
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use build_id;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use sys_info;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use uuid;
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 lazy_static! {
     static ref PROFILER_RUNNING: Mutex<bool> = Mutex::new(false);
     static ref PROFILE_INNER: MutStatic<ProfileInner> = {
@@ -308,10 +308,10 @@ pub(crate) struct TransactionInner {
 }
 
 #[derive(Default)]
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 struct ProfileInner {
     transaction_id: String,
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", not(target_os = "windows")))]
     profiler_guard: Option<pprof::ProfilerGuard<'static>>,
 }
 
@@ -358,7 +358,7 @@ impl Transaction {
         }
         // if the transaction was sampled then a profile, linked to the transaction,
         // might as well be sampled
-        #[cfg(feature = "profiling")]
+        #[cfg(all(feature = "profiling", not(target_os = "windows")))]
         if sampled {
             if let Some(client) = client.as_ref() {
                 let mut profiler_running = PROFILER_RUNNING.lock().unwrap();
@@ -483,10 +483,10 @@ impl Transaction {
                     transaction.environment = opts.environment.clone();
                     transaction.sdk = Some(std::borrow::Cow::Owned(client.sdk_info.clone()));
 
-                    #[cfg(feature = "profiling")]
+                    #[cfg(all(feature = "profiling", not(target_os = "windows")))]
                     let mut profile: Option<Profile> = None;
 
-                    #[cfg(feature = "profiling")]
+                    #[cfg(all(feature = "profiling", not(target_os = "windows")))]
                     if client.options().enable_profiling{
                         let mut profiler_running = PROFILER_RUNNING.lock().unwrap();
                         if *profiler_running {
@@ -517,7 +517,7 @@ impl Transaction {
                     let mut envelope = protocol::Envelope::new();
                     envelope.add_item(transaction);
 
-                    #[cfg(feature = "profiling")]
+                    #[cfg(all(feature = "profiling", not(target_os = "windows")))]
                     if let Some(profile) = profile {
                         envelope.add_item(profile);
                     }
@@ -716,7 +716,7 @@ fn parse_sentry_trace(header: &str) -> Option<SentryTrace> {
 /// are flipped to match the big endian expected by the breakpad processor.
 ///
 /// The `DebugId::appendix` field is always `0` for ELF.
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 fn debug_id_from_build_id(build_id: &[u8]) -> Option<DebugId> {
     const UUID_SIZE: usize = 16;
     let mut data = [0u8; UUID_SIZE];
@@ -736,7 +736,7 @@ fn debug_id_from_build_id(build_id: &[u8]) -> Option<DebugId> {
     Uuid::from_slice(&data).map(DebugId::from_uuid).ok()
 }
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 /// Returns the list of loaded libraries/images.
 pub fn debug_images() -> Vec<DebugImage> {
     let mut images = vec![];
@@ -799,7 +799,7 @@ pub fn debug_images() -> Vec<DebugImage> {
     images
 }
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 fn get_profile_from_report(
     rep: &pprof::UnresolvedReport,
     trace_id: TraceId,

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -26,13 +26,6 @@ use crate::Client;
 const MAX_SPANS: usize = 1_000;
 
 #[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use build_id;
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use sys_info;
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use uuid;
-
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 lazy_static! {
     static ref PROFILER_RUNNING: Mutex<bool> = Mutex::new(false);
     static ref PROFILE_INNER: MutStatic<ProfileInner> = {
@@ -499,7 +492,7 @@ impl Transaction {
                                         profile = Some(get_profile_from_report(
                                             &report,
                                             inner.context.trace_id,
-                                            transaction.event_id.clone(),
+                                            transaction.event_id,
                                             transaction.name.as_ref().unwrap().clone(),
                                         ));
                                     }
@@ -816,7 +809,7 @@ fn get_profile_from_report(
             })
         }
         samples.push(Sample {
-            frames: frames,
+            frames,
             thread_name: String::from_utf8_lossy(&sample.thread_name[0..sample.thread_name_length])
                 .into_owned(),
             thread_id: sample.thread_id,
@@ -852,18 +845,18 @@ fn get_profile_from_report(
         },
         platform: "rust".to_string(),
         architecture: std::env::consts::ARCH.to_string(),
-        trace_id: trace_id,
-        transaction_name: transaction_name,
-        transaction_id: transaction_id,
+        trace_id,
+        transaction_name,
+        transaction_id,
         profile_id: uuid::Uuid::new_v4(),
-        sampled_profile: sampled_profile,
+        sampled_profile,
         os_name: sys_info::os_type().unwrap(),
         os_version: sys_info::os_release().unwrap(),
         version_name: env!("CARGO_PKG_VERSION").to_string(),
         version_code: build_id::get().to_simple().to_string(),
     };
 
-    return profile;
+    profile
 }
 
 impl std::fmt::Display for SentryTrace {

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -421,6 +421,8 @@ impl Transaction {
                     transaction.environment = opts.environment.clone();
                     transaction.sdk = Some(std::borrow::Cow::Owned(client.sdk_info.clone()));
 
+                    // if the profiler is running for the given transaction
+                    // then call finish_profiling to return the profile
                     #[cfg(all(feature = "profiling", not(target_os = "windows")))]
                     let profile = inner.profiler_guard.take().and_then(|profiler_guard| {
                         profiling::finish_profiling(&transaction, profiler_guard, inner.context.trace_id)

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -1,22 +1,13 @@
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 #[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use findshlibs::{SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use lazy_static::lazy_static;
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use mut_static::MutStatic;
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use sentry_types::{CodeId, DebugId, Uuid};
-
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
 use sentry_types::protocol::v7::Profile;
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-use sentry_types::protocol::v7::{
-    DebugImage, DebugMeta, RustFrame, Sample, SampledProfile, SymbolicDebugImage, TraceId,
-};
 
+#[cfg(all(feature = "profiling", not(target_os = "windows")))]
+use crate::profiling;
 use crate::{protocol, Hub};
 
 #[cfg(feature = "client")]
@@ -26,15 +17,7 @@ use crate::Client;
 const MAX_SPANS: usize = 1_000;
 
 #[cfg(all(feature = "profiling", not(target_os = "windows")))]
-lazy_static! {
-    static ref PROFILER_RUNNING: Mutex<bool> = Mutex::new(false);
-    static ref PROFILE_INNER: MutStatic<ProfileInner> = {
-        MutStatic::from(ProfileInner {
-            transaction_id: "".to_string(),
-            profiler_guard: None,
-        })
-    };
-}
+static PROFILER_RUNNING: AtomicBool = AtomicBool::new(false);
 
 // global API:
 
@@ -296,16 +279,10 @@ pub(crate) struct TransactionInner {
     #[cfg(feature = "client")]
     client: Option<Arc<Client>>,
     sampled: bool,
-    context: protocol::TraceContext,
+    pub(crate) context: protocol::TraceContext,
     pub(crate) transaction: Option<protocol::Transaction<'static>>,
-}
-
-#[derive(Default)]
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-struct ProfileInner {
-    transaction_id: String,
     #[cfg(all(feature = "profiling", not(target_os = "windows")))]
-    profiler_guard: Option<pprof::ProfilerGuard<'static>>,
+    pub(crate) profiler_guard: Option<profiling::ProfilerGuard>,
 }
 
 type TransactionArc = Arc<Mutex<TransactionInner>>;
@@ -352,37 +329,11 @@ impl Transaction {
         // if the transaction was sampled then a profile, linked to the transaction,
         // might as well be sampled
         #[cfg(all(feature = "profiling", not(target_os = "windows")))]
+        let mut profiler_guard: Option<profiling::ProfilerGuard> = None;
+        #[cfg(all(feature = "profiling", not(target_os = "windows")))]
         if sampled {
             if let Some(client) = client.as_ref() {
-                let mut profiler_running = PROFILER_RUNNING.lock().unwrap();
-                // if the profile is sampled and currently there is no other profile
-                // being collected
-                if transaction.is_some()
-                    && client.options().enable_profiling
-                    && !*profiler_running
-                    && client.sample_should_send(client.options().profiles_sample_rate)
-                {
-                    let profile_guard_builder = pprof::ProfilerGuardBuilder::default()
-                        .frequency(100)
-                        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
-                        .build();
-
-                    match profile_guard_builder {
-                        Ok(guard_builder) => {
-                            *profiler_running = true;
-                            let mut profile_inner = PROFILE_INNER.write().unwrap();
-                            profile_inner.transaction_id =
-                                transaction.as_ref().unwrap().event_id.clone().to_string();
-                            profile_inner.profiler_guard = Some(guard_builder);
-                        }
-                        Err(err) => {
-                            sentry_debug!(
-                                "could not start the profiler due to the following error: {:?}",
-                                err
-                            );
-                        }
-                    }
-                }
+                profiler_guard = profiling::start_profiling(&PROFILER_RUNNING, client);
             }
         }
 
@@ -392,6 +343,8 @@ impl Transaction {
                 sampled,
                 context,
                 transaction,
+                #[cfg(all(feature = "profiling", not(target_os = "windows")))]
+                profiler_guard,
             })),
         }
     }
@@ -411,6 +364,8 @@ impl Transaction {
                 sampled,
                 context,
                 transaction: None,
+                #[cfg(all(feature = "profiling", not(target_os = "windows")))]
+                profiler_guard: None,
             })),
         }
     }
@@ -478,33 +433,9 @@ impl Transaction {
 
                     #[cfg(all(feature = "profiling", not(target_os = "windows")))]
                     let mut profile: Option<Profile> = None;
-
                     #[cfg(all(feature = "profiling", not(target_os = "windows")))]
                     if client.options().enable_profiling{
-                        let mut profiler_running = PROFILER_RUNNING.lock().unwrap();
-                        if *profiler_running {
-                            let mut profile_inner = PROFILE_INNER.write().unwrap();
-                            // if the transaction that is ending is the same that started the
-                            // profiler, then the profile should be added to the envelope too
-                            if profile_inner.transaction_id == transaction.event_id.to_string() {
-                                match profile_inner.profiler_guard.as_ref().unwrap().report().build_unresolved() {
-                                    Ok(report) => {
-                                        profile = Some(get_profile_from_report(
-                                            &report,
-                                            inner.context.trace_id,
-                                            transaction.event_id,
-                                            transaction.name.as_ref().unwrap().clone(),
-                                        ));
-                                    }
-                                    Err(err) => {
-                                        sentry_debug!("could not build the profile result due to the error: {}", err);
-                                    }
-                                }
-                                // in both cases (Ok or Err), reset profile_inner
-                                *profile_inner = ProfileInner::default();
-                                *profiler_running = false;
-                            }
-                        }
+                        profile = profiling::finish_profiling(&PROFILER_RUNNING, &transaction, &mut inner);
                     }
 
                     let mut envelope = protocol::Envelope::new();
@@ -700,163 +631,6 @@ fn parse_sentry_trace(header: &str) -> Option<SentryTrace> {
     });
 
     Some(SentryTrace(trace_id, parent_span_id, parent_sampled))
-}
-
-/// Converts an ELF object identifier into a `DebugId`.
-///
-/// The identifier data is first truncated or extended to match 16 byte size of
-/// Uuids. If the data is declared in little endian, the first three Uuid fields
-/// are flipped to match the big endian expected by the breakpad processor.
-///
-/// The `DebugId::appendix` field is always `0` for ELF.
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-fn debug_id_from_build_id(build_id: &[u8]) -> Option<DebugId> {
-    const UUID_SIZE: usize = 16;
-    let mut data = [0u8; UUID_SIZE];
-    let len = build_id.len().min(UUID_SIZE);
-    data[0..len].copy_from_slice(&build_id[0..len]);
-
-    #[cfg(target_endian = "little")]
-    {
-        // The ELF file targets a little endian architecture. Convert to
-        // network byte order (big endian) to match the Breakpad processor's
-        // expectations. For big endian object files, this is not needed.
-        data[0..4].reverse(); // uuid field 1
-        data[4..6].reverse(); // uuid field 2
-        data[6..8].reverse(); // uuid field 3
-    }
-
-    Uuid::from_slice(&data).map(DebugId::from_uuid).ok()
-}
-
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-/// Returns the list of loaded libraries/images.
-pub fn debug_images() -> Vec<DebugImage> {
-    let mut images = vec![];
-    if !TARGET_SUPPORTED {
-        return images;
-    }
-
-    //crate:: ::{CodeId, DebugId, Uuid};
-    TargetSharedLibrary::each(|shlib| {
-        let maybe_debug_id = shlib.debug_id().and_then(|id| match id {
-            SharedLibraryId::Uuid(bytes) => Some(DebugId::from_uuid(Uuid::from_bytes(bytes))),
-            SharedLibraryId::GnuBuildId(ref id) => debug_id_from_build_id(id),
-            SharedLibraryId::PdbSignature(guid, age) => DebugId::from_guid_age(&guid, age).ok(),
-            _ => None,
-        });
-
-        let debug_id = match maybe_debug_id {
-            Some(debug_id) => debug_id,
-            None => return,
-        };
-
-        let mut name = shlib.name().to_string_lossy().to_string();
-        if name.is_empty() {
-            name = std::env::current_exe()
-                .map(|x| x.display().to_string())
-                .unwrap_or_else(|_| "<main>".to_string());
-        }
-
-        let code_id = shlib.id().map(|id| CodeId::new(format!("{}", id)));
-        let debug_name = shlib.debug_name().map(|n| n.to_string_lossy().to_string());
-
-        // For windows, the `virtual_memory_bias` actually returns the real
-        // `module_base`, which is the address that sentry uses for symbolication.
-        // Going via the segments means that the `image_addr` would be offset in
-        // a way that symbolication yields wrong results.
-        let (image_addr, image_vmaddr) = if cfg!(windows) {
-            (shlib.virtual_memory_bias().0.into(), 0.into())
-        } else {
-            (
-                shlib.actual_load_addr().0.into(),
-                shlib.stated_load_addr().0.into(),
-            )
-        };
-
-        images.push(
-            SymbolicDebugImage {
-                id: debug_id,
-                name,
-                arch: None,
-                image_addr,
-                image_size: shlib.len() as u64,
-                image_vmaddr,
-                code_id,
-                debug_file: debug_name,
-            }
-            .into(),
-        );
-    });
-
-    images
-}
-
-#[cfg(all(feature = "profiling", not(target_os = "windows")))]
-fn get_profile_from_report(
-    rep: &pprof::UnresolvedReport,
-    trace_id: TraceId,
-    transaction_id: sentry_types::Uuid,
-    transaction_name: String,
-) -> Profile {
-    let mut samples: Vec<Sample> = Vec::new();
-
-    for sample in rep.data.keys() {
-        let mut frames: Vec<RustFrame> = Vec::new();
-        for frame in &sample.frames {
-            frames.push(RustFrame {
-                instruction_addr: format!("{:p}", frame.ip()),
-            })
-        }
-        samples.push(Sample {
-            frames,
-            thread_name: String::from_utf8_lossy(&sample.thread_name[0..sample.thread_name_length])
-                .into_owned(),
-            thread_id: sample.thread_id,
-            nanos_relative_to_start: sample
-                .sample_timestamp
-                .duration_since(rep.timing.start_time)
-                .unwrap()
-                .as_nanos() as u64,
-        });
-    }
-    let sampled_profile = SampledProfile {
-        start_time_nanos: rep
-            .timing
-            .start_time
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as u64,
-        start_time_secs: rep
-            .timing
-            .start_time
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-        duration_nanos: rep.timing.duration.as_nanos() as u64,
-        samples,
-    };
-    use std::time::SystemTime;
-    let profile: Profile = Profile {
-        duration_ns: sampled_profile.duration_nanos,
-        debug_meta: DebugMeta {
-            sdk_info: None,
-            images: debug_images(),
-        },
-        platform: "rust".to_string(),
-        architecture: std::env::consts::ARCH.to_string(),
-        trace_id,
-        transaction_name,
-        transaction_id,
-        profile_id: uuid::Uuid::new_v4(),
-        sampled_profile,
-        os_name: sys_info::os_type().unwrap(),
-        os_version: sys_info::os_release().unwrap(),
-        version_name: env!("CARGO_PKG_VERSION").to_string(),
-        version_code: build_id::get().to_simple().to_string(),
-    };
-
-    profile
 }
 
 impl std::fmt::Display for SentryTrace {

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -1,0 +1,248 @@
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use findshlibs::{SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
+
+use crate::TransactionInner;
+use sentry_types::protocol::v7::Profile;
+use sentry_types::protocol::v7::{
+    DebugImage, DebugMeta, RustFrame, Sample, SampledProfile, SymbolicDebugImage, TraceId,
+    Transaction,
+};
+use sentry_types::{CodeId, DebugId, Uuid};
+
+#[cfg(feature = "client")]
+use crate::Client;
+
+pub(crate) struct ProfilerGuard(pprof::ProfilerGuard<'static>);
+
+impl fmt::Debug for ProfilerGuard {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[ProfilerGuard]")
+    }
+}
+
+pub(crate) fn start_profiling(
+    profiler_running: &AtomicBool,
+    client: &Arc<Client>,
+) -> Option<ProfilerGuard> {
+    // if profiling is not enabled or the profile was not sampled
+    // return None immediately
+    if !client.options().enable_profiling
+        || !client.sample_should_send(client.options().profiles_sample_rate)
+    {
+        return None;
+    }
+
+    // if no other profile is being collected, then
+    // start the profiler
+    if let Ok(false) =
+        profiler_running.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+    {
+        let profile_guard_builder = pprof::ProfilerGuardBuilder::default()
+            .frequency(100)
+            .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+            .build();
+
+        match profile_guard_builder {
+            Ok(guard_builder) => return Some(ProfilerGuard(guard_builder)),
+            Err(err) => {
+                sentry_debug!(
+                    "could not start the profiler due to the following error: {:?}",
+                    err
+                );
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn finish_profiling(
+    profiler_running: &AtomicBool,
+    transaction: &Transaction,
+    transaction_inner: &mut TransactionInner,
+) -> Option<Profile> {
+    // if the profiler is running for this transaction,
+    // then stop it and return the profile
+    if let Some(profiler_guard) = transaction_inner.profiler_guard.take() {
+        let mut profile: Option<Profile> = None;
+
+        match profiler_guard.0.report().build_unresolved() {
+            Ok(report) => {
+                profile = Some(get_profile_from_report(
+                    &report,
+                    transaction_inner.context.trace_id,
+                    transaction.event_id,
+                    transaction.name.as_ref().unwrap().clone(),
+                ));
+            }
+            Err(err) => {
+                sentry_debug!(
+                    "could not build the profile result due to the error: {}",
+                    err
+                );
+            }
+        }
+        profiler_running.store(false, Ordering::SeqCst);
+        return profile;
+    }
+    None
+}
+
+/// Converts an ELF object identifier into a `DebugId`.
+///
+/// The identifier data is first truncated or extended to match 16 byte size of
+/// Uuids. If the data is declared in little endian, the first three Uuid fields
+/// are flipped to match the big endian expected by the breakpad processor.
+///
+/// The `DebugId::appendix` field is always `0` for ELF.
+fn debug_id_from_build_id(build_id: &[u8]) -> Option<DebugId> {
+    const UUID_SIZE: usize = 16;
+    let mut data = [0u8; UUID_SIZE];
+    let len = build_id.len().min(UUID_SIZE);
+    data[0..len].copy_from_slice(&build_id[0..len]);
+
+    #[cfg(target_endian = "little")]
+    {
+        // The ELF file targets a little endian architecture. Convert to
+        // network byte order (big endian) to match the Breakpad processor's
+        // expectations. For big endian object files, this is not needed.
+        data[0..4].reverse(); // uuid field 1
+        data[4..6].reverse(); // uuid field 2
+        data[6..8].reverse(); // uuid field 3
+    }
+
+    Uuid::from_slice(&data).map(DebugId::from_uuid).ok()
+}
+
+pub fn debug_images() -> Vec<DebugImage> {
+    let mut images = vec![];
+    if !TARGET_SUPPORTED {
+        return images;
+    }
+
+    //crate:: ::{CodeId, DebugId, Uuid};
+    TargetSharedLibrary::each(|shlib| {
+        let maybe_debug_id = shlib.debug_id().and_then(|id| match id {
+            SharedLibraryId::Uuid(bytes) => Some(DebugId::from_uuid(Uuid::from_bytes(bytes))),
+            SharedLibraryId::GnuBuildId(ref id) => debug_id_from_build_id(id),
+            SharedLibraryId::PdbSignature(guid, age) => DebugId::from_guid_age(&guid, age).ok(),
+            _ => None,
+        });
+
+        let debug_id = match maybe_debug_id {
+            Some(debug_id) => debug_id,
+            None => return,
+        };
+
+        let mut name = shlib.name().to_string_lossy().to_string();
+        if name.is_empty() {
+            name = std::env::current_exe()
+                .map(|x| x.display().to_string())
+                .unwrap_or_else(|_| "<main>".to_string());
+        }
+
+        let code_id = shlib.id().map(|id| CodeId::new(format!("{}", id)));
+        let debug_name = shlib.debug_name().map(|n| n.to_string_lossy().to_string());
+
+        // For windows, the `virtual_memory_bias` actually returns the real
+        // `module_base`, which is the address that sentry uses for symbolication.
+        // Going via the segments means that the `image_addr` would be offset in
+        // a way that symbolication yields wrong results.
+        let (image_addr, image_vmaddr) = if cfg!(windows) {
+            (shlib.virtual_memory_bias().0.into(), 0.into())
+        } else {
+            (
+                shlib.actual_load_addr().0.into(),
+                shlib.stated_load_addr().0.into(),
+            )
+        };
+
+        images.push(
+            SymbolicDebugImage {
+                id: debug_id,
+                name,
+                arch: None,
+                image_addr,
+                image_size: shlib.len() as u64,
+                image_vmaddr,
+                code_id,
+                debug_file: debug_name,
+            }
+            .into(),
+        );
+    });
+
+    images
+}
+
+fn get_profile_from_report(
+    rep: &pprof::UnresolvedReport,
+    trace_id: TraceId,
+    transaction_id: sentry_types::Uuid,
+    transaction_name: String,
+) -> Profile {
+    use std::time::SystemTime;
+
+    let mut samples: Vec<Sample> = Vec::new();
+
+    for sample in rep.data.keys() {
+        let frames = sample
+            .frames
+            .iter()
+            .map(|frame| RustFrame {
+                instruction_addr: format!("{:p}", frame.ip()),
+            })
+            .collect();
+
+        samples.push(Sample {
+            frames,
+            thread_name: String::from_utf8_lossy(&sample.thread_name[0..sample.thread_name_length])
+                .into_owned(),
+            thread_id: sample.thread_id,
+            nanos_relative_to_start: sample
+                .sample_timestamp
+                .duration_since(rep.timing.start_time)
+                .unwrap()
+                .as_nanos() as u64,
+        });
+    }
+    let sampled_profile = SampledProfile {
+        start_time_nanos: rep
+            .timing
+            .start_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64,
+        start_time_secs: rep
+            .timing
+            .start_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        duration_nanos: rep.timing.duration.as_nanos() as u64,
+        samples,
+    };
+
+    let profile: Profile = Profile {
+        duration_ns: sampled_profile.duration_nanos,
+        debug_meta: DebugMeta {
+            sdk_info: None,
+            images: debug_images(),
+        },
+        platform: "rust".to_string(),
+        architecture: Some(std::env::consts::ARCH.to_string()),
+        trace_id,
+        transaction_name,
+        transaction_id,
+        profile_id: uuid::Uuid::new_v4(),
+        sampled_profile,
+        os_name: sys_info::os_type().unwrap(),
+        os_version: sys_info::os_release().unwrap(),
+        version_name: env!("CARGO_PKG_VERSION").to_string(),
+        version_code: build_id::get().to_simple().to_string(),
+    };
+
+    profile
+}

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -294,11 +294,7 @@ impl Envelope {
                     writeln!(writer)?;
                     continue;
                 }
-                EnvelopeItem::Profile(profile) => {
-                    profile.to_writer(&mut writer)?;
-                    writeln!(writer)?;
-                    continue;
-                }
+                EnvelopeItem::Profile(profile) => serde_json::to_writer(&mut item_buf, profile)?,
             }
             let item_type = match item {
                 EnvelopeItem::Event(_) => "event",
@@ -306,7 +302,7 @@ impl Envelope {
                 EnvelopeItem::SessionAggregates(_) => "sessions",
                 EnvelopeItem::Transaction(_) => "transaction",
                 EnvelopeItem::Attachment(_) => unreachable!(),
-                EnvelopeItem::Profile(_) => unreachable!(),
+                EnvelopeItem::Profile(_) => "profile",
             };
             writeln!(
                 writer,

--- a/sentry-types/src/protocol/mod.rs
+++ b/sentry-types/src/protocol/mod.rs
@@ -11,4 +11,5 @@ pub use v7 as latest;
 
 mod attachment;
 mod envelope;
+mod profile;
 mod session;

--- a/sentry-types/src/protocol/profile.rs
+++ b/sentry-types/src/protocol/profile.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use uuid::Uuid;
 
 fn serialize_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
-    serializer.serialize_some(&uuid.as_simple().to_string())
+    serializer.serialize_some(&uuid.as_simple())
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -50,7 +50,8 @@ pub struct Profile {
     pub platform: String,
     /// A string describing the architecture of the CPU that is currently in use
     /// <https://doc.rust-lang.org/std/env/consts/constant.ARCH.html>
-    pub architecture: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
     /// The trace ID
     pub trace_id: TraceId,
     /// The name of the transaction this profile belongs to
@@ -63,8 +64,8 @@ pub struct Profile {
     pub profile_id: Uuid,
     /// Represents the profile collected
     pub sampled_profile: SampledProfile,
-    #[serde(rename = "device_os_name")]
     /// OS name
+    #[serde(rename = "device_os_name")]
     pub os_name: String,
     #[serde(rename = "device_os_version")]
     /// OS version
@@ -85,6 +86,7 @@ struct ProfileItemHeader {
     length: usize,
 }
 
+/*
 impl Profile {
     /// Writes the attachment and its headers to the provided `Writer`.
     pub fn to_writer<W>(&self, writer: &mut W) -> std::io::Result<()>
@@ -108,3 +110,4 @@ impl Profile {
         Ok(())
     }
 }
+*/

--- a/sentry-types/src/protocol/profile.rs
+++ b/sentry-types/src/protocol/profile.rs
@@ -49,7 +49,7 @@ pub struct Profile {
     /// Platform is `rust`
     pub platform: String,
     /// A string describing the architecture of the CPU that is currently in use
-    /// https://doc.rust-lang.org/std/env/consts/constant.ARCH.html
+    /// <https://doc.rust-lang.org/std/env/consts/constant.ARCH.html>
     pub architecture: String,
     /// The trace ID
     pub trace_id: TraceId,
@@ -71,7 +71,7 @@ pub struct Profile {
     pub os_version: String,
     /// Package version
     pub version_name: String,
-    /// Current binary build ID. See https://docs.rs/build_id/latest/build_id/
+    /// Current binary build ID. See <https://docs.rs/build_id/latest/build_id/>
     pub version_code: String,
 }
 

--- a/sentry-types/src/protocol/profile.rs
+++ b/sentry-types/src/protocol/profile.rs
@@ -98,13 +98,13 @@ impl Profile {
             "{}",
             serde_json::to_string(&ProfileItemHeader {
                 content_type: "application/json".to_string(),
-                file_name: format!("{}.trace", self.trace_id).to_string(),
+                file_name: format!("{}.trace", self.trace_id),
                 typez: "profile".to_string(),
                 length: serialized_profile.len(),
             })?
         )?;
 
-        writer.write_all(&serialized_profile.as_bytes())?;
+        writer.write_all(serialized_profile.as_bytes())?;
         Ok(())
     }
 }

--- a/sentry-types/src/protocol/profile.rs
+++ b/sentry-types/src/protocol/profile.rs
@@ -75,39 +75,3 @@ pub struct Profile {
     /// Current binary build ID. See <https://docs.rs/build_id/latest/build_id/>
     pub version_code: String,
 }
-
-#[derive(Debug, Default, Deserialize, Serialize)]
-struct ProfileItemHeader {
-    content_type: String,
-    #[serde(skip_serializing_if = "String::is_empty")]
-    file_name: String,
-    #[serde(rename = "type")]
-    typez: String,
-    length: usize,
-}
-
-/*
-impl Profile {
-    /// Writes the attachment and its headers to the provided `Writer`.
-    pub fn to_writer<W>(&self, writer: &mut W) -> std::io::Result<()>
-    where
-        W: std::io::Write,
-    {
-        let serialized_profile = serde_json::to_string(self).unwrap();
-
-        writeln!(
-            writer,
-            "{}",
-            serde_json::to_string(&ProfileItemHeader {
-                content_type: "application/json".to_string(),
-                file_name: format!("{}.trace", self.trace_id),
-                typez: "profile".to_string(),
-                length: serialized_profile.len(),
-            })?
-        )?;
-
-        writer.write_all(serialized_profile.as_bytes())?;
-        Ok(())
-    }
-}
-*/

--- a/sentry-types/src/protocol/profile.rs
+++ b/sentry-types/src/protocol/profile.rs
@@ -1,0 +1,110 @@
+use super::v7::{DebugMeta, TraceId};
+use serde::{Deserialize, Serialize, Serializer};
+use uuid::Uuid;
+
+fn serialize_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_some(&uuid.as_simple().to_string())
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+/// Represents a Symbol
+pub struct RustFrame {
+    /// Raw instruction address
+    pub instruction_addr: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+/// Represents a Sample
+pub struct Sample {
+    /// List of symbols
+    pub frames: Vec<RustFrame>,
+    /// The thread name
+    pub thread_name: String,
+    /// The thread id
+    pub thread_id: u64,
+    /// Nanoseconds elapsed between when the profiler started and when this sample was collected
+    pub nanos_relative_to_start: u64,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+/// Represents a collected Profile
+pub struct SampledProfile {
+    /// Collection start time in nanoseconds
+    pub start_time_nanos: u64,
+    /// Collection start time in seconds
+    pub start_time_secs: u64,
+    /// Collection duration in nanoseconds
+    pub duration_nanos: u64,
+    /// List of collected samples
+    pub samples: Vec<Sample>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+/// Represents a Profile Envelope ItemType
+pub struct Profile {
+    /// Duration in nanoseconds of the Profile
+    pub duration_ns: u64,
+    /// List of debug images
+    pub debug_meta: DebugMeta,
+    /// Platform is `rust`
+    pub platform: String,
+    /// A string describing the architecture of the CPU that is currently in use
+    /// https://doc.rust-lang.org/std/env/consts/constant.ARCH.html
+    pub architecture: String,
+    /// The trace ID
+    pub trace_id: TraceId,
+    /// The name of the transaction this profile belongs to
+    pub transaction_name: String,
+    #[serde(serialize_with = "serialize_id")]
+    /// The ID of the transaction this profile belongs to
+    pub transaction_id: Uuid,
+    /// The ID of the event
+    #[serde(serialize_with = "serialize_id")]
+    pub profile_id: Uuid,
+    /// Represents the profile collected
+    pub sampled_profile: SampledProfile,
+    #[serde(rename = "device_os_name")]
+    /// OS name
+    pub os_name: String,
+    #[serde(rename = "device_os_version")]
+    /// OS version
+    pub os_version: String,
+    /// Package version
+    pub version_name: String,
+    /// Current binary build ID. See https://docs.rs/build_id/latest/build_id/
+    pub version_code: String,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct ProfileItemHeader {
+    content_type: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    file_name: String,
+    #[serde(rename = "type")]
+    typez: String,
+    length: usize,
+}
+
+impl Profile {
+    /// Writes the attachment and its headers to the provided `Writer`.
+    pub fn to_writer<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: std::io::Write,
+    {
+        let serialized_profile = serde_json::to_string(self).unwrap();
+
+        writeln!(
+            writer,
+            "{}",
+            serde_json::to_string(&ProfileItemHeader {
+                content_type: "application/json".to_string(),
+                file_name: format!("{}.trace", self.trace_id).to_string(),
+                typez: "profile".to_string(),
+                length: serialized_profile.len(),
+            })?
+        )?;
+
+        writer.write_all(&serialized_profile.as_bytes())?;
+        Ok(())
+    }
+}

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -26,6 +26,7 @@ use crate::utils::{ts_rfc3339_opt, ts_seconds_float};
 
 pub use super::attachment::*;
 pub use super::envelope::*;
+pub use super::profile::*;
 pub use super::session::*;
 
 /// An arbitrary (JSON) value.

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -47,6 +47,7 @@ native-tls = ["reqwest_/default-tls"]
 rustls = ["reqwest_/rustls-tls"]
 ureq = ["ureq_/tls", "httpdate"]
 ureq-native-tls = ["ureq_/native-tls", "httpdate"]
+profiling = ["sentry-core/profiling"]
 
 [dependencies]
 sentry-core = { version = "0.27.0", path = "../sentry-core", features = ["client"] }

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -12,6 +12,7 @@ pub struct RateLimiter {
     session: Option<SystemTime>,
     transaction: Option<SystemTime>,
     attachment: Option<SystemTime>,
+    profile: Option<SystemTime>,
 }
 
 impl RateLimiter {
@@ -56,6 +57,7 @@ impl RateLimiter {
                     "session" => self.session = new_time,
                     "transaction" => self.transaction = new_time,
                     "attachment" => self.attachment = new_time,
+                    "profile" => self.profile = new_time,
                     _ => {}
                 }
             }
@@ -89,6 +91,7 @@ impl RateLimiter {
             RateLimitingCategory::Session => self.session,
             RateLimitingCategory::Transaction => self.transaction,
             RateLimitingCategory::Attachment => self.attachment,
+            RateLimitingCategory::Profile => self.profile,
         }?;
         time_left.duration_since(SystemTime::now()).ok()
     }
@@ -112,6 +115,7 @@ impl RateLimiter {
                 }
                 EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
                 EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
+                EnvelopeItem::Profile(_) => RateLimitingCategory::Profile,
                 _ => RateLimitingCategory::Any,
             })
         })
@@ -131,6 +135,8 @@ pub enum RateLimitingCategory {
     Transaction,
     /// Rate Limit pertaining to Attachments.
     Attachment,
+    /// Rate Limit pertaining to Profiles.
+    Profile,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds support for the profiling feature.

For this first iteration we will stick to the design implementation of the mobile profilers (`Android`/`iOS`) with one profile being linked to one transaction.

* adds `enable_profiling` option to enable/disable profiling
* adds `profiles_sample_rate` option to further sample profiles with respect to the transactions. This is dependent on `traces_sample_rate` and the probability of a profile being collected is: `traces_sample_rate * profiles_sample_rate` 
* only one profile at a time can be collected. If the profiler is running, no other profiles will be collected when other transactions start