### PR TITLE
fix: Avoid Deadlock popping ScopeGuards out of order

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -531,6 +531,7 @@ impl Transaction {
                     let sample_profile = inner.profiler_guard.take().and_then(|profiler_guard| {
                         profiling::finish_profiling(&transaction, profiler_guard, inner.context.trace_id)
                     });
+                    drop(inner);
 
                     let mut envelope = protocol::Envelope::new();
                     envelope.add_item(transaction);


### PR DESCRIPTION
The `ScopeGuard` panics when it is being dropped out of order. Previously it would do so while holding the Scope/stack `RwLock`. The `PanicIntegration` would also try to acquire that same lock in order to capture the resulting panic, resulting in a deadlock or a double-panic in case the `RwLock` implementation detected the deadlock.