### PR TITLE
feat(contexts): Add Windows OS version to OS context

### DIFF
--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -21,6 +21,9 @@ hostname = "0.3.0"
 [target."cfg(not(windows))".dependencies]
 uname = "0.1.1"
 
+[target."cfg(windows)".dependencies]
+os_info = "3.5.0"
+
 [build-dependencies]
 rustc_version = "0.4.0"
 


### PR DESCRIPTION
Add Windows OS version to the `Context::Os` context. A test was also added to verify that the version string we're getting back is non-empty and not equal to the `Version::Unknown` version from the `os_info` crate.

On my windows machine, this will give a version string of `10.0.19044`. Previously, all windows crashes reported had the version reported as `Unknown`.

Fixes #500