### PR TITLE
ref: Switch Hubs using a Guard

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -21,7 +21,7 @@ harness = false
 
 [features]
 default = []
-client = ["rand"]
+client = ["rand", "arc-swap"]
 # I would love to just have a `log` feature, but this is used inside a macro,
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["dep:log"]
@@ -41,10 +41,11 @@ sys-info = { version = "0.9.1", optional = true }
 build_id = { version = "0.2.1", optional = true }
 findshlibs = { version = "=0.10.2", optional = true }
 rustc_version_runtime = { version = "0.2.1", optional = true }
-indexmap = { version = "1.9.1", optional = true}
+indexmap = { version = "1.9.1", optional = true }
+arc-swap = { version = "1.5.1", optional = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
-pprof = { version = "0.11.0", optional = true, default-features = false}
+pprof = { version = "0.11.0", optional = true, default-features = false }
 libc = { version = "^0.2.66", optional = true }
 
 [dev-dependencies]

--- a/sentry-core/src/futures.rs
+++ b/sentry-core/src/futures.rs
@@ -37,7 +37,8 @@ where
         let future = unsafe { self.map_unchecked_mut(|s| &mut s.future) };
         #[cfg(feature = "client")]
         {
-            Hub::run(hub, || future.poll(cx))
+            let _guard = crate::hub_impl::SwitchGuard::new(hub);
+            future.poll(cx)
         }
         #[cfg(not(feature = "client"))]
         {


### PR DESCRIPTION
Use a `SwitchGuard` internally as a replacement for `Hub::run` which does
not require passing a closure, and does not go through `panic::catch_unwind`,
as `Drop` impls are guaranteed to be executed even when panics are unwinding.

fixes #522