### PR TITLE
feat(profiling): add ProfilesSampler

### DIFF
--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::constants::USER_AGENT;
-use crate::performance::TracesSampler;
+use crate::performance::{ProfilesSampler, TracesSampler};
 use crate::protocol::{Breadcrumb, Event};
 use crate::types::Dsn;
 use crate::{Integration, IntoDsn, TransportFactory};
@@ -87,6 +87,10 @@ pub struct ClientOptions {
     /// This represents the probability that a sampled transaction
     /// will send a profile to Sentry
     pub profiles_sample_rate: f32,
+    /// If given, called with a TransactionContext for each profile to determine the sampling rate.
+    ///
+    /// Return a sample rate between 0.0 and 1.0 for the profile in question.
+    pub profiles_sampler: Option<Arc<ProfilesSampler>>,
     /// Maximum number of breadcrumbs. (defaults to 100)
     pub max_breadcrumbs: usize,
     /// Attaches stacktraces to messages.
@@ -247,6 +251,7 @@ impl Default for ClientOptions {
             traces_sampler: None,
             enable_profiling: false,
             profiles_sample_rate: 0.0,
+            profiles_sampler: None,
             max_breadcrumbs: 100,
             attach_stacktrace: false,
             send_default_pii: false,

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -384,6 +384,7 @@ fn transaction_sample_rate(
     }
 }
 
+#[cfg(all(feature = "profiling", target_family = "unix"))]
 fn profile_sample_rate(
     profile_sampler: Option<&ProfilesSampler>,
     ctx: &TransactionContext,
@@ -407,6 +408,7 @@ impl Client {
         ))
     }
 
+    #[cfg(all(feature = "profiling", target_family = "unix"))]
     pub(crate) fn is_profile_sampled(&self, ctx: &TransactionContext) -> bool {
         let client_options = self.options();
         self.sample_should_send(profile_sample_rate(

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -230,6 +230,9 @@ impl TransactionContext {
 /// or ignore it.
 pub type TracesSampler = dyn Fn(&TransactionContext) -> f32 + Send + Sync;
 
+/// Same as TracesSampler but for profiles
+pub type ProfilesSampler = TracesSampler;
+
 // global API types:
 
 /// A wrapper that groups a [`Transaction`] and a [`Span`] together.
@@ -381,6 +384,17 @@ fn transaction_sample_rate(
     }
 }
 
+fn profile_sample_rate(
+    profile_sampler: Option<&ProfilesSampler>,
+    ctx: &TransactionContext,
+    profiles_sample_rate: f32,
+) -> f32 {
+    match (profile_sampler, profiles_sample_rate) {
+        (Some(profile_sampler), _) => profile_sampler(ctx),
+        (None, profiles_sample_rate) => profiles_sample_rate,
+    }
+}
+
 /// Determine whether the new transaction should be sampled.
 #[cfg(feature = "client")]
 impl Client {
@@ -390,6 +404,15 @@ impl Client {
             client_options.traces_sampler.as_deref(),
             ctx,
             client_options.traces_sample_rate,
+        ))
+    }
+
+    pub(crate) fn is_profile_sampled(&self, ctx: &TransactionContext) -> bool {
+        let client_options = self.options();
+        self.sample_should_send(profile_sample_rate(
+            client_options.traces_sampler.as_deref(),
+            ctx,
+            client_options.profiles_sample_rate,
         ))
     }
 }
@@ -411,7 +434,7 @@ impl Transaction {
             Some(client) => (
                 client.is_transaction_sampled(&ctx),
                 Some(protocol::Transaction {
-                    name: Some(ctx.name),
+                    name: Some(ctx.name.clone()),
                     #[cfg(all(feature = "profiling", target_family = "unix"))]
                     active_thread_id: Some(
                         // NOTE: `pthread_t` is a `usize`, so clippy is wrong complaining about this cast
@@ -429,7 +452,7 @@ impl Transaction {
         let context = protocol::TraceContext {
             trace_id: ctx.trace_id,
             parent_span_id: ctx.parent_span_id,
-            op: Some(ctx.op),
+            op: Some(ctx.op.clone()),
             ..Default::default()
         };
 
@@ -443,7 +466,9 @@ impl Transaction {
         // might as well be sampled
         #[cfg(all(feature = "profiling", target_family = "unix"))]
         let profiler_guard = if sampled {
-            client.as_deref().and_then(profiling::start_profiling)
+            client
+                .as_deref()
+                .and_then(|cli| profiling::start_profiling(cli, &ctx))
         } else {
             None
         };

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -17,6 +17,7 @@ use sentry_types::{CodeId, DebugId, Uuid};
 
 #[cfg(feature = "client")]
 use crate::Client;
+use crate::TransactionContext;
 
 static PROFILER_RUNNING: AtomicBool = AtomicBool::new(false);
 
@@ -28,12 +29,10 @@ impl fmt::Debug for ProfilerGuard {
     }
 }
 
-pub(crate) fn start_profiling(client: &Client) -> Option<ProfilerGuard> {
+pub(crate) fn start_profiling(client: &Client, ctx: &TransactionContext) -> Option<ProfilerGuard> {
     // if profiling is not enabled or the profile was not sampled
     // return None immediately
-    if !client.options().enable_profiling
-        || !client.sample_should_send(client.options().profiles_sample_rate)
-    {
+    if !client.options().enable_profiling || !client.is_profile_sampled(ctx) {
         return None;
     }
 


### PR DESCRIPTION
Similarly to `TracesSampler`, this PR aims to add support for a `ProfilesSampler`.