### PR TITLE
Use `rand` instead of `getrandom` for IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,8 +2818,8 @@ name = "sentry-types"
 version = "0.31.6"
 dependencies = [
  "debugid",
- "getrandom 0.2.10",
  "hex",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror",

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -17,9 +17,9 @@ use crate::{Hub, Integration, IntoBreadcrumbs, Scope};
 ///
 /// ```
 /// use sentry::protocol::{Event, Level};
-/// use sentry::types::Uuid;
+/// use sentry::types::{Uuid, random_uuid};
 ///
-/// let uuid = Uuid::new_v4();
+/// let uuid = random_uuid();
 /// let event = Event {
 ///     event_id: uuid,
 ///     message: Some("Hello World!".into()),

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use rand::random;
 use sentry_types::protocol::v7::SessionUpdate;
+use sentry_types::random_uuid;
 
 use crate::constants::SDK_INFO;
 use crate::protocol::{ClientSdkInfo, Event};
@@ -161,7 +162,7 @@ impl Client {
         // event_id and sdk_info are set before the processors run so that the
         // processors can poke around in that data.
         if event.event_id.is_nil() {
-            event.event_id = Uuid::new_v4();
+            event.event_id = random_uuid();
         }
 
         if event.sdk.is_none() {

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -406,7 +406,7 @@ impl Transaction {
             Some(client) => (
                 client.is_transaction_sampled(&ctx),
                 Some(protocol::Transaction {
-                    name: Some(ctx.name.clone()),
+                    name: Some(ctx.name),
                     ..Default::default()
                 }),
             ),

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -14,7 +14,7 @@ use crate::protocol::{
     SessionStatus, SessionUpdate,
 };
 use crate::scope::StackLayer;
-use crate::types::Uuid;
+use crate::types::random_uuid;
 use crate::{Client, Envelope};
 
 #[derive(Clone, Debug)]
@@ -50,7 +50,7 @@ impl Session {
         Some(Self {
             client: client.clone(),
             session_update: SessionUpdate {
-                session_id: Uuid::new_v4(),
+                session_id: random_uuid(),
                 distinct_id,
                 sequence: None,
                 timestamp: None,

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -22,11 +22,11 @@ protocol = []
 
 [dependencies]
 debugid = { version = "0.8.0", features = ["serde"] }
-getrandom = "0.2.3"
 hex = "0.4.3"
+rand = "0.8.5"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.46"
 thiserror = "1.0.15"
 time = { version = "0.3.5", features = ["formatting", "parsing"] }
 url = { version = "2.1.1", features = ["serde"] }
-uuid = { version = "1.0.0", features = ["v4", "serde"] }
+uuid = { version = "1.0.0", features = ["serde"] }

--- a/sentry-types/src/lib.rs
+++ b/sentry-types/src/lib.rs
@@ -52,3 +52,8 @@ pub use crate::project_id::*;
 // Re-export external types and traits for convenience
 pub use debugid::*;
 pub use uuid::{Uuid, Variant as UuidVariant, Version as UuidVersion};
+
+/// Generates a random [Uuid] using a thread local RNG.
+pub fn random_uuid() -> Uuid {
+    uuid::Builder::from_random_bytes(rand::random()).into_uuid()
+}

--- a/sentry-types/src/protocol/session.rs
+++ b/sentry-types/src/protocol/session.rs
@@ -92,7 +92,7 @@ fn is_false(val: &bool) -> bool {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SessionUpdate<'a> {
     /// The session identifier.
-    #[serde(rename = "sid", default = "Uuid::new_v4")]
+    #[serde(rename = "sid", default = "crate::random_uuid")]
     pub session_id: Uuid,
 
     /// The distinct identifier. Should be device or user ID.

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1338,12 +1338,7 @@ pub struct SpanId([u8; 8]);
 
 impl Default for SpanId {
     fn default() -> Self {
-        let mut buf = [0; 8];
-
-        getrandom::getrandom(&mut buf)
-            .unwrap_or_else(|err| panic!("could not retrieve random bytes for SpanId: {err}"));
-
-        Self(buf)
+        Self(rand::random())
     }
 }
 
@@ -1384,12 +1379,7 @@ pub struct TraceId([u8; 16]);
 
 impl Default for TraceId {
     fn default() -> Self {
-        let mut buf = [0; 16];
-
-        getrandom::getrandom(&mut buf)
-            .unwrap_or_else(|err| panic!("could not retrieve random bytes for TraceId: {err}"));
-
-        Self(buf)
+        Self(rand::random())
     }
 }
 
@@ -1520,7 +1510,7 @@ mod event {
     use super::*;
 
     pub fn default_id() -> Uuid {
-        Uuid::new_v4()
+        uuid::Builder::from_random_bytes(rand::random()).into_uuid()
     }
 
     pub fn serialize_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1510,7 +1510,7 @@ mod event {
     use super::*;
 
     pub fn default_id() -> Uuid {
-        uuid::Builder::from_random_bytes(rand::random()).into_uuid()
+        crate::random_uuid()
     }
 
     pub fn serialize_id<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error> {


### PR DESCRIPTION
The `getrandom` crate uses syscalls to get *true* randomness from the OS. We do not need that high quality of randomness, we do not even need cryptographically secure randomness.

This switches to the `rand` crate which uses a reseeding PRNG which is still cryptographically secure though.

This is much faster, and we can switch to an even simpler PRNG if it is not fast enough still.