### PR TITLE
fix actix match name bug

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -531,7 +531,7 @@ mod tests {
         assert_eq!(events.len(), 2);
         for event in events {
             let request = event.request.expect("Request should be set.");
-            assert_eq!(event.transaction, Some("GET /test".into())); // Transaction name is the name of the function
+            assert_eq!(event.transaction, Some("GET /test".into())); // Transaction name is the matcher of the route
             assert_eq!(event.message, None);
             assert_eq!(event.exception.values[0].ty, String::from("Custom"));
             assert_eq!(event.exception.values[0].value, Some("Test Error".into()));


### PR DESCRIPTION
# Issue

Actix `request.match_name()` is buggy. 
It doesn't care about the HTTP verb. It only looks at the `path`. Thus 2 routes with the same `path` will have the same match name. 

# Proposal

Previously, `format!("{} {}", req.method(), req.uri())` was already used as a fallback for the transaction name.
These changes make it as the default transaction name.