### PR TITLE
ref: Switch back to UnsafeCell from ArcSwap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **Internal**:
 
-- Simplify `Hub::run` and `SentryFuture` by using a scope-guard and `arc-swap` for `Hub` switching. ([#524](https://github.com/getsentry/sentry-rust/pull/524))
+- Simplify `Hub::run` and `SentryFuture` by using a scope-guard for `Hub` switching. ([#524](https://github.com/getsentry/sentry-rust/pull/524), [#529](https://github.com/getsentry/sentry-rust/pull/529))
 
 **Thank you**:
 

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -21,7 +21,7 @@ harness = false
 
 [features]
 default = []
-client = ["rand", "arc-swap"]
+client = ["rand"]
 # I would love to just have a `log` feature, but this is used inside a macro,
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["dep:log"]
@@ -42,7 +42,6 @@ build_id = { version = "0.2.1", optional = true }
 findshlibs = { version = "=0.10.2", optional = true }
 rustc_version_runtime = { version = "0.2.1", optional = true }
 indexmap = { version = "1.9.1", optional = true }
-arc-swap = { version = "1.5.1", optional = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 pprof = { version = "0.11.0", optional = true, default-features = false }


### PR DESCRIPTION
Turns out ArcSwap does have a slight cost. The previous implementation used `UnsafeCell`, so switch back to that.