### PR TITLE
sentry-core: make TraceContext publicly readable

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -62,7 +62,7 @@ pub type CustomTransactionContext = serde_json::Map<String, serde_json::Value>;
 ///
 /// The Transaction Context defines the metadata for a Performance Monitoring
 /// Transaction, and also the connection point for distributed tracing.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TransactionContext {
     #[cfg_attr(not(feature = "client"), allow(dead_code))]
     name: String,
@@ -252,6 +252,16 @@ impl TransactionOrSpan {
         match self {
             TransactionOrSpan::Transaction(transaction) => transaction.set_data(key, value),
             TransactionOrSpan::Span(span) => span.set_data(key, value),
+        }
+    }
+
+    /// Get the TransactionContext of the Transaction/Span.
+    ///
+    /// Note that this clones the underlying value.
+    pub fn get_trace_context(&self) -> protocol::TraceContext {
+        match self {
+            TransactionOrSpan::Transaction(transaction) => transaction.get_trace_context(),
+            TransactionOrSpan::Span(span) => span.get_trace_context(),
         }
     }
 
@@ -472,6 +482,14 @@ impl Transaction {
         }
     }
 
+    /// Get the TransactionContext of the Transaction.
+    ///
+    /// Note that this clones the underlying value.
+    pub fn get_trace_context(&self) -> protocol::TraceContext {
+        let inner = self.inner.lock().unwrap();
+        inner.context.clone()
+    }
+
     /// Get the status of the Transaction.
     pub fn get_status(&self) -> Option<protocol::SpanStatus> {
         let inner = self.inner.lock().unwrap();
@@ -594,6 +612,14 @@ impl Span {
     pub fn set_data(&self, key: &str, value: protocol::Value) {
         let mut span = self.span.lock().unwrap();
         span.data.insert(key.into(), value);
+    }
+
+    /// Get the TransactionContext of the Span.
+    ///
+    /// Note that this clones the underlying value.
+    pub fn get_trace_context(&self) -> protocol::TraceContext {
+        let transaction = self.transaction.lock().unwrap();
+        transaction.context.clone()
     }
 
     /// Get the status of the Span.


### PR DESCRIPTION
Raised in review of https://github.com/getsentry/sentry-rust/pull/533#issuecomment-1375551161

This PR exposes the `TraceContext` stored on a `Transaction` or `Span`.

All data on the `TraceContext` is publicly readable in other SDKs, such as Python or Javascript.

- Rust struct: https://github.com/getsentry/sentry-rust/blob/5013eb1fdca505ef9c7c28266afcf847da7c17b3/sentry-types/src/protocol/v7.rs#L1439
- Python analagous class: https://github.com/getsentry/sentry-python/blob/d0eed0ee828684f22fe2a2b28b02cf7f4ce8c74a/sentry_sdk/tracing.py#L81