### PR TITLE
ref(profiling): do not set the profile_id in the profile context on the transaction.

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -581,7 +581,7 @@ impl Transaction {
                     // then call finish_profiling to return the profile
                     #[cfg(all(feature = "profiling", target_family = "unix"))]
                     let sample_profile = inner.profiler_guard.take().and_then(|profiler_guard| {
-                        profiling::finish_profiling(&mut transaction, profiler_guard, inner.context.trace_id)
+                        profiling::finish_profiling(&transaction, profiler_guard, inner.context.trace_id)
                     });
                     drop(inner);
 

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -61,21 +61,12 @@ pub(crate) fn start_profiling(client: &Client, ctx: &TransactionContext) -> Opti
 }
 
 pub(crate) fn finish_profiling(
-    transaction: &mut Transaction,
+    transaction: &Transaction,
     profiler_guard: ProfilerGuard,
     trace_id: TraceId,
 ) -> Option<SampleProfile> {
     let sample_profile = match profiler_guard.0.report().build_unresolved() {
-        Ok(report) => {
-            let prof = get_profile_from_report(&report, trace_id, transaction);
-            transaction.contexts.insert(
-                "profile".to_string(),
-                Context::Profile(Box::new(ProfileContext {
-                    profile_id: prof.event_id,
-                })),
-            );
-            Some(prof)
-        }
+        Ok(report) => Some(get_profile_from_report(&report, trace_id, transaction)),
         Err(err) => {
             sentry_debug!(
                 "could not build the profile result due to the error: {}",

--- a/sentry-core/src/profiling.rs
+++ b/sentry-core/src/profiling.rs
@@ -5,8 +5,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use findshlibs::{SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
 
-use sentry_types::protocol::latest::Context;
-use sentry_types::protocol::latest::ProfileContext;
 use sentry_types::protocol::v7::Profile;
 use sentry_types::protocol::v7::{
     DebugImage, DebugMeta, DeviceMetadata, OSMetadata, RuntimeMetadata, RustFrame, Sample,


### PR DESCRIPTION
Better to leave Relay set it.
This will ensure the profile is correctly accepted and validated before we set it instead of having to remove the profile id from the context in case the profile is rate limited/invalid or else.