### PR TITLE
feat(tracing): Improve structure for tracing errors

### DIFF
--- a/sentry-backtrace/src/trim.rs
+++ b/sentry-backtrace/src/trim.rs
@@ -16,6 +16,8 @@ const WELL_KNOWN_SYS_MODULES: &[&str] = &[
     // these are well-known library frames
     "anyhow::",
     "log::",
+    "tokio::",
+    "tracing_core::",
 ];
 
 const WELL_KNOWN_BORDER_FRAMES: &[&str] = &[
@@ -24,6 +26,7 @@ const WELL_KNOWN_BORDER_FRAMES: &[&str] = &[
     // well-known library frames
     "anyhow::",
     "<sentry_log::Logger as log::Log>::log",
+    "tracing_core::",
 ];
 
 /// A helper function to trim a stacktrace.

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -12,10 +12,15 @@ Sentry integration for tracing and tracing-subscriber crates.
 edition = "2021"
 rust-version = "1.66"
 
+[features]
+default = []
+backtrace = ["dep:sentry-backtrace"]
+
 [dependencies]
 sentry-core = { version = "0.31.2", path = "../sentry-core", features = ["client"] }
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["std"] }
+sentry-backtrace = { version = "0.31.2", path = "../sentry-backtrace", optional = true }
 
 [dev-dependencies]
 log = "0.4"

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::error::Error;
 
 use sentry_core::protocol::{Event, Exception, Mechanism, Thread, Value};
-use sentry_core::{event_from_error, Breadcrumb, Hub, Level};
+use sentry_core::{event_from_error, Breadcrumb, Level};
 use tracing_core::field::{Field, Visit};
 use tracing_core::{span, Subscriber};
 use tracing_subscriber::layer::Context;
@@ -193,7 +193,7 @@ where
         let mut thread = Thread::default();
 
         #[cfg(feature = "backtrace")]
-        if let Some(client) = Hub::current().client() {
+        if let Some(client) = sentry_core::Hub::current().client() {
             if client.options().attach_stacktrace {
                 thread = sentry_backtrace::current_thread(true);
             }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 default = ["backtrace", "contexts", "debug-images", "panic", "transport"]
 
 # default integrations
-backtrace = ["sentry-backtrace"]
+backtrace = ["sentry-backtrace", "sentry-tracing?/backtrace"]
 contexts = ["sentry-contexts"]
 panic = ["sentry-panic"]
 # other integrations

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -45,7 +45,7 @@ fn test_tracing() {
         event.breadcrumbs[0].message,
         Some("Hello Tracing World!".into())
     );
-    match event.contexts.get("Rust Tracing Tags").unwrap() {
+    match event.contexts.get("Rust Tracing Fields").unwrap() {
         Context::Other(tags) => {
             let value = Value::String("tagvalue".to_string());
             assert_eq!(*tags.get("tagname").unwrap(), value);
@@ -84,7 +84,7 @@ fn test_tracing() {
         event.exception[0].value,
         Some("invalid digit found in string".into())
     );
-    match event.contexts.get("Rust Tracing Tags").unwrap() {
+    match event.contexts.get("Rust Tracing Fields").unwrap() {
         Context::Other(tags) => {
             let value = Value::String("tagvalue".to_string());
             assert_eq!(*tags.get("tagname").unwrap(), value);

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -106,7 +106,7 @@ fn test_tracing() {
 
 #[tracing::instrument(fields(span_field))]
 fn function() {
-    tracing::Span::current().record("span_field", "some data");
+    tracing::Span::current().record("span_field", &"some data");
 }
 
 #[test]

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -106,7 +106,7 @@ fn test_tracing() {
 
 #[tracing::instrument(fields(span_field))]
 fn function() {
-    tracing::Span::current().record("span_field", &"some data");
+    tracing::Span::current().record("span_field", "some data");
 }
 
 #[test]


### PR DESCRIPTION
Changes how the tracing integration tracks errors with messages and provides more structured data for fields passed via tracing. 

First, this introduces the ability to set Sentry tags via a `tags.*` prefix. The prefix is removed and does no longer occur in the tracing context. The following example will create a tag called `foo`:

```rust
tracing::error!(tags.foo = "bar", "this is an error");
```

Next, the custom context is renamed to `Rust Tracing Fields`. This is closer to the original naming in the `tracing` crate and also disambiguates this data more from Sentry tags.

The top-level exception passed to tracing is now marked with a `tracing` mechanism to annotate in the UI how the exception was captured.

Finally, if both a message and an error are passed to tracing, the message gets moved to a synthetic exception on the top of the stack. Most importantly, this allows for proper grouping and display in the issue stream. Additionally, if `attach_stacktrace` is enabled, the stack trace is placed on the synthetic exception rather than the thread interface, so it is shown inline with the chained exception.

## Example Rendering

Due to the synthetic exception, the title of the issue is now the location of the capture. The captured message is shown underneath. This is also the case in the title bar on issue details:

![Screenshot 2023-05-24 at 14 22 05](https://github.com/getsentry/sentry-rust/assets/1433023/3373d691-8b82-4374-b679-25f2613593e0)

The exception stack now shows an entry for `tracing::error!` with the logged message, marked with the `tracing` mechanism. The stack trace is captured through the backtrace integration and points to the capture:

![Screenshot 2023-05-24 at 14 22 20](https://github.com/getsentry/sentry-rust/assets/1433023/9aa7ed2a-4401-497f-a569-ca8b7950e3c7)

If the source errors had backtraces, those would be shown underneath.

## Background

The tracing integration converts fields containing a `dyn Error` into Sentry exception records. This also works with error sources and creates a stack of nested exceptions on Sentry. Additionally, the formatted message from the `error!` invocation is added as a message. Finally, if `attach_stacktrace` is enabled on the client, the integration also adds a stacktrace. 

For both grouping and rendering, this is suboptimal for the following reasons:
- The logged message usually contains a more specific or useful description than the logged error. However, Sentry does not render the attached message in issue stream, which makes it hard to disambiguate places where the same error is tracked.
- Neither the message nor the stack trace contribute to grouping if there is an exception list. The exceptions are generic, however, which means unrelated problems would be grouped together. 
- Likewise, the message does not end up in the issue title.
- The Sentry UI currently does not even display the exception list if there is a message and a stack trace on the issue. This will have to be fixed in the product, however.

A synthetic exception in Sentry is an exception record that was created from something that's not a language-level exception. It can carry a stack trace and a value, but unlike regular exceptions, the "type" has no meaning and is not used for grouping or issue title. Instead, Sentry will use the source location from the stack trace to for both.

With this, we receive the behavior that is most likely desirable in such a scenario:
- A chain of exceptions is shown with the logged message and stack trace on top, pointing to the log location.
- Grouping does not use the synthetic "tracing::error!" type, it uses the source location.
- Issue details show a descriptive location and the message.