### PR TITLE
Bump `webpki-roots` to ^0.25.1

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -73,7 +73,7 @@ tokio = { version = "1.0", features = ["rt"], optional = true }
 ureq = { version = "2.7.0", optional = true, default-features = false }
 native-tls = { version = "0.2.8", optional = true }
 rustls = { version = "0.21.2", optional = true, features = ["dangerous_configuration"] }
-webpki-roots = { version = "0.23.0", optional = true }
+webpki-roots = { version = "0.25.1", optional = true }
 
 [dev-dependencies]
 sentry-anyhow = { path = "../sentry-anyhow" }


### PR DESCRIPTION
See https://github.com/rustls/webpki-roots/compare/v/0.23.1..08972db98bafca0bb1ed682b018f0e37352a2767.

Removes a transitive dependency on `webpki`, which is currently pulling in vulnerable code to one of our projects.

See https://rustsec.org/advisories/RUSTSEC-2023-0052.

The latest tagged version of `sentry` (`0.31.5`) still pulls `webpki-roots`@`0.22.6`, which pulls `webpki`@`^0.22`.