### PR TITLE
Update webpki-roots to fix RUSTSEC-2023-0052

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -73,7 +73,7 @@ tokio = { version = "1.0", features = ["rt"], optional = true }
 ureq = { version = "2.7.0", optional = true, default-features = false }
 native-tls = { version = "0.2.8", optional = true }
 rustls = { version = "0.21.2", optional = true, features = ["dangerous_configuration"] }
-webpki-roots = { version = "0.23.0", optional = true }
+webpki-roots = { version = "0.25.0", optional = true }
 
 [dev-dependencies]
 sentry-anyhow = { path = "../sentry-anyhow" }

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -74,7 +74,7 @@ impl UreqHttpTransport {
                     }
 
                     let mut root_store = RootCertStore::empty();
-                    root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|ta| {
+                    root_store.add_trust_anchors(TLS_SERVER_ROOTS.iter().map(|ta| {
                         OwnedTrustAnchor::from_subject_spki_name_constraints(
                             ta.subject,
                             ta.spki,


### PR DESCRIPTION
webpki-roots 0.23 still depends on webpki 0.22 which is affected by a denial of service vulnerability, see https://rustsec.org/advisories/RUSTSEC-2023-0052.html

Opening this PR despite #606 because that one doesn't fix the compilation error that the update brings with it.