### PR TITLE
docs: `debug-images` should be listed as a default feature

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -73,7 +73,7 @@ extra setup to function properly.
 | `transport`       | ✅      |                |            |                                                                                          |
 | `anyhow`          |         | 🔌             |            |                                                                                          |
 | `test`            |         |                |            |                                                                                          |
-| `debug-images`    |         | 🔌             |            |                                                                                          |
+| `debug-images`    | ✅      | 🔌             |            |                                                                                          |
 | `log`             |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 | `debug-logs`      |         |                | ❗         | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 | `slog`            |         | 🔌             |            | Requires extra setup; See [`sentry-slog`]'s documentation.                               |
@@ -95,11 +95,11 @@ extra setup to function properly.
 - `contexts`: Enables capturing device, OS, and Rust contexts.
 - `panic`: Enables support for capturing panics.
 - `transport`: Enables the default transport, which is currently `reqwest` with `native-tls`.
+- `debug-images`: Enables capturing metadata about the loaded shared libraries.
 
 ### Debugging/Testing
 - `anyhow`: Enables support for the `anyhow` crate.
 - `test`: Enables testing support.
-- `debug-images`: Attaches a list of loaded libraries to events (currently only supported on Unix).
 
 ### Logging
 - `log`: Enables support for the `log` crate.

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -65,7 +65,7 @@
 //! | `transport`       | ✅      |                |            |                                                                                          |
 //! | `anyhow`          |         | 🔌             |            |                                                                                          |
 //! | `test`            |         |                |            |                                                                                          |
-//! | `debug-images`    |         | 🔌             |            |                                                                                          |
+//! | `debug-images`    | ✅      | 🔌             |            |                                                                                          |
 //! | `log`             |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 //! | `debug-logs`      |         |                | ❗         | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 //! | `slog`            |         | 🔌             |            | Requires extra setup; See [`sentry-slog`]'s documentation.                               |
@@ -87,11 +87,11 @@
 //! - `contexts`: Enables capturing device, OS, and Rust contexts.
 //! - `panic`: Enables support for capturing panics.
 //! - `transport`: Enables the default transport, which is currently `reqwest` with `native-tls`.
+//! - `debug-images`: Enables capturing metadata about the loaded shared libraries.
 //!
 //! ## Debugging/Testing
 //! - `anyhow`: Enables support for the `anyhow` crate.
 //! - `test`: Enables testing support.
-//! - `debug-images`: Attaches a list of loaded libraries to events (currently only supported on Unix).
 //!
 //! ## Logging
 //! - `log`: Enables support for the `log` crate.


### PR DESCRIPTION
`debug-images` was moved to the default features but the docs were not updated