### PR TITLE
feat: Allow Envelopes to contain raw binary data

### DIFF
--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -382,15 +382,15 @@ impl Envelope {
         Envelope::from_slice(&bytes)
     }
 
-    /// Creates a new Envelope from path without attempting to parse any items.
+    /// Creates a new Envelope from path without attempting to parse anything.
     ///
-    /// The resulting Envelope's `items` will just be a binary blob.
+    /// The resulting Envelope will have no `event_id` and the file contents will
+    /// be contained verbatim in the `items` field.
     pub fn from_path_raw<P: AsRef<Path>>(path: P) -> Result<Self, EnvelopeError> {
-        let mut bytes = std::fs::read(path).map_err(|_| EnvelopeError::UnexpectedEof)?;
-        let (header, offset) = Self::parse_header(&bytes)?;
+        let bytes = std::fs::read(path).map_err(|_| EnvelopeError::UnexpectedEof)?;
         Ok(Self {
-            event_id: header.event_id,
-            items: Items::Raw(bytes.drain(offset..).collect()),
+            event_id: None,
+            items: Items::Raw(bytes),
         })
     }
 

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -152,14 +152,14 @@ impl From<SampleProfile> for EnvelopeItem {
 /// An Iterator over the items of an Envelope.
 #[derive(Clone)]
 pub struct EnvelopeItemIter<'s> {
-    inner: Option<std::slice::Iter<'s, EnvelopeItem>>,
+    inner: std::slice::Iter<'s, EnvelopeItem>,
 }
 
 impl<'s> Iterator for EnvelopeItemIter<'s> {
     type Item = &'s EnvelopeItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.as_mut()?.next()
+        self.inner.next()
     }
 }
 
@@ -232,8 +232,8 @@ impl Envelope {
     /// Create an [`Iterator`] over all the [`EnvelopeItem`]s.
     pub fn items(&self) -> EnvelopeItemIter {
         let inner = match &self.items {
-            Items::EnvelopeItems(items) => Some(items.iter()),
-            Items::Raw(_) => None,
+            Items::EnvelopeItems(items) => items.iter(),
+            Items::Raw(_) => [].iter(),
         };
 
         EnvelopeItemIter { inner }


### PR DESCRIPTION
This turns the type of `Envelope::items` into an enum that may be a vector of `EnvelopeItems` (the status quo) or a blob of binary data. In the latter case, operations on items become no-ops because nothing can be done if there's no structure to the items.

It also adds a function `from_path_raw` that reads an Envelope from disk without attempting to parse any items. The motivation for this is https://github.com/getsentry/sentry-cli/issues/1458.