### PR TITLE
sentry-core: make TransactionContext.trace_id readable

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -180,6 +180,11 @@ impl TransactionContext {
         &self.op
     }
 
+    /// Get the Trace ID of this Transaction.
+    pub fn trace_id(&self) -> protocol::TraceId {
+        self.trace_id
+    }
+
     /// Get the custom context of this Transaction.
     pub fn custom(&self) -> Option<&CustomTransactionContext> {
         self.custom.as_ref()


### PR DESCRIPTION
I would like to add the Sentry trace_id to our internal logs to be able to correlate it with the sentry transaction. Currently this isn't publicly accessible anywhere.