### PR TITLE
Enable building sentry-tower and sentry-tracing with all features on docs.rs

### DIFF
--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for tower-based crates.
 edition = "2021"
 rust-version = "1.68"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 http = ["dep:http", "pin-project", "url"]
 axum-matched-path = ["http", "axum/matched-path"]

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for tracing and tracing-subscriber crates.
 edition = "2021"
 rust-version = "1.68"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = []
 backtrace = ["dep:sentry-backtrace"]


### PR DESCRIPTION
I found e.g. `SentryHttpLayer` missing from docs.rs for `sentry-tower` so I went ahead and added the necessary `docs.rs` metadata to `Cargo.toml` for `sentry-tower` and `sentry-tracing` (those were the packages with non-default features that didn't have it enabled yet).