### PR TITLE
ref: Move HubImpl to its own file

### DIFF
--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -1,68 +1,9 @@
-#![allow(unused)]
+use std::sync::{Arc, Mutex, RwLock};
 
-use std::cell::{Cell, UnsafeCell};
-use std::error::Error;
-use std::mem::drop;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, PoisonError, RwLock, TryLockError};
-use std::thread;
-use std::time::Duration;
-
-#[cfg(feature = "client")]
-use once_cell::sync::Lazy;
-
-use crate::protocol::{Breadcrumb, Event, Level, SessionStatus};
+use crate::protocol::{Event, Level, SessionStatus};
+use crate::session::Session;
 use crate::types::Uuid;
-use crate::{event_from_error, Integration, IntoBreadcrumbs, Scope, ScopeGuard};
-#[cfg(feature = "client")]
-use crate::{scope::Stack, session::Session, Client, Envelope};
-
-#[cfg(feature = "client")]
-static PROCESS_HUB: Lazy<(Arc<Hub>, thread::ThreadId)> = Lazy::new(|| {
-    (
-        Arc::new(Hub::new(None, Arc::new(Default::default()))),
-        thread::current().id(),
-    )
-});
-
-#[cfg(feature = "client")]
-thread_local! {
-    static THREAD_HUB: UnsafeCell<Arc<Hub>> = UnsafeCell::new(
-        Arc::new(Hub::new_from_top(&PROCESS_HUB.0)));
-    static USE_PROCESS_HUB: Cell<bool> = Cell::new(PROCESS_HUB.1 == thread::current().id());
-}
-
-#[cfg(feature = "client")]
-#[derive(Debug)]
-pub(crate) struct HubImpl {
-    stack: Arc<RwLock<Stack>>,
-}
-
-#[cfg(feature = "client")]
-impl HubImpl {
-    pub(crate) fn with<F: FnOnce(&Stack) -> R, R>(&self, f: F) -> R {
-        let guard = self.stack.read().unwrap_or_else(PoisonError::into_inner);
-        f(&guard)
-    }
-
-    fn with_mut<F: FnOnce(&mut Stack) -> R, R>(&self, f: F) -> R {
-        let mut guard = self.stack.write().unwrap_or_else(PoisonError::into_inner);
-        f(&mut guard)
-    }
-
-    fn is_active_and_usage_safe(&self) -> bool {
-        let guard = match self.stack.read() {
-            Err(err) => err.into_inner(),
-            Ok(guard) => guard,
-        };
-
-        guard
-            .top()
-            .client
-            .as_ref()
-            .map_or(false, |c| c.is_enabled())
-    }
-}
+use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 
 /// The central object that can manages scopes and clients.
 ///
@@ -94,81 +35,11 @@ impl HubImpl {
 #[derive(Debug)]
 pub struct Hub {
     #[cfg(feature = "client")]
-    pub(crate) inner: HubImpl,
-    last_event_id: RwLock<Option<Uuid>>,
+    pub(crate) inner: crate::hub_impl::HubImpl,
+    pub(crate) last_event_id: RwLock<Option<Uuid>>,
 }
 
 impl Hub {
-    /// Creates a new hub from the given client and scope.
-    #[cfg(feature = "client")]
-    pub fn new(client: Option<Arc<Client>>, scope: Arc<Scope>) -> Hub {
-        Hub {
-            inner: HubImpl {
-                stack: Arc::new(RwLock::new(Stack::from_client_and_scope(client, scope))),
-            },
-            last_event_id: RwLock::new(None),
-        }
-    }
-
-    /// Creates a new hub based on the top scope of the given hub.
-    #[cfg(feature = "client")]
-    pub fn new_from_top<H: AsRef<Hub>>(other: H) -> Hub {
-        let hub = other.as_ref();
-        hub.inner.with(|stack| {
-            let top = stack.top();
-            Hub::new(top.client.clone(), top.scope.clone())
-        })
-    }
-
-    /// Returns the current, thread-local hub.
-    ///
-    /// Invoking this will return the current thread-local hub.  The first
-    /// time it is called on a thread, a new thread-local hub will be
-    /// created based on the topmost scope of the hub on the main thread as
-    /// returned by [`Hub::main`].  If the main thread did not yet have a
-    /// hub it will be created when invoking this function.
-    ///
-    /// To have control over which hub is installed as the current
-    /// thread-local hub, use [`Hub::run`].
-    ///
-    /// This method is unavailable if the client implementation is disabled.
-    /// When using the minimal API set use [`Hub::with_active`] instead.
-    #[cfg(feature = "client")]
-    pub fn current() -> Arc<Hub> {
-        Hub::with(Arc::clone)
-    }
-
-    /// Returns the main thread's hub.
-    ///
-    /// This is similar to [`Hub::current`] but instead of picking the
-    /// current thread's hub it returns the main thread's hub instead.
-    #[cfg(feature = "client")]
-    pub fn main() -> Arc<Hub> {
-        PROCESS_HUB.0.clone()
-    }
-
-    /// Invokes the callback with the default hub.
-    ///
-    /// This is a slightly more efficient version than [`Hub::current`] and
-    /// also unavailable in minimal mode.
-    #[cfg(feature = "client")]
-    pub fn with<F, R>(f: F) -> R
-    where
-        F: FnOnce(&Arc<Hub>) -> R,
-    {
-        if USE_PROCESS_HUB.with(Cell::get) {
-            f(&PROCESS_HUB.0)
-        } else {
-            // note on safety: this is safe because even though we change the Arc
-            // by temporary binding we guarantee that the original Arc stays alive.
-            // For more information see: run
-            THREAD_HUB.with(|stack| unsafe {
-                let ptr = stack.get();
-                f(&*ptr)
-            })
-        }
-    }
-
     /// Like [`Hub::with`] but only calls the function if a client is bound.
     ///
     /// This is useful for integrations that want to do efficiently nothing if there is no
@@ -188,59 +59,6 @@ impl Hub {
                 }
             })
         }}
