### PR TITLE
chore(deps): bump rustls

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -72,9 +72,9 @@ http-client = { version = "6.5.3", optional = true }
 isahc = { version = "0.9.14", optional = true }
 serde_json = { version = "1.0.48", optional = true }
 tokio = { version = "1.0", features = ["rt"], optional = true }
-ureq = { version = "2.3.0", optional = true, default-features = false }
+ureq = { version = "2.7.0", optional = true, default-features = false }
 native-tls = { version = "0.2.8", optional = true }
-rustls = { version = "0.20.6", optional = true, features = ["dangerous_configuration"] }
+rustls = { version = "0.21.2", optional = true, features = ["dangerous_configuration"] }
 webpki-roots = { version = "0.22.5", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
ureq 2.7 is using rustls 0.21 now, so sentry won't build if both `rustls` & `ureq` are enabled.