### PR TITLE
fix: Support process v0 symbols in stack traces

### DIFF
--- a/sentry-backtrace/src/parse.rs
+++ b/sentry-backtrace/src/parse.rs
@@ -45,7 +45,7 @@ pub fn parse_stacktrace(bt: &str) -> Option<Stacktrace> {
             let filename = abs_path.as_ref().map(|p| filename(p).to_string());
             let real_symbol = captures["symbol"].to_string();
             let symbol = strip_symbol(&real_symbol);
-            let function = demangle_symbol(symbol);
+            let function = demangle_symbol(&symbol);
 
             // Obtain the instruction address. A missing address usually indicates an inlined stack
             // frame, in which case the previous address needs to be used.

--- a/sentry-backtrace/src/process.rs
+++ b/sentry-backtrace/src/process.rs
@@ -104,7 +104,7 @@ pub fn backtrace_to_stacktrace(bt: &Backtrace) -> Option<Stacktrace> {
                         .name()
                         .map_or(Cow::Borrowed("<unknown>"), |n| Cow::Owned(n.to_string()));
                     let symbol = strip_symbol(&real_symbol);
-                    let function = demangle_symbol(symbol);
+                    let function = demangle_symbol(&symbol);
                     Frame {
                         symbol: if symbol != function {
                             Some(symbol.into())

--- a/sentry-backtrace/src/utils.rs
+++ b/sentry-backtrace/src/utils.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 
@@ -10,6 +12,15 @@ static HASH_FUNC_RE: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
+static CRATE_HASH_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r#"(?x)
+        \b(\[[a-f0-9]{16}\])
+    "#,
+    )
+    .unwrap()
+});
+
 static CRATE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         r#"(?x)
@@ -17,7 +28,7 @@ static CRATE_RE: Lazy<Regex> = Lazy::new(|| {
         (?:_?<)?           # trait impl syntax
         (?:\w+\ as \ )?    # anonymous implementor
         ([a-zA-Z0-9_]+?)   # crate name
-        (?:\.\.|::)        # crate delimiter (.. or ::)
+        (?:\.\.|::|\[)     # crate delimiter (.. or ::)
     "#,
     )
     .unwrap()
@@ -47,11 +58,13 @@ pub fn filename(s: &str) -> &str {
     s.rsplit(&['/', '\\'][..]).next().unwrap()
 }
 
-pub fn strip_symbol(s: &str) -> &str {
-    HASH_FUNC_RE
+pub fn strip_symbol(s: &str) -> Cow<str> {
+    let stripped_trailing_hash = HASH_FUNC_RE
         .captures(s)
         .map(|c| c.get(1).unwrap().as_str())
-        .unwrap_or(s)
+        .unwrap_or(s);
+
+    CRATE_HASH_RE.replace_all(stripped_trailing_hash, "")
 }
 
 pub fn demangle_symbol(s: &str) -> String {
@@ -197,6 +210,23 @@ mod tests {
     }
 
     #[test]
+    fn strip_crate_hash() {
+        assert_eq!(
+            &strip_symbol("std::panic::catch_unwind::hd044952603e5f56c"),
+            "std::panic::catch_unwind"
+        );
+        assert_eq!(
+            &strip_symbol("std[550525b9dd91a68e]::rt::lang_start::<()>"),
+            "std::rt::lang_start::<()>"
+        );
+        assert_eq!(
+            &strip_symbol("<fn() as core[bb3d6b31f0e973c8]::ops::function::FnOnce<()>>::call_once"),
+            "<fn() as core::ops::function::FnOnce<()>>::call_once"
+        );
+        assert_eq!(&strip_symbol("<std[550525b9dd91a68e]::thread::local::LocalKey<(arc_swap[1d34a79be67db79e]::ArcSwapAny<alloc[bc7f897b574022f6]::sync::Arc<sentry_core[1d5336878cce1456]::hub::Hub>>, core[bb3d6b31f0e973c8]::cell::Cell<bool>)>>::with::<<sentry_core[1d5336878cce1456]::hub::Hub>::with<<sentry_core[1d5336878cce1456]::hub::Hub>::with_active<sentry_core[1d5336878cce1456]::api::with_integration<sentry_panic[c87c9124ff32f50e]::PanicIntegration, sentry_panic[c87c9124ff32f50e]::panic_handler::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>"), "<std::thread::local::LocalKey<(arc_swap::ArcSwapAny<alloc::sync::Arc<sentry_core::hub::Hub>>, core::cell::Cell<bool>)>>::with::<<sentry_core::hub::Hub>::with<<sentry_core::hub::Hub>::with_active<sentry_core::api::with_integration<sentry_panic::PanicIntegration, sentry_panic::panic_handler::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>");
+    }
+
+    #[test]
     fn test_parse_crate_name_none() {
         assert_eq!(parse_crate_name("main"), None);
     }
@@ -206,6 +236,18 @@ mod tests {
         assert_eq!(
             parse_crate_name("<failure::error::Error as core::convert::From<F>>::from"),
             Some("failure".into())
+        );
+    }
+
+    #[test]
+    fn test_parse_crate_name_hash() {
+        assert_eq!(
+            parse_crate_name("backtrace[856cf81bbf211f65]::backtrace::libunwind::trace"),
+            Some("backtrace".into())
+        );
+        assert_eq!(
+            parse_crate_name("<backtrace[856cf81bbf211f65]::capture::Backtrace>::new"),
+            Some("backtrace".into())
         );
     }
 }


### PR DESCRIPTION
This will now correctly strip the crate hash from new v0 mangled symbols.

We may need to do the same in sentry itself when cleaning symbols that come from serverside symbolication.

fixes https://github.com/getsentry/sentry-rust/issues/520