### PR TITLE
sentry-core: add traces_sampler client option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Breaking Changes**:
 
 - The minimum supported Rust version was bumped to **1.60.0** due to requirements from dependencies. ([#498](https://github.com/getsentry/sentry-rust/pull/498))
+- Added the `traces_sampler` option to `ClientOptions`. This allows the user to customise sampling rates on a per-transaction basis. ([#510](https://github.com/getsentry/sentry-rust/pull/510))
 
 **Features**:
 

--- a/sentry-contexts/src/utils.rs
+++ b/sentry-contexts/src/utils.rs
@@ -26,7 +26,7 @@ mod model_support {
                 return None;
             }
 
-            let mut buf = vec![0u8; size as usize];
+            let mut buf = vec![0u8; size];
             let res = libc::sysctlbyname(
                 c_name.as_ptr() as _,
                 buf.as_mut_ptr() as *mut c_void,

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -42,12 +42,12 @@ pub(crate) struct HubImpl {
 impl HubImpl {
     pub(crate) fn with<F: FnOnce(&Stack) -> R, R>(&self, f: F) -> R {
         let guard = self.stack.read().unwrap_or_else(PoisonError::into_inner);
-        f(&*guard)
+        f(&guard)
     }
 
     fn with_mut<F: FnOnce(&mut Stack) -> R, R>(&self, f: F) -> R {
         let mut guard = self.stack.write().unwrap_or_else(PoisonError::into_inner);
-        f(&mut *guard)
+        f(&mut guard)
     }
 
     fn is_active_and_usage_safe(&self) -> bool {

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -310,10 +310,7 @@ impl Client {
     fn is_transaction_sampled(&self, ctx: &TransactionContext) -> bool {
         let client_options = self.options();
         self.sample_should_send(transaction_sample_rate(
-            client_options
-                .traces_sampler
-                .as_ref()
-                .map(|sampler| &**sampler),
+            client_options.traces_sampler.as_deref(),
             ctx,
             client_options.traces_sample_rate,
         ))

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -241,7 +241,7 @@ fn get_profile_from_report(
         timestamp: rep.timing.start_time,
         transactions: vec![TransactionMetadata {
             id: transaction.event_id,
-            name: transaction.name.clone().unwrap_or_else(|| "".to_string()),
+            name: transaction.name.clone().unwrap_or_default(),
             trace_id,
             relative_start_ns: 0,
             relative_end_ns: transaction

--- a/sentry-panic/src/lib.rs
+++ b/sentry-panic/src/lib.rs
@@ -77,7 +77,7 @@ impl Integration for PanicIntegration {
 /// Extract the message of a panic.
 pub fn message_from_panic_info<'a>(info: &'a PanicInfo<'_>) -> &'a str {
     match info.payload().downcast_ref::<&'static str>() {
-        Some(s) => *s,
+        Some(s) => s,
         None => match info.payload().downcast_ref::<String>() {
             Some(s) => &s[..],
             None => "Box<Any>",

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -388,7 +388,7 @@ impl Envelope {
         let payload_start = std::cmp::min(header_end + 1, slice.len());
         let payload_end = match header.length {
             Some(len) => {
-                let payload_end = payload_start + len as usize;
+                let payload_end = payload_start + len;
                 if slice.len() < payload_end {
                     return Err(EnvelopeError::UnexpectedEof);
                 }

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1360,7 +1360,7 @@ impl Default for SpanId {
 
 impl fmt::Display for SpanId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", hex::encode(&self.0))
+        write!(fmt, "{}", hex::encode(self.0))
     }
 }
 
@@ -1406,7 +1406,7 @@ impl Default for TraceId {
 
 impl fmt::Display for TraceId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", hex::encode(&self.0))
+        write!(fmt, "{}", hex::encode(self.0))
     }
 }
 

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -31,7 +31,7 @@ impl CurlHttpTransport {
         let http_proxy = options.http_proxy.as_ref().map(ToString::to_string);
         let https_proxy = options.https_proxy.as_ref().map(ToString::to_string);
         let dsn = options.dsn.as_ref().unwrap();
-        let user_agent = options.user_agent.to_owned();
+        let user_agent = options.user_agent.clone();
         let auth = dsn.to_auth(Some(&user_agent)).to_string();
         let url = dsn.envelope_api_url().to_string();
         let scheme = dsn.scheme();

--- a/sentry/src/transports/reqwest.rs
+++ b/sentry/src/transports/reqwest.rs
@@ -56,7 +56,7 @@ impl ReqwestHttpTransport {
             builder.build().unwrap()
         });
         let dsn = options.dsn.as_ref().unwrap();
-        let user_agent = options.user_agent.to_owned();
+        let user_agent = options.user_agent.clone();
         let auth = dsn.to_auth(Some(&user_agent)).to_string();
         let url = dsn.envelope_api_url().to_string();
 

--- a/sentry/src/transports/surf.rs
+++ b/sentry/src/transports/surf.rs
@@ -43,7 +43,7 @@ impl SurfHttpTransport {
         }
 
         let dsn = options.dsn.as_ref().unwrap();
-        let user_agent = options.user_agent.to_owned();
+        let user_agent = options.user_agent.clone();
         let auth = dsn.to_auth(Some(&user_agent)).to_string();
         let url = dsn.envelope_api_url().to_string();
 

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -112,7 +112,7 @@ impl UreqHttpTransport {
 
             builder.build()
         });
-        let user_agent = options.user_agent.to_owned();
+        let user_agent = options.user_agent.clone();
         let auth = dsn.to_auth(Some(&user_agent)).to_string();
         let url = dsn.envelope_api_url().to_string();
 

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -106,7 +106,7 @@ fn test_tracing() {
 
 #[tracing::instrument(fields(span_field))]
 fn function() {
-    tracing::Span::current().record("span_field", &"some data");
+    tracing::Span::current().record("span_field", "some data");
 }
 
 #[test]


### PR DESCRIPTION
This PR adds the `traces_sampler` option to `ClientOptions`, and respects it when making transaction sampling decisions as detailed in the SDK guidelines: https://develop.sentry.dev/sdk/performance/#sdk-configuration

There was some prior work on this topic in https://github.com/getsentry/sentry-rust/pull/288, however by now it's pretty stale so I started fresh.

Points for review:
- To implement `Debug` for this option I just print the function's memory address (if set); I can't think of something simple that would have more value to the user. [link](https://doc.rust-lang.org/std/ptr/macro.addr_of.html)
- If accepted, I would like to update the official docs with the new option, could someone point me in the right direction for that?
- Adding a new field to `ClientOptions` is a breaking change - I presume this necessitates a minor version bump for release?