### PR TITLE
Re-disable scheduled jobs on forks

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,6 +16,7 @@ jobs:
         rust: [nightly, beta]
 
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'getsentry'
 
     steps:
       - uses: actions/checkout@v3
@@ -32,6 +33,7 @@ jobs:
   weekly-audit:
     name: Audit
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'getsentry'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I disabled scheduled jobs on forks in #435 to prevent [unnecessary spam from steps that are not supposed to succeed anyway], but @Swatinem removed the check in #528 for an undocumented reason.  Add it back to not bother forkers with day-to-day issues, while still allowing them to test/see CI results locally on push (to one of a limited set of preconfigured branches).

[unnecessary spam from steps that are not supposed to succeed anyway]: https://github.com/MarijnS95/sentry-rust/actions/runs/3926205216