-    }
-
-    /// Binds a hub to the current thread for the duration of the call.
-    ///
-    /// During the execution of `f` the given hub will be installed as the
-    /// thread-local hub.  So any call to [`Hub::current`] during this time
-    /// will return the provided hub.
-    ///
-    /// Once the function is finished executing, including after it
-    /// paniced, the original hub is re-installed if one was present.
-    #[cfg(feature = "client")]
-    pub fn run<F: FnOnce() -> R, R>(hub: Arc<Hub>, f: F) -> R {
-        let mut restore_process_hub = false;
-        let did_switch = THREAD_HUB.with(|ctx| unsafe {
-            let ptr = ctx.get();
-            if std::ptr::eq(&**ptr, &*hub) {
-                None
-            } else {
-                USE_PROCESS_HUB.with(|x| {
-                    if x.get() {
-                        restore_process_hub = true;
-                        x.set(false);
-                    }
-                });
-                let old = (*ptr).clone();
-                *ptr = hub.clone();
-                Some(old)
-            }
-        });
-
-        match did_switch {
-            None => {
-                // None means no switch happened.  We can invoke the function
-                // just like that, no changes necessary.
-                f()
-            }
-            Some(old_hub) => {
-                use std::panic;
-
-                // this is for the case where we just switched the hub.  This
-                // means we need to catch the panic, restore the
-                // old context and resume the panic if needed.
-                let rv = panic::catch_unwind(panic::AssertUnwindSafe(f));
-                THREAD_HUB.with(|ctx| unsafe { *ctx.get() = old_hub });
-                if restore_process_hub {
-                    USE_PROCESS_HUB.with(|x| x.set(true));
-                }
-                match rv {
-                    Err(err) => panic::resume_unwind(err),
-                    Ok(rv) => rv,
-                }
-            }
-        }
     }
 
     /// Looks up an integration on the hub.
@@ -298,34 +116,13 @@ impl Hub {
     /// for more documentation.
     pub fn capture_message(&self, msg: &str, level: Level) -> Uuid {
         with_client_impl! {{
-            self.inner.with(|stack| {
-                let top = stack.top();
-                if let Some(ref client) = top.client {
-                    let mut event = Event {
-                        message: Some(msg.to_string()),
-                        level,
-                        ..Default::default()
-                    };
-                    self.capture_event(event)
-                } else {
-                    Uuid::nil()
-                }
-            })
+            let event = Event {
+                message: Some(msg.to_string()),
+                level,
+                ..Default::default()
+            };
+            self.capture_event(event)
         }}
-    }
-
-    /// Returns the currently bound client.
-    #[cfg(feature = "client")]
-    pub fn client(&self) -> Option<Arc<Client>> {
-        self.inner.with(|stack| stack.top().client.clone())
-    }
-
-    /// Binds a new client to the hub.
-    #[cfg(feature = "client")]
-    pub fn bind_client(&self, client: Option<Arc<Client>>) {
-        self.inner.with_mut(|stack| {
-            stack.top_mut().client = client;
-        })
     }
 
     /// Start a new session for Release Health.
@@ -447,21 +244,5 @@ impl Hub {
                 }
             })
         }}
