### PR TITLE
fix(profiling): Add support to use frame-pointer on macos

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -40,8 +40,11 @@ sys-info = { version = "0.9.1", optional = true }
 build_id = { version = "0.2.1", optional = true }
 findshlibs = { version = "=0.10.2", optional = true }
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "macos")))'.dependencies]
 pprof = { version = "0.10.0", optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+pprof = { version = "0.10.0", optional = true, features = ["frame-pointer"]}
 
 [dev-dependencies]
 # Because we re-export all the public API in `sentry`, we actually run all the

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -40,10 +40,10 @@ sys-info = { version = "0.9.1", optional = true }
 build_id = { version = "0.2.1", optional = true }
 findshlibs = { version = "=0.10.2", optional = true }
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "macos")))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(all(target_os = "macos", target_arch = "aarch64"))))'.dependencies]
 pprof = { version = "0.10.0", optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 pprof = { version = "0.10.0", optional = true, features = ["frame-pointer"]}
 
 [dev-dependencies]

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -183,9 +183,9 @@ fn get_profile_from_report(
             .frames
             .iter()
             .map(|frame| RustFrame {
-                #[cfg(target_os = "macos")]
+                #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
                 instruction_addr: format!("{:p}", frame.ip as *mut core::ffi::c_void),
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
                 instruction_addr: format!("{:p}", frame.ip()),
             })
             .collect();

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -183,6 +183,9 @@ fn get_profile_from_report(
             .frames
             .iter()
             .map(|frame| RustFrame {
+                #[cfg(target_os = "macos")]
+                instruction_addr: format!("{:p}", frame.ip as *mut core::ffi::c_void),
+                #[cfg(not(target_os = "macos"))]
                 instruction_addr: format!("{:p}", frame.ip()),
             })
             .collect();


### PR DESCRIPTION
This solves a problem (probably due to unwind) on macos, where the profiler would
yield a `Trace/BPT trap`.

Instead of using the `backtrace` crate, when running on `macos`, using `frame-pointer`
is more recommended to get the backtrace.