### PR TITLE
Add chaining documentation

### DIFF
--- a/sentry-panic/README.md
+++ b/sentry-panic/README.md
@@ -22,6 +22,8 @@ might optionally create a sentry `Event` out of a `PanicInfo`.
 let integration = sentry_panic::PanicIntegration::default().add_extractor(|info| None);
 ```
 
+If a panic handler is already configured when `sentry_panic` is initialized, `sentry_panic` will invoke that handler after it uploads the panic event.
+
 ## Resources
 
 License: Apache-2.0


### PR DESCRIPTION
Sentry wasn't working for me because I was calling `std::panic::set_hook()` after `sentry::init()`.   Make it clear that you can have your own hook too, as long as you set it first.