### PR TITLE
fix: Don't block on sending envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Envelopes will be discarded rather than blocking if the transport channel fills up. ([#546](https://github.com/getsentry/sentry-rust/pull/546))
+
 ## 0.29.2
 
 ### Various fixes & improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Fixes
+**Fixes**:
 
 - Envelopes will be discarded rather than blocking if the transport channel fills up. ([#546](https://github.com/getsentry/sentry-rust/pull/546))
 

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -89,7 +89,7 @@ impl TransportThread {
         // reason, trying to send an envelope would block everything. We'd rather
         // drop the envelope in that case.
         if let Err(e) = self.sender.try_send(Task::SendEnvelope(envelope)) {
-            eprintln!("envelope dropped: {e}");
+            sentry_debug!("envelope dropped: {e}");
         }
     }
 


### PR DESCRIPTION
Fixes #543.

I am unsure if there is anything better than `eprintln` we can do in the error case—would using e.g. the `sentry_debug` macro exacerbate the problem because it also tries to send on the same channel?