### PR TITLE
ref: Add small improvements to bash scripts

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR/..
+cd "$SCRIPT_DIR"/..
 
 OLD_VERSION="${1}"
 NEW_VERSION="${2}"
@@ -13,4 +13,4 @@ echo "Bumping version: ${NEW_VERSION}"
 perl -pi -e "s/^version = \".*?\"/version = \"$NEW_VERSION\"/" sentry*/Cargo.toml
 perl -pi -e "s/^(sentry.*)?version = \".*?\"/\$1version = \"$NEW_VERSION\"/" sentry*/Cargo.toml
 
-$SCRIPT_DIR/update-readme.sh $NEW_VERSION
+"$SCRIPT_DIR"/update-readme.sh "$NEW_VERSION"

--- a/scripts/generate-readme.sh
+++ b/scripts/generate-readme.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 NEW_VERSION="${1}"
-CRATE=$(basename $PWD)
 CRATE_UNDERSCORE=$(echo $CRATE | sed s/-/_/)
+CRATE=$(basename "$PWD")
 
 cargo readme --template ../README.tpl --output README.md
 

--- a/scripts/generate-readme.sh
+++ b/scripts/generate-readme.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 NEW_VERSION="${1}"
-CRATE_UNDERSCORE=$(echo $CRATE | sed s/-/_/)
 CRATE=$(basename "$PWD")
+CRATE_UNDERSCORE="${CRATE//-/_}"
 
 cargo readme --template ../README.tpl --output README.md
 

--- a/scripts/update-readme.sh
+++ b/scripts/update-readme.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR/..
+cd "$SCRIPT_DIR"/..
 
 NEW_VERSION="${1}"
 
-find sentry* -name Cargo.toml -execdir ../scripts/generate-readme.sh $NEW_VERSION \;
+find sentry* -name Cargo.toml -execdir ../scripts/generate-readme.sh "$NEW_VERSION" \;


### PR DESCRIPTION
Mostly just double quotes  for variables to satisfy the shellchek. 
And also remove `echo` and `sed` from [`scripts/generate-readme.sh`](https://github.com/getsentry/sentry-rust/compare/fix/small-improvements-for-shell-scripts?expand=1#diff-a85909ed3be999ca8de0cc440657a41460a29d6054f16a255b612fa53c479254)  - and use only bash substitution syntax. 