### PR TITLE
build(backtrace): Disable most of default regex features

### DIFF
--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -15,5 +15,5 @@ rust-version = "1.60"
 [dependencies]
 backtrace = "0.3.44"
 once_cell = "1"
-regex = "1.5.5"
+regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-perl"] }
 sentry-core = { version = "0.29.3", path = "../sentry-core" }


### PR DESCRIPTION
regex as used by Sentry doesn't need full Unicode tables, just ones used by `\w`, `\s`, `\d` and `\b` (`unicode-perl` feature). This reduces size of the binary.