### PR TITLE
sentry-tower: Use `axum::MatchedPath` for transaction names

### DIFF
--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -14,8 +14,10 @@ rust-version = "1.66"
 
 [features]
 http = ["dep:http", "pin-project", "url"]
+axum-matched-path = ["axum/matched-path"]
 
 [dependencies]
+axum = { version = "0.6", optional = true }
 tower-layer = "0.3"
 tower-service = "0.3"
 http = { version = "0.2.6", optional = true }


### PR DESCRIPTION
If the `axum-matched-path` feature of `sentry-tower` is used, it will enable the corresponding `matched-path` feature of `axum` and use the `MatchedPath` request extension to generate the transaction name. As before, the HTTP method is also still included in the transaction name.

Resolves https://github.com/getsentry/sentry-rust/issues/541

/cc @Swatinem 