### PR TITLE
feat(tracing): Add method for accessing span data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `debug_images` is now a default feature. ([#545](https://github.com/getsentry/sentry-rust/pull/545)
 - Added a `from_path_raw` function to `Envelope` that reads an envelope from a file without parsing anything. ([#549](https://github.com/getsentry/sentry-rust/pull/549))
+- Added a `data` method to `performance::Span` that gives access to the span's attached data. ([#548](https://github.com/getsentry/sentry-rust/pull/548))
 
 **Fixes**:
 

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -643,6 +643,13 @@ impl Span {
     ///
     /// Since [`Data`] implements `Deref` and `DerefMut`, this can be used to read and mutate
     /// the span data.
+    ///
+    /// # Concurrency
+    /// In order to obtain any kind of reference to the `data` field,
+    /// a `Mutex` needs to be locked. The returned `Data` holds on to this lock
+    /// for as long as it lives. Therefore you must take care not to keep the returned
+    /// `Data` around too long or it will never relinquish the lock and you may run into
+    /// a deadlock.
     pub fn data(&self) -> Data {
         Data(self.span.lock().unwrap())
     }

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -1,9 +1,6 @@
 use std::collections::BTreeMap;
-use std::ops::Deref;
-use std::ops::DerefMut;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::MutexGuard;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 #[cfg(all(feature = "profiling", target_family = "unix"))]
 use crate::profiling;


### PR DESCRIPTION
This adds a `data` method to `performance::Span` that gives exclusive access to the underlying `protocol::Span`'s `data` field (a map from `String` to `protocol::Value`). Since the inner span is behind a `Mutex`, the `data` method returns a `Data` smart pointer that holds the lock.