### PR TITLE
fix(profiling): Temporarily remove the blocklist

### DIFF
--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -39,7 +39,6 @@ pub(crate) fn start_profiling(client: &Client) -> Option<ProfilerGuard> {
     {
         let profile_guard_builder = pprof::ProfilerGuardBuilder::default()
             .frequency(100)
-            .blocklist(&["libc", "libgcc", "pthread", "vdso"])
             .build();
 
         match profile_guard_builder {


### PR DESCRIPTION
Adding pthread is currently causing problems collecting stack traces
on Linux. This commit remove that blocklist to allow us debug this
problem further.

Please, keep this PR on hold. I'm using this to test a different service (Synbolicator)