### PR TITLE
ref: Apply user field from scope to transaction event

### DIFF
--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -304,6 +304,12 @@ impl Scope {
 
     /// Applies the contained scoped data to fill a transaction.
     pub fn apply_to_transaction(&self, transaction: &mut Transaction<'static>) {
+        if transaction.user.is_none() {
+            if let Some(user) = self.user.as_deref() {
+                transaction.user = Some(user.clone());
+            }
+        }
+
         transaction
             .extra
             .extend(self.extra.iter().map(|(k, v)| (k.to_owned(), v.to_owned())));

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1958,6 +1958,9 @@ pub struct Transaction<'a> {
     /// An optional environment identifier.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment: Option<Cow<'a, str>>,
+    /// Optionally user data to be sent along.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
     /// Optional tags to be attached to the event.
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub tags: Map<String, String>,
@@ -2002,6 +2005,7 @@ impl<'a> Default for Transaction<'a> {
         Transaction {
             event_id: event::default_id(),
             name: Default::default(),
+            user: Default::default(),
             tags: Default::default(),
             extra: Default::default(),
             release: Default::default(),
@@ -2028,6 +2032,7 @@ impl<'a> Transaction<'a> {
         Transaction {
             event_id: self.event_id,
             name: self.name,
+            user: self.user,
             tags: self.tags,
             extra: self.extra,
             release: self.release.map(|x| Cow::Owned(x.into_owned())),


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry-rust/pull/590
Fixes https://github.com/getsentry/sentry-rust/issues/575

Per https://develop.sentry.dev/sdk/event-payloads/transaction/
> Transactions are [Events](https://develop.sentry.dev/sdk/event-payloads/) enriched with [Span](https://develop.sentry.dev/sdk/event-payloads/span/) data.