-    }
-
-    #[cfg(feature = "client")]
-    pub(crate) fn is_active_and_usage_safe(&self) -> bool {
-        self.inner.is_active_and_usage_safe()
-    }
-
-    #[cfg(feature = "client")]
-    pub(crate) fn with_current_scope<F: FnOnce(&Scope) -> R, R>(&self, f: F) -> R {
-        self.inner.with(|stack| f(&stack.top().scope))
-    }
-
-    #[cfg(feature = "client")]
-    pub(crate) fn with_current_scope_mut<F: FnOnce(&mut Scope) -> R, R>(&self, f: F) -> R {
-        self.inner
-            .with_mut(|stack| f(Arc::make_mut(&mut stack.top_mut().scope)))
     }
 }

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex, RwLock};
 
 use crate::protocol::{Event, Level, SessionStatus};
-use crate::session::Session;
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 
@@ -133,7 +132,7 @@ impl Hub {
         with_client_impl! {{
             self.inner.with_mut(|stack| {
                 let top = stack.top_mut();
-                if let Some(session) = Session::from_stack(top) {
+                if let Some(session) = crate::session::Session::from_stack(top) {
                     // When creating a *new* session, we make sure it is unique,
                     // as to no inherit *backwards* to any parents.
                     let mut scope = Arc::make_mut(&mut top.scope);

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -1,4 +1,8 @@
-use std::sync::{Arc, Mutex, RwLock};
+// NOTE: Most of the methods are noops without the `client` feature, and this will
+// silence all the "unused variable" warnings related to fn arguments.
+#![allow(unused)]
+
+use std::sync::{Arc, RwLock};
 
 use crate::protocol::{Event, Level, SessionStatus};
 use crate::types::Uuid;
@@ -136,7 +140,7 @@ impl Hub {
                     // When creating a *new* session, we make sure it is unique,
                     // as to no inherit *backwards* to any parents.
                     let mut scope = Arc::make_mut(&mut top.scope);
-                    scope.session = Arc::new(Mutex::new(Some(session)));
+                    scope.session = Arc::new(std::sync::Mutex::new(Some(session)));
                 }
             })
         }}

--- a/sentry-core/src/hub_impl.rs
+++ b/sentry-core/src/hub_impl.rs
@@ -1,0 +1,195 @@
+use std::cell::{Cell, UnsafeCell};
+use std::sync::{Arc, PoisonError, RwLock};
+use std::thread;
+
+use crate::Scope;
+use crate::{scope::Stack, Client, Hub};
+
+use once_cell::sync::Lazy;
+
+static PROCESS_HUB: Lazy<(Arc<Hub>, thread::ThreadId)> = Lazy::new(|| {
+    (
+        Arc::new(Hub::new(None, Arc::new(Default::default()))),
+        thread::current().id(),
+    )
+});
+
+thread_local! {
+    static THREAD_HUB: UnsafeCell<Arc<Hub>> = UnsafeCell::new(
+        Arc::new(Hub::new_from_top(&PROCESS_HUB.0)));
+    static USE_PROCESS_HUB: Cell<bool> = Cell::new(PROCESS_HUB.1 == thread::current().id());
+}
+
+#[derive(Debug)]
+pub(crate) struct HubImpl {
+    pub(crate) stack: Arc<RwLock<Stack>>,
+}
+
+impl HubImpl {
+    pub(crate) fn with<F: FnOnce(&Stack) -> R, R>(&self, f: F) -> R {
+        let guard = self.stack.read().unwrap_or_else(PoisonError::into_inner);
+        f(&guard)
+    }
+
+    pub(crate) fn with_mut<F: FnOnce(&mut Stack) -> R, R>(&self, f: F) -> R {
+        let mut guard = self.stack.write().unwrap_or_else(PoisonError::into_inner);
+        f(&mut guard)
+    }
+
+    pub(crate) fn is_active_and_usage_safe(&self) -> bool {
+        let guard = match self.stack.read() {
+            Err(err) => err.into_inner(),
+            Ok(guard) => guard,
+        };
+
+        guard
+            .top()
+            .client
+            .as_ref()
+            .map_or(false, |c| c.is_enabled())
+    }
+}
+
+impl Hub {
+    /// Creates a new hub from the given client and scope.
+    pub fn new(client: Option<Arc<Client>>, scope: Arc<Scope>) -> Hub {
+        Hub {
+            inner: HubImpl {
+                stack: Arc::new(RwLock::new(Stack::from_client_and_scope(client, scope))),
+            },
+            last_event_id: RwLock::new(None),
+        }
+    }
+
+    /// Creates a new hub based on the top scope of the given hub.
+    pub fn new_from_top<H: AsRef<Hub>>(other: H) -> Hub {
+        let hub = other.as_ref();
+        hub.inner.with(|stack| {
+            let top = stack.top();
+            Hub::new(top.client.clone(), top.scope.clone())
+        })
+    }
+
+    /// Returns the current, thread-local hub.
+    ///
+    /// Invoking this will return the current thread-local hub.  The first
+    /// time it is called on a thread, a new thread-local hub will be
+    /// created based on the topmost scope of the hub on the main thread as
+    /// returned by [`Hub::main`].  If the main thread did not yet have a
+    /// hub it will be created when invoking this function.
+    ///
+    /// To have control over which hub is installed as the current
+    /// thread-local hub, use [`Hub::run`].
+    ///
+    /// This method is unavailable if the client implementation is disabled.
+    /// When using the minimal API set use [`Hub::with_active`] instead.
+    pub fn current() -> Arc<Hub> {
+        Hub::with(Arc::clone)
+    }
+
+    /// Returns the main thread's hub.
+    ///
+    /// This is similar to [`Hub::current`] but instead of picking the
+    /// current thread's hub it returns the main thread's hub instead.
+    pub fn main() -> Arc<Hub> {
+        PROCESS_HUB.0.clone()
+    }
+
+    /// Invokes the callback with the default hub.
+    ///
+    /// This is a slightly more efficient version than [`Hub::current`] and
+    /// also unavailable in minimal mode.
+    pub fn with<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Arc<Hub>) -> R,
+    {
+        if USE_PROCESS_HUB.with(Cell::get) {
+            f(&PROCESS_HUB.0)
+        } else {
+            // note on safety: this is safe because even though we change the Arc
+            // by temporary binding we guarantee that the original Arc stays alive.
+            // For more information see: run
+            THREAD_HUB.with(|stack| unsafe {
+                let ptr = stack.get();
+                f(&*ptr)
+            })
+        }
+    }
+
+    /// Binds a hub to the current thread for the duration of the call.
+    ///
+    /// During the execution of `f` the given hub will be installed as the
+    /// thread-local hub.  So any call to [`Hub::current`] during this time
+    /// will return the provided hub.
+    ///
+    /// Once the function is finished executing, including after it
+    /// paniced, the original hub is re-installed if one was present.
+    pub fn run<F: FnOnce() -> R, R>(hub: Arc<Hub>, f: F) -> R {
+        let mut restore_process_hub = false;
+        let did_switch = THREAD_HUB.with(|ctx| unsafe {
+            let ptr = ctx.get();
+            if std::ptr::eq(&**ptr, &*hub) {
+                None
+            } else {
+                USE_PROCESS_HUB.with(|x| {
+                    if x.get() {
+                        restore_process_hub = true;
+                        x.set(false);
+                    }
+                });
+                let old = (*ptr).clone();
+                *ptr = hub.clone();
+                Some(old)
+            }
+        });
+
+        match did_switch {
+            None => {
+                // None means no switch happened.  We can invoke the function
+                // just like that, no changes necessary.
+                f()
+            }
+            Some(old_hub) => {
+                use std::panic;
+
+                // this is for the case where we just switched the hub.  This
+                // means we need to catch the panic, restore the
+                // old context and resume the panic if needed.
+                let rv = panic::catch_unwind(panic::AssertUnwindSafe(f));
+                THREAD_HUB.with(|ctx| unsafe { *ctx.get() = old_hub });
+                if restore_process_hub {
+                    USE_PROCESS_HUB.with(|x| x.set(true));
+                }
+                match rv {
+                    Err(err) => panic::resume_unwind(err),
+                    Ok(rv) => rv,
+                }
+            }
+        }
+    }
+
+    /// Returns the currently bound client.
+    pub fn client(&self) -> Option<Arc<Client>> {
+        self.inner.with(|stack| stack.top().client.clone())
+    }
+
+    /// Binds a new client to the hub.
+    pub fn bind_client(&self, client: Option<Arc<Client>>) {
+        self.inner.with_mut(|stack| {
+            stack.top_mut().client = client;
+        })
+    }
+
+    pub(crate) fn is_active_and_usage_safe(&self) -> bool {
+        self.inner.is_active_and_usage_safe()
+    }
+
+    pub(crate) fn with_current_scope<F: FnOnce(&Scope) -> R, R>(&self, f: F) -> R {
+        self.inner.with(|stack| f(&stack.top().scope))
+    }
+
+    pub(crate) fn with_current_scope_mut<F: FnOnce(&mut Scope) -> R, R>(&self, f: F) -> R {
+        self.inner
+            .with_mut(|stack| f(Arc::make_mut(&mut stack.top_mut().scope)))
+    }
+}

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -140,6 +140,8 @@ pub use crate::transport::{Transport, TransportFactory};
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "client")]
+mod hub_impl;
+#[cfg(feature = "client")]
 mod session;
 #[cfg(feature = "client")]
 pub use crate::client::Client;


### PR DESCRIPTION
Avoids a lot of annoying `#[cfg]` wrapping and should make it easier to add things.