### PR TITLE
sentry-core: add public getters for TransactionContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**
+
+- Allow `traces_sampler` to inspect well known properties of `TransactionContext` ([#514](https://github.com/getsentry/sentry-rust/pull/514))
+
 ## 0.28.0
 
 **Breaking Changes**:

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -154,6 +154,21 @@ impl TransactionContext {
     pub fn set_sampled(&mut self, sampled: impl Into<Option<bool>>) {
         self.sampled = sampled.into();
     }
+
+    /// Get the sampling decision for this Transaction.
+    pub fn sampled(&self) -> Option<bool> {
+        self.sampled
+    }
+
+    /// Get the name of this Transaction.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the operation of this Transaction.
+    pub fn operation(&self) -> &str {
+        &self.op
+    }
 }
 
 /// A function to be run for each new transaction, to determine the rate at which
@@ -716,6 +731,17 @@ mod tests {
         assert_eq!(parsed.2, Some(true));
     }
 
+    #[test]
+    fn transaction_context_public_getters() {
+        let mut ctx = TransactionContext::new("test-name", "test-operation");
+        assert_eq!(ctx.name(), "test-name");
+        assert_eq!(ctx.operation(), "test-operation");
+        assert_eq!(ctx.sampled(), None);
+
+        ctx.set_sampled(true);
+        assert_eq!(ctx.sampled(), Some(true));
+    }
+
     #[cfg(feature = "client")]
     #[test]
     fn compute_transaction_sample_rate() {
@@ -737,7 +763,7 @@ mod tests {
         ctx.set_sampled(false);
         assert_eq!(transaction_sample_rate(Some(&|_| { 0.7 }), &ctx, 0.3), 0.7);
         // But the sampler may choose to inspect parent sampling
-        let sampler = |ctx: &TransactionContext| match ctx.sampled {
+        let sampler = |ctx: &TransactionContext| match ctx.sampled() {
             Some(true) => 0.8,
             Some(false) => 0.4,
             None => 0.6,

--- a/sentry/tests/test_client.rs
+++ b/sentry/tests/test_client.rs
@@ -18,6 +18,9 @@ fn test_into_client() {
         "https://public@example.com/42%21",
         sentry::ClientOptions {
             release: Some("foo@1.0".into()),
+            traces_sampler: Some(Arc::new(
+                |ctx| if ctx.name().is_empty() { 0.0 } else { 1.0 },
+            )),
             ..Default::default()
         },
     ));


### PR DESCRIPTION
Split from #512, to enable support for `traces_sampler` inspecting first class properties of `TransactionContext`.

This was split as we though the addition of `CustomTransactionContext` may require further discussion, while these changes should be uncontroversial.

ref: https://github.com/getsentry/sentry-rust/pull/512#issuecomment-1304747662