### PR TITLE
ref: Add a tower-http feature as a shortcut

### DIFF
--- a/sentry-contexts/src/utils.rs
+++ b/sentry-contexts/src/utils.rs
@@ -82,17 +82,19 @@ mod model_support {
         let m = get_model().unwrap();
         assert!(m.chars().all(|c| c != '\0'));
         let f = get_family().unwrap();
-        assert!(f.chars().all(|c| !c.is_digit(10)));
+        assert!(f.chars().all(|c| !c.is_ascii_digit()));
     }
 
     #[test]
     fn test_macos_version_and_build() {
         let v = get_macos_version().unwrap();
-        assert!(v.chars().all(|c| c.is_digit(10) || c == '.'));
+        assert!(v.chars().all(|c| c.is_ascii_digit() || c == '.'));
         let dot_count = v.split('.').count() - 1;
         assert_eq!(dot_count, 2);
         let b = get_macos_build().unwrap();
-        assert!(b.chars().all(|c| c.is_ascii_alphabetic() || c.is_digit(10)));
+        assert!(b
+            .chars()
+            .all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit()));
     }
 }
 

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -31,7 +31,7 @@ pub type BeforeCallback<T> = Arc<dyn Fn(T) -> Option<T> + Send + Sync>;
 ///
 /// See the [Documentation on Session Modes](https://develop.sentry.dev/sdk/sessions/#sdk-considerations)
 /// for more information.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SessionMode {
     /// Long running application session.
     Application,

--- a/sentry-log/src/logger.rs
+++ b/sentry-log/src/logger.rs
@@ -64,6 +64,7 @@ impl log::Log for NoopLogger {
 pub struct SentryLogger<L: log::Log> {
     dest: L,
     filter: Box<dyn Fn(&log::Metadata<'_>) -> LogFilter + Send + Sync>,
+    #[allow(clippy::type_complexity)]
     mapper: Option<Box<dyn Fn(&Record<'_>) -> RecordMapping + Send + Sync>>,
 }
 

--- a/sentry-slog/src/drain.rs
+++ b/sentry-slog/src/drain.rs
@@ -44,6 +44,7 @@ pub fn default_filter(level: slog::Level) -> LevelFilter {
 pub struct SentryDrain<D: Drain> {
     drain: D,
     filter: Box<dyn Fn(slog::Level) -> LevelFilter + Send + Sync>,
+    #[allow(clippy::type_complexity)]
     mapper: Option<Box<dyn Fn(&Record, &OwnedKVList) -> RecordMapping + Send + Sync>>,
 }
 

--- a/sentry-types/src/protocol/mod.rs
+++ b/sentry-types/src/protocol/mod.rs
@@ -1,5 +1,9 @@
 //! This module exposes the types for the Sentry protocol in different versions.
 
+// We would like to reserve the possibility to add floating point numbers to
+// protocol types without breaking API (removing Eq) in the future.
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 #[cfg(feature = "protocol")]
 pub mod v7;
 

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -33,7 +33,9 @@ debug-images = ["sentry-debug-images"]
 log = ["sentry-log"]
 slog = ["sentry-slog"]
 tower = ["sentry-tower"]
+tower-http = ["sentry-tower", "sentry-tower/http"]
 tracing = ["sentry-tracing"]
+profiling = ["sentry-core/profiling"]
 # other features
 test = ["sentry-core/test"]
 debug-logs = ["log_", "sentry-core/debug-logs"]
@@ -47,7 +49,6 @@ native-tls = ["reqwest_/default-tls"]
 rustls = ["reqwest_/rustls-tls"]
 ureq = ["ureq_/tls", "httpdate"]
 ureq-native-tls = ["ureq_/native-tls", "httpdate"]
-profiling = ["sentry-core/profiling"]
 
 [dependencies]
 sentry-core = { version = "0.27.0", path = "../sentry-core", features = ["client"] }


### PR DESCRIPTION
The new feature activates the sentry-tower/http feature, as otherwise one would have to
declare sentry-tower separately which can lead to out-of-sync dependency versions.

This also fixes all the new clippy lints as a drive-by change, those should be rather minimal.