### PR TITLE
ref(profiling): make profile timestamp the same as transaction start_timestamp

### DIFF
--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -206,7 +206,7 @@ fn get_profile_from_report(
             thread_id: sample.thread_id,
             elapsed_since_start_ns: sample
                 .sample_timestamp
-                .duration_since(rep.timing.start_time)
+                .duration_since(transaction.start_timestamp)
                 .unwrap()
                 .as_nanos() as u64,
         });
@@ -246,7 +246,7 @@ fn get_profile_from_report(
 
         event_id: uuid::Uuid::new_v4(),
         release: transaction.release.clone().unwrap_or_default().into(),
-        timestamp: rep.timing.start_time,
+        timestamp: transaction.start_timestamp,
         transaction: TransactionMetadata {
             id: transaction.event_id,
             name: transaction.name.clone().unwrap_or_default(),


### PR DESCRIPTION
This is intended to align (as far as the profile timestamp is concerned) the SDK with the official `sample format` [doc](https://develop.sentry.dev/sdk/sample-format/) recently uploaded.

```
timestamp
           String, recommended. The timestamp when the profile was captured by 
           the SDK as [RFC 3339] format. This is meant to be the anchor for all 
           relative timestamps captured for the profile.

Ideally, this will be the same as the field start_timestamp on the transaction so all 
relative timestamps for transaction and profile can be both from the same reference 
point and we don't need to correct relative timestamps.

If for some reasons, the profiler implementation doesn't allow that, set it to the closest 
time to the profiler start (or to whatever the profiler gives you as a profile start timestamp) 
and it will be used to align with the transaction later on.
```