### PR TITLE
ref(profiling): remove deprecated fields from profile data

### DIFF
--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -182,8 +182,6 @@ fn get_profile_from_report(
     trace_id: TraceId,
     transaction: &Transaction,
 ) -> SampleProfile {
-    use std::time::SystemTime;
-
     let mut samples: Vec<Sample> = Vec::with_capacity(rep.data.len());
     let mut stacks: Vec<Vec<u32>> = Vec::with_capacity(rep.data.len());
     let mut address_to_frame_idx: IndexSet<_> = IndexSet::new();

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -250,19 +250,12 @@ fn get_profile_from_report(
         event_id: uuid::Uuid::new_v4(),
         release: transaction.release.clone().unwrap_or_default().into(),
         timestamp: rep.timing.start_time,
-        transactions: vec![TransactionMetadata {
+        transaction: TransactionMetadata {
             id: transaction.event_id,
             name: transaction.name.clone().unwrap_or_default(),
             trace_id,
-            relative_start_ns: 0,
-            relative_end_ns: transaction
-                .timestamp
-                .unwrap_or_else(SystemTime::now)
-                .duration_since(rep.timing.start_time)
-                .unwrap()
-                .as_nanos() as u64,
             active_thread_id: transaction.active_thread_id.unwrap_or(0),
-        }],
+        },
         platform: "rust".to_string(),
         profile: Profile {
             samples,

--- a/sentry-types/src/protocol/profile.rs
+++ b/sentry-types/src/protocol/profile.rs
@@ -19,10 +19,6 @@ pub struct TransactionMetadata {
     pub name: String,
     /// Trace ID
     pub trace_id: TraceId,
-    /// Transaction start timestamp in nanoseconds relative to the start of the profiler
-    pub relative_start_ns: u64,
-    /// Transaction end timestamp in nanoseconds relative to the start of the profiler
-    pub relative_end_ns: u64,
     /// ID of the thread in which the transaction started
     #[serde(default)]
     pub active_thread_id: u64,
@@ -138,7 +134,6 @@ pub struct SampleProfile {
     /// Timestamp at which the profiler started
     pub timestamp: SystemTime,
 
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    /// List of transactions associated with this profile
-    pub transactions: Vec<TransactionMetadata>,
+    /// Transaction associated with this profile
+    pub transaction: TransactionMetadata,
 }


### PR DESCRIPTION
Removes deprecated fields `relative_start_ns` and `relative_end_ns` from TransactionMetadata and replace Vec<TransactionMetadata> with a single TransactionMetadata.

This is meant to align the SDK with PR [#1878](https://github.com/getsentry/relay/pull/1878)