### PR TITLE
feat(profiling): Drop the profile when no sample were collected

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -433,7 +433,12 @@ impl Transaction {
 
                     #[cfg(all(feature = "profiling", not(target_os = "windows")))]
                     if let Some(profile) = profile {
-                        envelope.add_item(profile);
+                        if !profile.sampled_profile.samples.is_empty(){
+                            envelope.add_item(profile);
+                        }
+                        else {
+                            sentry_debug!("the profile is being dropped because it contains no samples");
+                        }
                     }
 
                     client.send_envelope(envelope)


### PR DESCRIPTION
This check is already happening in Relay.

The idea is drop it already on the client side in order to avoid waste of resources on Relay.