### PR TITLE
sentry-core: update pprof dependency to version 0.11.0

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -44,7 +44,7 @@ rustc_version_runtime = { version = "0.2.1", optional = true }
 indexmap = { version = "1.9.1", optional = true}
 
 [target.'cfg(target_family = "unix")'.dependencies]
-pprof = { version = "0.10.1", optional = true, default-features = false}
+pprof = { version = "0.11.0", optional = true, default-features = false}
 libc = { version = "^0.2.66", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This new version of `pprof-rs` introduces some important fixes among which one that let us run profiling on unix without frame-pointers (using libunwind) seamlessly.