### PR TITLE
Add experimental metrics implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add experimental implementations for Sentry metrics and a cadence sink. These
+  require to use the `UNSTABLE_metrics` and `UNSTABLE_cadence` feature flags.
+  Note that these APIs are still under development and subject to change.
+
 ## 0.32.0
 
 **Features**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,32 +651,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
-name = "bytecount"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad152d03a2c813c80bb94fedbf3a3f02b28f793e39e7c214c8a0bcc196343de7"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -729,16 +707,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
-dependencies = [
- "num-traits",
- "serde",
-]
 
 [[package]]
 name = "ciborium"
@@ -1422,19 +1390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
-name = "globset"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
-dependencies = [
- "aho-corasick",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,28 +1427,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1919,15 +1856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
-]
-
-[[package]]
-name = "lru"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
-dependencies = [
- "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2481,99 +2409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
-name = "relay-base-schema"
-version = "23.10.0"
-source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
-dependencies = [
- "relay-common",
- "relay-protocol",
- "serde",
-]
-
-[[package]]
-name = "relay-common"
-version = "23.10.0"
-source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
-dependencies = [
- "chrono",
- "globset",
- "lru",
- "once_cell",
- "parking_lot",
- "regex",
- "sentry-types 0.31.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
-]
-
-[[package]]
-name = "relay-log"
-version = "23.10.0"
-source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
-dependencies = [
- "sentry-core 0.31.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
-]
-
-[[package]]
-name = "relay-metrics"
-version = "23.10.0"
-source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
-dependencies = [
- "bytecount",
- "fnv",
- "hash32",
- "itertools",
- "relay-base-schema",
- "relay-common",
- "relay-log",
- "relay-statsd",
- "relay-system",
- "serde",
- "serde_json",
- "smallvec",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "relay-protocol"
-version = "23.10.0"
-source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
-dependencies = [
- "num-traits",
- "relay-common",
- "serde",
- "serde_json",
- "smallvec",
- "unicase",
- "uuid",
-]
-
-[[package]]
-name = "relay-statsd"
-version = "23.10.0"
-source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
-dependencies = [
- "cadence",
- "crossbeam-channel",
- "parking_lot",
- "rand 0.8.5",
- "relay-log",
-]
-
-[[package]]
-name = "relay-system"
-version = "23.10.0"
-source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
-dependencies = [
- "futures",
- "once_cell",
- "relay-log",
- "relay-statsd",
- "tokio",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,7 +2665,7 @@ dependencies = [
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
- "sentry-core 0.31.7",
+ "sentry-core",
  "sentry-debug-images",
  "sentry-log",
  "sentry-panic",
@@ -2856,7 +2691,7 @@ dependencies = [
  "futures",
  "futures-util",
  "sentry",
- "sentry-core 0.31.7",
+ "sentry-core",
  "tokio",
 ]
 
@@ -2867,7 +2702,7 @@ dependencies = [
  "anyhow",
  "sentry",
  "sentry-backtrace",
- "sentry-core 0.31.7",
+ "sentry-core",
 ]
 
 [[package]]
@@ -2877,7 +2712,7 @@ dependencies = [
  "backtrace",
  "once_cell",
  "regex",
- "sentry-core 0.31.7",
+ "sentry-core",
 ]
 
 [[package]]
@@ -2889,7 +2724,7 @@ dependencies = [
  "os_info",
  "rustc_version 0.4.0",
  "sentry",
- "sentry-core 0.31.7",
+ "sentry-core",
  "uname",
 ]
 
@@ -2905,9 +2740,8 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "rayon",
- "relay-metrics",
  "sentry",
- "sentry-types 0.31.7",
+ "sentry-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -2916,24 +2750,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-core"
-version = "0.31.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f51264e4013ed9b16558cce43917b983fa38170de2ca480349ceb57d71d6053"
-dependencies = [
- "once_cell",
- "sentry-types 0.31.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "sentry-debug-images"
 version = "0.31.7"
 dependencies = [
  "findshlibs",
  "once_cell",
- "sentry-core 0.31.7",
+ "sentry-core",
 ]
 
 [[package]]
@@ -2943,7 +2765,7 @@ dependencies = [
  "log",
  "pretty_env_logger",
  "sentry",
- "sentry-core 0.31.7",
+ "sentry-core",
 ]
 
 [[package]]
@@ -2952,7 +2774,7 @@ version = "0.31.7"
 dependencies = [
  "sentry",
  "sentry-backtrace",
- "sentry-core 0.31.7",
+ "sentry-core",
 ]
 
 [[package]]
@@ -2961,7 +2783,7 @@ version = "0.31.7"
 dependencies = [
  "erased-serde",
  "sentry",
- "sentry-core 0.31.7",
+ "sentry-core",
  "serde",
  "serde_json",
  "slog",
@@ -2978,7 +2800,7 @@ dependencies = [
  "prost",
  "sentry",
  "sentry-anyhow",
- "sentry-core 0.31.7",
+ "sentry-core",
  "tokio",
  "tonic",
  "tower",
@@ -2994,7 +2816,7 @@ dependencies = [
  "log",
  "sentry",
  "sentry-backtrace",
- "sentry-core 0.31.7",
+ "sentry-core",
  "tokio",
  "tracing",
  "tracing-core",
@@ -3004,23 +2826,6 @@ dependencies = [
 [[package]]
 name = "sentry-types"
 version = "0.31.7"
-dependencies = [
- "debugid",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "thiserror",
- "time 0.3.28",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.31.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e663b3eb62ddfc023c9cf5432daf5f1a4f6acb1df4d78dd80b740b32dd1a740"
 dependencies = [
  "debugid",
  "hex",
@@ -3197,9 +3002,6 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"
@@ -3521,7 +3323,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.4",
  "tokio-macros",
- "tracing",
  "windows-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,10 +651,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "bytecount"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad152d03a2c813c80bb94fedbf3a3f02b28f793e39e7c214c8a0bcc196343de7"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -678,6 +700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cadence"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39286bc075b023101dccdb79456a1334221c768b8faede0c2aff7ed29a9482d"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +729,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "ciborium"
@@ -1381,6 +1422,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,10 +1472,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1847,6 +1919,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2400,6 +2481,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "relay-base-schema"
+version = "23.10.0"
+source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
+dependencies = [
+ "relay-common",
+ "relay-protocol",
+ "serde",
+]
+
+[[package]]
+name = "relay-common"
+version = "23.10.0"
+source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
+dependencies = [
+ "chrono",
+ "globset",
+ "lru",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "sentry-types 0.31.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "relay-log"
+version = "23.10.0"
+source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
+dependencies = [
+ "sentry-core 0.31.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+]
+
+[[package]]
+name = "relay-metrics"
+version = "23.10.0"
+source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "hash32",
+ "itertools",
+ "relay-base-schema",
+ "relay-common",
+ "relay-log",
+ "relay-statsd",
+ "relay-system",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "relay-protocol"
+version = "23.10.0"
+source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
+dependencies = [
+ "num-traits",
+ "relay-common",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "unicase",
+ "uuid",
+]
+
+[[package]]
+name = "relay-statsd"
+version = "23.10.0"
+source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
+dependencies = [
+ "cadence",
+ "crossbeam-channel",
+ "parking_lot",
+ "rand 0.8.5",
+ "relay-log",
+]
+
+[[package]]
+name = "relay-system"
+version = "23.10.0"
+source = "git+https://github.com/getsentry/relay#e188c586f81a641a00596a7b39ff87802e835e77"
+dependencies = [
+ "futures",
+ "once_cell",
+ "relay-log",
+ "relay-statsd",
+ "tokio",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,7 +2814,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2656,7 +2830,7 @@ dependencies = [
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
- "sentry-core",
+ "sentry-core 0.31.7",
  "sentry-debug-images",
  "sentry-log",
  "sentry-panic",
@@ -2676,62 +2850,64 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "actix-web",
  "futures",
  "futures-util",
  "sentry",
- "sentry-core",
+ "sentry-core 0.31.7",
  "tokio",
 ]
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "anyhow",
  "sentry",
  "sentry-backtrace",
- "sentry-core",
+ "sentry-core 0.31.7",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "backtrace",
  "once_cell",
  "regex",
- "sentry-core",
+ "sentry-core 0.31.7",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "hostname",
  "libc",
  "os_info",
  "rustc_version 0.4.0",
  "sentry",
- "sentry-core",
+ "sentry-core 0.31.7",
  "uname",
 ]
 
 [[package]]
 name = "sentry-core"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "anyhow",
+ "cadence",
  "criterion",
  "futures",
  "log",
  "once_cell",
  "rand 0.8.5",
  "rayon",
+ "relay-metrics",
  "sentry",
- "sentry-types",
+ "sentry-types 0.31.7",
  "serde",
  "serde_json",
  "thiserror",
@@ -2740,40 +2916,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentry-core"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f51264e4013ed9b16558cce43917b983fa38170de2ca480349ceb57d71d6053"
+dependencies = [
+ "once_cell",
+ "sentry-types 0.31.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sentry-debug-images"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "findshlibs",
  "once_cell",
- "sentry-core",
+ "sentry-core 0.31.7",
 ]
 
 [[package]]
 name = "sentry-log"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "log",
  "pretty_env_logger",
  "sentry",
- "sentry-core",
+ "sentry-core 0.31.7",
 ]
 
 [[package]]
 name = "sentry-panic"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "sentry",
  "sentry-backtrace",
- "sentry-core",
+ "sentry-core 0.31.7",
 ]
 
 [[package]]
 name = "sentry-slog"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "erased-serde",
  "sentry",
- "sentry-core",
+ "sentry-core 0.31.7",
  "serde",
  "serde_json",
  "slog",
@@ -2781,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -2790,7 +2978,7 @@ dependencies = [
  "prost",
  "sentry",
  "sentry-anyhow",
- "sentry-core",
+ "sentry-core 0.31.7",
  "tokio",
  "tonic",
  "tower",
@@ -2801,12 +2989,12 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.31.6"
+version = "0.31.7"
 dependencies = [
  "log",
  "sentry",
  "sentry-backtrace",
- "sentry-core",
+ "sentry-core 0.31.7",
  "tokio",
  "tracing",
  "tracing-core",
@@ -2815,7 +3003,24 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.31.6"
+version = "0.31.7"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.28",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e663b3eb62ddfc023c9cf5432daf5f1a4f6acb1df4d78dd80b740b32dd1a740"
 dependencies = [
  "debugid",
  "hex",
@@ -2992,6 +3197,9 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3313,6 +3521,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.4",
  "tokio-macros",
+ "tracing",
  "windows-sys",
 ]
 

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -26,7 +26,8 @@ client = ["rand"]
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["dep:log"]
 test = ["client"]
-UNSTABLE_metrics = ["dep:cadence", "sentry-types/UNSTABLE_metrics"]
+UNSTABLE_metrics = ["sentry-types/UNSTABLE_metrics"]
+UNSTABLE_cadence = ["dep:cadence", "UNSTABLE_metrics"]
 
 [dependencies]
 cadence = { version = "0.29.0", optional = true }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -26,11 +26,14 @@ client = ["rand"]
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["dep:log"]
 test = ["client"]
+UNSTABLE_metrics = ["dep:relay-metrics", "dep:cadence"]
 
 [dependencies]
+cadence = { version = "0.29.0", optional = true }
 log = { version = "0.4.8", optional = true, features = ["std"] }
 once_cell = "1"
 rand = { version = "0.8.1", optional = true }
+relay-metrics = { git = "https://github.com/getsentry/relay", optional = true }
 sentry-types = { version = "0.31.7", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0.46" }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -26,14 +26,13 @@ client = ["rand"]
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["dep:log"]
 test = ["client"]
-UNSTABLE_metrics = ["dep:relay-metrics", "dep:cadence"]
+UNSTABLE_metrics = ["dep:cadence", "sentry-types/UNSTABLE_metrics"]
 
 [dependencies]
 cadence = { version = "0.29.0", optional = true }
 log = { version = "0.4.8", optional = true, features = ["std"] }
 once_cell = "1"
 rand = { version = "0.8.1", optional = true }
-relay-metrics = { git = "https://github.com/getsentry/relay", optional = true }
 sentry-types = { version = "0.31.7", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0.46" }

--- a/sentry-core/src/cadence.rs
+++ b/sentry-core/src/cadence.rs
@@ -147,7 +147,7 @@ mod tests {
         assert_eq!(envelopes.len(), 1);
 
         let mut items = envelopes[0].items();
-        let Some(EnvelopeItem::Metrics(metrics)) = items.next() else {
+        let Some(EnvelopeItem::Statsd(metrics)) = items.next() else {
             panic!("expected metrics");
         };
         let metrics = std::str::from_utf8(metrics).unwrap();

--- a/sentry-core/src/cadence.rs
+++ b/sentry-core/src/cadence.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use cadence::MetricSink;
+
+use crate::{Client, Hub};
+
+/// A [`cadence`] compatible [`MetricSink`].
+///
+/// This will ingest all the emitted metrics to Sentry as well as forward them
+/// to the inner [`MetricSink`].
+#[derive(Debug)]
+pub struct SentryMetricSink<S> {
+    client: Arc<Client>,
+    sink: S,
+}
+
+impl<S> SentryMetricSink<S> {
+    /// Creates a new [`SentryMetricSink`], wrapping the given [`MetricSink`].
+    pub fn try_new(sink: S) -> Result<Self, S> {
+        let hub = Hub::current();
+        let Some(client) = hub.client() else {
+            return Err(sink);
+        };
+
+        Ok(Self { client, sink })
+    }
+}
+
+impl<S> MetricSink for SentryMetricSink<S>
+where
+    S: MetricSink,
+{
+    fn emit(&self, metric: &str) -> std::io::Result<usize> {
+        self.client.add_metric(metric);
+        self.sink.emit(metric)
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        if self.client.flush(None) {
+            self.sink.flush()
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Flushing Client failed",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cadence::{Counted, Distributed};
+    use sentry_types::protocol::latest::EnvelopeItem;
+
+    use crate::test::with_captured_envelopes;
+
+    use super::*;
+
+    #[test]
+    fn test_basic_metrics() {
+        let envelopes = with_captured_envelopes(|| {
+            let sink = SentryMetricSink::try_new(cadence::NopMetricSink).unwrap();
+
+            let client = cadence::StatsdClient::from_sink("sentry.test", sink);
+            client.count("some.count", 1).unwrap();
+            client.count("some.count", 10).unwrap();
+            client
+                .count_with_tags("count.with.tags", 1)
+                .with_tag("foo", "bar")
+                .send();
+            client.distribution("some.distr", 1).unwrap();
+            client.distribution("some.distr", 2).unwrap();
+            client.distribution("some.distr", 3).unwrap();
+        });
+        assert_eq!(envelopes.len(), 1);
+
+        let mut items = envelopes[0].items();
+        let Some(EnvelopeItem::Metrics(metrics)) = items.next() else {
+            panic!("expected metrics");
+        };
+        let metrics = std::str::from_utf8(metrics).unwrap();
+
+        println!("{metrics}");
+
+        assert!(metrics.contains("sentry.test.count.with.tags:1|c|#foo:bar|T"));
+        assert!(metrics.contains("sentry.test.some.count:11|c|T"));
+        assert!(metrics.contains("sentry.test.some.distr:1:2:3|d|T"));
+        assert_eq!(items.next(), None);
+    }
+}

--- a/sentry-core/src/cadence.rs
+++ b/sentry-core/src/cadence.rs
@@ -17,12 +17,10 @@ pub struct SentryMetricSink<S> {
 impl<S> SentryMetricSink<S> {
     /// Creates a new [`SentryMetricSink`], wrapping the given [`MetricSink`].
     pub fn try_new(sink: S) -> Result<Self, S> {
-        let hub = Hub::current();
-        let Some(client) = hub.client() else {
-            return Err(sink);
-        };
-
-        Ok(Self { client, sink })
+        match Hub::current().client() {
+            Some(client) => Ok(Self { client, sink }),
+            None => Err(sink),
+        }
     }
 }
 

--- a/sentry-core/src/cadence.rs
+++ b/sentry-core/src/cadence.rs
@@ -1,50 +1,122 @@
+//! [`cadence`] integration for Sentry.
+//!
+//! [`cadence`] is a popular Statsd client for Rust. The [`SentryMetricSink`] provides a drop-in
+//! integration to send metrics captured via `cadence` to Sentry. For direct usage of Sentry
+//! metrics, see the [`metrics`](crate::metrics) module.
+//!
+//! # Usage
+//!
+//! To use the `cadence` integration, enable the `UNSTABLE_cadence` feature in your `Cargo.toml`.
+//! Then, create a [`SentryMetricSink`] and pass it to your `cadence` client:
+//!
+//! ```
+//! use cadence::StatsdClient;
+//! use sentry::cadence::SentryMetricSink;
+//!
+//! let client = StatsdClient::from_sink("sentry.test", SentryMetricSink::new());
+//! ```
+//!
+//! # Side-by-side Usage
+//!
+//! If you want to send metrics to Sentry and another backend at the same time, you can use
+//! [`SentryMetricSink::wrap`] to wrap another [`MetricSink`]:
+//!
+//! ```
+//! use cadence::{StatsdClient, NopMetricSink};
+//! use sentry::cadence::SentryMetricSink;
+//!
+//! let sink = SentryMetricSink::wrap(NopMetricSink);
+//! let client = StatsdClient::from_sink("sentry.test", sink);
+//! ```
+
 use std::sync::Arc;
 
-use cadence::MetricSink;
+use cadence::{MetricSink, NopMetricSink};
 
 use crate::metrics::Metric;
 use crate::{Client, Hub};
 
-/// A [`cadence`] compatible [`MetricSink`].
+/// A [`MetricSink`] that sends metrics to Sentry.
 ///
-/// This will ingest all the emitted metrics to Sentry as well as forward them
-/// to the inner [`MetricSink`].
+/// This metric sends all metrics to Sentry. The Sentry client is internally buffered, so submission
+/// will be delayed.
+///
+/// Optionally, this sink can also forward metrics to another [`MetricSink`]. This is useful if you
+/// want to send metrics to Sentry and another backend at the same time. Use
+/// [`SentryMetricSink::wrap`] to construct such a sink.
 #[derive(Debug)]
-pub struct SentryMetricSink<S> {
-    client: Arc<Client>,
+pub struct SentryMetricSink<S = NopMetricSink> {
+    client: Option<Arc<Client>>,
     sink: S,
 }
 
-impl<S> SentryMetricSink<S> {
+impl<S> SentryMetricSink<S>
+where
+    S: MetricSink,
+{
     /// Creates a new [`SentryMetricSink`], wrapping the given [`MetricSink`].
-    pub fn try_new(sink: S) -> Result<Self, S> {
-        match Hub::current().client() {
-            Some(client) => Ok(Self { client, sink }),
-            None => Err(sink),
+    pub fn wrap(sink: S) -> Self {
+        Self { client: None, sink }
+    }
+
+    /// Creates a new [`SentryMetricSink`] sending data to the given [`Client`].
+    pub fn with_client(mut self, client: Arc<Client>) -> Self {
+        self.client = Some(client);
+        self
+    }
+}
+
+impl SentryMetricSink {
+    /// Creates a new [`SentryMetricSink`].
+    ///
+    /// It is not required that a client is available when this sink is created. The sink sends
+    /// metrics to the client of the Sentry hub that is registered when the metrics are emitted.
+    pub fn new() -> Self {
+        Self {
+            client: None,
+            sink: NopMetricSink,
         }
     }
 }
 
-impl<S> MetricSink for SentryMetricSink<S>
-where
-    S: MetricSink,
-{
+impl Default for SentryMetricSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricSink for SentryMetricSink {
     fn emit(&self, string: &str) -> std::io::Result<usize> {
         if let Ok(metric) = Metric::parse_statsd(string) {
-            self.client.add_metric(metric);
+            if let Some(ref client) = self.client {
+                client.add_metric(metric);
+            } else if let Some(client) = Hub::current().client() {
+                client.add_metric(metric);
+            }
         }
 
+        // NopMetricSink returns `0`, which is correct as Sentry is buffering the metrics.
         self.sink.emit(string)
     }
 
     fn flush(&self) -> std::io::Result<()> {
-        if self.client.flush(None) {
-            self.sink.flush()
+        let flushed = if let Some(ref client) = self.client {
+            client.flush(None)
+        } else if let Some(client) = Hub::current().client() {
+            client.flush(None)
         } else {
+            true
+        };
+
+        let sink_result = self.sink.flush();
+
+        if !flushed {
             Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "Flushing Client failed",
+                "failed to flush metrics to Sentry",
             ))
+        } else {
+            sink_result
         }
     }
 }
@@ -61,9 +133,7 @@ mod tests {
     #[test]
     fn test_basic_metrics() {
         let envelopes = with_captured_envelopes(|| {
-            let sink = SentryMetricSink::try_new(cadence::NopMetricSink).unwrap();
-
-            let client = cadence::StatsdClient::from_sink("sentry.test", sink);
+            let client = cadence::StatsdClient::from_sink("sentry.test", SentryMetricSink::new());
             client.count("some.count", 1).unwrap();
             client.count("some.count", 10).unwrap();
             client

--- a/sentry-core/src/cadence.rs
+++ b/sentry-core/src/cadence.rs
@@ -71,7 +71,7 @@ fn parse_metric(string: &str) -> Option<Metric> {
 
     for component in components {
         if let Some('#') = component.chars().next() {
-            for pair in string.get(1..)?.split(',') {
+            for pair in component.get(1..)?.split(',') {
                 let mut key_value = pair.splitn(2, ':');
 
                 let key = key_value.next()?.to_owned();

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -322,6 +322,7 @@ impl Client {
         }
     }
 
+    /// Captures a metric and sends it to Sentry after a short delay.
     #[cfg(feature = "UNSTABLE_metrics")]
     pub fn add_metric(&self, metric: metrics::Metric) {
         if let Some(ref aggregator) = *self.metric_aggregator.read().unwrap() {

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -70,7 +70,10 @@ impl Clone for Client {
             self.options.session_mode,
         )));
         #[cfg(feature = "UNSTABLE_metrics")]
-        let metric_aggregator = RwLock::new(Some(MetricAggregator::new(transport.clone())));
+        let metric_aggregator = RwLock::new(Some(MetricAggregator::new(
+            transport.clone(),
+            &self.options,
+        )));
         Client {
             options: self.options.clone(),
             transport,
@@ -146,7 +149,8 @@ impl Client {
         )));
 
         #[cfg(feature = "UNSTABLE_metrics")]
-        let metric_aggregator = RwLock::new(Some(MetricAggregator::new(transport.clone())));
+        let metric_aggregator =
+            RwLock::new(Some(MetricAggregator::new(transport.clone(), &options)));
 
         Client {
             options,

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -340,8 +340,8 @@ impl Client {
             flusher.flush();
         }
         #[cfg(feature = "UNSTABLE_metrics")]
-        if let Some(ref flusher) = *self.metric_aggregator.read().unwrap() {
-            flusher.flush();
+        if let Some(ref aggregator) = *self.metric_aggregator.read().unwrap() {
+            aggregator.flush();
         }
         if let Some(ref transport) = *self.transport.read().unwrap() {
             transport.flush(timeout.unwrap_or(self.options.shutdown_timeout))

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -12,7 +12,7 @@ use sentry_types::random_uuid;
 
 use crate::constants::SDK_INFO;
 #[cfg(feature = "UNSTABLE_metrics")]
-use crate::metrics::MetricAggregator;
+use crate::metrics::{self, MetricAggregator};
 use crate::protocol::{ClientSdkInfo, Event};
 use crate::session::SessionFlusher;
 use crate::types::{Dsn, Uuid};
@@ -323,7 +323,7 @@ impl Client {
     }
 
     #[cfg(feature = "UNSTABLE_metrics")]
-    pub(crate) fn add_metric(&self, metric: &str) {
+    pub fn add_metric(&self, metric: metrics::Metric) {
         if let Some(ref aggregator) = *self.metric_aggregator.read().unwrap() {
             aggregator.add(metric)
         }

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -326,7 +326,7 @@ impl Client {
         }
     }
 
-    /// Captures a metric and sends it to Sentry after a short delay.
+    /// Captures a metric and sends it to Sentry on the next flush.
     #[cfg(feature = "UNSTABLE_metrics")]
     pub fn add_metric(&self, metric: metrics::Metric) {
         if let Some(ref aggregator) = *self.metric_aggregator.read().unwrap() {

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -11,7 +11,7 @@ use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 /// The central object that can manages scopes and clients.
 ///
 /// This can be used to capture events and manage the scope.  This object is
-/// [`Send`][std::marker::Send] and [`Sync`][std::marker::Sync] so it can be used from
+/// [`Send`] and [`Sync`] so it can be used from
 /// multiple threads if needed.
 ///
 /// Each thread has its own thread-local ( see [`Hub::current`]) hub, which is

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -147,6 +147,8 @@ mod metrics;
 mod session;
 #[cfg(feature = "client")]
 pub use crate::client::Client;
+#[cfg(all(feature = "client", feature = "UNSTABLE_metrics"))]
+pub use crate::metrics::SentryMetricSink;
 
 // test utilities
 #[cfg(feature = "test")]

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -144,7 +144,7 @@ mod client;
 #[cfg(feature = "client")]
 mod hub_impl;
 #[cfg(all(feature = "client", feature = "UNSTABLE_metrics"))]
-mod metrics;
+pub mod metrics;
 #[cfg(feature = "client")]
 mod session;
 #[cfg(all(feature = "client", feature = "UNSTABLE_metrics"))]

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -137,7 +137,7 @@ pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 
 #[cfg(all(feature = "client", feature = "UNSTABLE_cadence"))]
-mod cadence;
+pub mod cadence;
 // client feature
 #[cfg(feature = "client")]
 mod client;
@@ -149,8 +149,6 @@ pub mod metrics;
 mod session;
 #[cfg(all(feature = "client", feature = "UNSTABLE_metrics"))]
 mod units;
-#[cfg(all(feature = "client", feature = "UNSTABLE_cadence"))]
-pub use crate::cadence::SentryMetricSink;
 #[cfg(feature = "client")]
 pub use crate::client::Client;
 

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -136,6 +136,8 @@ pub use crate::performance::*;
 pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
 
+#[cfg(all(feature = "client", feature = "UNSTABLE_cadence"))]
+mod cadence;
 // client feature
 #[cfg(feature = "client")]
 mod client;
@@ -145,10 +147,10 @@ mod hub_impl;
 mod metrics;
 #[cfg(feature = "client")]
 mod session;
+#[cfg(all(feature = "client", feature = "UNSTABLE_cadence"))]
+pub use crate::cadence::SentryMetricSink;
 #[cfg(feature = "client")]
 pub use crate::client::Client;
-#[cfg(all(feature = "client", feature = "UNSTABLE_metrics"))]
-pub use crate::metrics::SentryMetricSink;
 
 // test utilities
 #[cfg(feature = "test")]

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -141,6 +141,8 @@ pub use crate::transport::{Transport, TransportFactory};
 mod client;
 #[cfg(feature = "client")]
 mod hub_impl;
+#[cfg(all(feature = "client", feature = "UNSTABLE_metrics"))]
+mod metrics;
 #[cfg(feature = "client")]
 mod session;
 #[cfg(feature = "client")]

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -147,6 +147,8 @@ mod hub_impl;
 mod metrics;
 #[cfg(feature = "client")]
 mod session;
+#[cfg(all(feature = "client", feature = "UNSTABLE_metrics"))]
+mod units;
 #[cfg(all(feature = "client", feature = "UNSTABLE_cadence"))]
 pub use crate::cadence::SentryMetricSink;
 #[cfg(feature = "client")]

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use sentry_types::protocol::latest::{Envelope, EnvelopeItem};
 
 use crate::client::TransportArc;
+use crate::Hub;
 
 use crate::units::DurationUnit;
 pub use crate::units::MetricUnit;
@@ -343,6 +344,12 @@ impl MetricBuilder {
 
     pub fn finish(self) -> Metric {
         self.metric
+    }
+
+    pub fn send(self) {
+        if let Some(client) = Hub::current().client() {
+            client.add_metric(self.finish());
+        }
     }
 }
 

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -1,21 +1,47 @@
-use relay_metrics::{Bucket, UnixTimestamp};
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{sync_channel, Receiver, RecvTimeoutError, SyncSender};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use cadence::MetricSink;
+use sentry_types::protocol::latest::{Envelope, EnvelopeItem};
 
 use crate::client::TransportArc;
-use crate::Client;
+use crate::{Client, Hub};
 
-pub struct SentryMetricSink {
-    client: Client,
+#[derive(Debug)]
+pub struct SentryMetricSink<S> {
+    client: Arc<Client>,
+    sink: S,
 }
 
-impl cadence::MetricSink for SentryMetricSink {
+impl<S> SentryMetricSink<S> {
+    pub fn try_new(sink: S) -> Result<Self, S> {
+        let hub = Hub::current();
+        let Some(client) = hub.client() else {
+            return Err(sink);
+        };
+
+        Ok(Self { client, sink })
+    }
+}
+
+impl<S> MetricSink for SentryMetricSink<S>
+where
+    S: MetricSink,
+{
     fn emit(&self, metric: &str) -> std::io::Result<usize> {
         self.client.send_metric(metric);
-        Ok(metric.len())
+        self.sink.emit(metric)
     }
 
     fn flush(&self) -> std::io::Result<()> {
         if self.client.flush(None) {
-            Ok(())
+            self.sink.flush()
         } else {
             Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
@@ -25,18 +51,345 @@ impl cadence::MetricSink for SentryMetricSink {
     }
 }
 
-pub struct MetricFlusher {
-    transport: TransportArc,
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum MetricType {
+    Counter,
+    Distribution,
+    Set,
+    Gauge,
 }
+
+impl MetricType {
+    /// Return the shortcode for this metric type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MetricType::Counter => "c",
+            MetricType::Distribution => "d",
+            MetricType::Set => "s",
+            MetricType::Gauge => "g",
+        }
+    }
+}
+
+impl fmt::Display for MetricType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for MetricType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "c" | "m" => Self::Counter,
+            "h" | "d" | "ms" => Self::Distribution,
+            "s" => Self::Set,
+            "g" => Self::Gauge,
+            _ => return Err(()),
+        })
+    }
+}
+
+struct GaugeValue {
+    last: f64,
+    min: f64,
+    max: f64,
+    sum: f64,
+    count: u64,
+}
+enum BucketValue {
+    Counter(f64),
+    Distribution(Vec<f64>),
+    Set(BTreeSet<u32>),
+    Gauge(GaugeValue),
+}
+impl BucketValue {
+    fn distribution(val: f64) -> BucketValue {
+        Self::Distribution(vec![val])
+    }
+
+    fn gauge(val: f64) -> BucketValue {
+        Self::Gauge(GaugeValue {
+            last: val,
+            min: val,
+            max: val,
+            sum: val,
+            count: 1,
+        })
+    }
+
+    fn set_from_str(value: &str) -> BucketValue {
+        todo!()
+    }
+
+    fn merge(&mut self, other: BucketValue) -> Result<(), ()> {
+        match (self, other) {
+            (BucketValue::Counter(c1), BucketValue::Counter(c2)) => {
+                *c1 += c2;
+            }
+            (BucketValue::Distribution(d1), BucketValue::Distribution(d2)) => {
+                d1.extend(d2);
+            }
+            (BucketValue::Set(s1), BucketValue::Set(s2)) => s1.extend(s2),
+            (BucketValue::Gauge(g1), BucketValue::Gauge(g2)) => {
+                g1.last = g2.last;
+                g1.min = g1.min.min(g2.min);
+                g1.max = g1.max.max(g2.max);
+                g1.sum += g2.sum;
+                g1.count += g2.count;
+            }
+            _ => return Err(()),
+        }
+        Ok(())
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct BucketKey {
+    timestamp: u64,
+    ty: MetricType,
+    name: String,
+    tags: String,
+}
+
+type AggregateMetrics = BTreeMap<BucketKey, BucketValue>;
+
+enum Task {
+    SendMetrics((BucketKey, BucketValue)),
+    Flush,
+    Shutdown,
+}
+
+pub struct MetricFlusher {
+    sender: SyncSender<Task>,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+const FLUSH_INTERVAL: Duration = Duration::from_secs(10);
 
 impl MetricFlusher {
     pub fn new(transport: TransportArc) -> Self {
-        Self { transport }
+        let (sender, receiver) = sync_channel(30);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_worker = shutdown.clone();
+        let handle = thread::Builder::new()
+            .name("sentry-metrics".into())
+            .spawn(move || Self::worker_thread(receiver, shutdown_worker, transport))
+            .ok();
+
+        Self {
+            sender,
+            shutdown,
+            handle,
+        }
     }
 
     pub fn send_metric(&self, metric: &str) {
-        let parsed_metric = Bucket::parse(metric.as_bytes(), UnixTimestamp::now());
+        fn mk_value(ty: MetricType, value: &str) -> Option<BucketValue> {
+            Some(match ty {
+                MetricType::Counter => BucketValue::Counter(value.parse().ok()?),
+                MetricType::Distribution => BucketValue::distribution(value.parse().ok()?),
+                MetricType::Set => BucketValue::set_from_str(value),
+                MetricType::Gauge => BucketValue::gauge(value.parse().ok()?),
+            })
+        }
+
+        fn parse(metric: &str) -> Option<(BucketKey, BucketValue)> {
+            let mut components = metric.split('|');
+            let mut values = components.next()?.split(':');
+            let name = values.next()?;
+
+            let ty: MetricType = components.next().and_then(|s| s.parse().ok())?;
+            let mut value = mk_value(ty, values.next()?)?;
+
+            for value_s in values {
+                value.merge(mk_value(ty, value_s)?).ok()?;
+            }
+
+            let mut tags = "";
+            let mut timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            for component in components {
+                if let Some(component_tags) = component.strip_prefix('#') {
+                    tags = component_tags;
+                } else if let Some(component_timestamp) = component.strip_prefix('T') {
+                    timestamp = component_timestamp.parse().ok()?;
+                }
+            }
+
+            Some((
+                BucketKey {
+                    timestamp,
+                    ty,
+                    name: name.into(),
+                    tags: tags.into(),
+                },
+                value,
+            ))
+        }
+
+        if let Some(parsed_metric) = parse(metric) {
+            let _ = self.sender.send(Task::SendMetrics(parsed_metric));
+        }
     }
 
-    pub fn flush(&self) {}
+    pub fn flush(&self) {
+        let _ = self.sender.send(Task::Flush);
+    }
+
+    fn worker_thread(receiver: Receiver<Task>, shutdown: Arc<AtomicBool>, transport: TransportArc) {
+        let mut buckets = AggregateMetrics::new();
+        let mut last_flush = Instant::now();
+
+        loop {
+            if shutdown.load(Ordering::SeqCst) {
+                Self::flush_buckets(buckets, &transport);
+                return;
+            }
+
+            let timeout = FLUSH_INTERVAL
+                .checked_sub(last_flush.elapsed())
+                .unwrap_or_else(|| Duration::from_secs(0));
+
+            match receiver.recv_timeout(timeout) {
+                Err(RecvTimeoutError::Timeout) | Ok(Task::Flush) => {
+                    // flush
+                    Self::flush_buckets(std::mem::take(&mut buckets), &transport);
+                    last_flush = Instant::now();
+                }
+                Ok(Task::SendMetrics((mut key, value))) => {
+                    // aggregate
+                    let rounding_interval = FLUSH_INTERVAL.as_secs();
+                    let rounded_timestamp = (key.timestamp / rounding_interval) * rounding_interval;
+
+                    key.timestamp = rounded_timestamp;
+
+                    match buckets.entry(key) {
+                        Entry::Occupied(mut entry) => {
+                            let _ = entry.get_mut().merge(value);
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(value);
+                        }
+                    }
+                }
+                _ => {
+                    // shutdown
+                    Self::flush_buckets(buckets, &transport);
+                    return;
+                }
+            }
+        }
+    }
+
+    fn flush_buckets(buckets: AggregateMetrics, transport: &TransportArc) {
+        fn format_payload(buckets: AggregateMetrics) -> std::io::Result<Vec<u8>> {
+            use std::io::Write;
+            let mut out = vec![];
+            for (key, value) in buckets {
+                write!(&mut out, "{}", key.name)?;
+
+                match value {
+                    BucketValue::Counter(c) => {
+                        write!(&mut out, ":{}", c)?;
+                    }
+                    BucketValue::Distribution(d) => {
+                        for v in d {
+                            write!(&mut out, ":{}", v)?;
+                        }
+                    }
+                    BucketValue::Set(s) => {
+                        for v in s {
+                            write!(&mut out, ":{}", v)?;
+                        }
+                    }
+                    BucketValue::Gauge(g) => {
+                        write!(
+                            &mut out,
+                            ":{}:{}:{}:{}:{}",
+                            g.last, g.min, g.max, g.sum, g.count
+                        )?;
+                    }
+                }
+
+                write!(&mut out, "|{}", key.ty.as_str())?;
+                if !key.tags.is_empty() {
+                    write!(&mut out, "|#{}", key.tags)?;
+                }
+                writeln!(&mut out, "|T{}", key.timestamp)?;
+            }
+
+            Ok(out)
+        }
+
+        let Ok(output) = format_payload(buckets) else {
+            return;
+        };
+
+        let mut envelope = Envelope::new();
+        envelope.add_item(EnvelopeItem::Metrics(output));
+
+        if let Some(ref transport) = *transport.read().unwrap() {
+            transport.send_envelope(envelope);
+        }
+    }
+}
+
+impl Drop for MetricFlusher {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.sender.send(Task::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            handle.join().unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::from_utf8;
+
+    use cadence::{Counted, Distributed};
+
+    use crate::test::with_captured_envelopes;
+
+    use super::*;
+
+    #[test]
+    fn test_basic_metrics() {
+        let envelopes = with_captured_envelopes(|| {
+            let sink = SentryMetricSink::try_new(cadence::NopMetricSink).unwrap();
+
+            let client = cadence::StatsdClient::from_sink("sentry.test", sink);
+            client.count("some.count", 1).unwrap();
+            client.count("some.count", 10).unwrap();
+            client
+                .count_with_tags("count.with.tags", 1)
+                .with_tag("foo", "bar")
+                .send();
+            client.distribution("some.distr", 1).unwrap();
+            client.distribution("some.distr", 2).unwrap();
+            client.distribution("some.distr", 3).unwrap();
+        });
+        assert_eq!(envelopes.len(), 1);
+
+        let mut items = envelopes[0].items();
+        if let Some(EnvelopeItem::Metrics(metrics)) = items.next() {
+            let metrics = from_utf8(metrics).unwrap();
+
+            println!("{metrics}");
+
+            assert!(metrics.contains("sentry.test.count.with.tags:1|c|#foo:bar|T"));
+            assert!(metrics.contains("sentry.test.some.count:11|c|T"));
+            assert!(metrics.contains("sentry.test.some.distr:1:2:3|d|T"));
+        } else {
+            panic!("expected metrics");
+        }
+        assert_eq!(items.next(), None);
+    }
 }

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -590,6 +590,16 @@ impl Metric {
     pub fn gauge(name: impl Into<MetricStr>, value: f64) -> MetricBuilder {
         Self::build(name, MetricValue::Gauge(value))
     }
+
+    /// Sends the metric to the current client.
+    ///
+    /// When building a metric, you can use [`MetricBuilder::send`] to send the metric directly. If
+    /// there is no client on the current [`Hub`], the metric is dropped.
+    pub fn send(self) {
+        if let Some(client) = Hub::current().client() {
+            client.add_metric(self);
+        }
+    }
 }
 
 /// A builder for metrics.
@@ -644,11 +654,10 @@ impl MetricBuilder {
 
     /// Sends the metric to the current client.
     ///
-    /// If there is no client on the current [`Hub`], the metric is dropped.
+    /// This is a shorthand for `.finish().send()`. If there is no client on the current [`Hub`],
+    /// the metric is dropped.
     pub fn send(self) {
-        if let Some(client) = Hub::current().client() {
-            client.add_metric(self.finish());
-        }
+        self.finish().send()
     }
 }
 

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -448,7 +448,10 @@ impl MetricAggregator {
         let mut out = vec![];
 
         for (key, value) in buckets.into_iter().flat_map(|(_, v)| v) {
-            write!(&mut out, "{}@{}", SafeKey(key.name.as_ref()), key.unit)?;
+            write!(&mut out, "{}", SafeKey(key.name.as_ref()))?;
+            if key.unit != MetricUnit::None {
+                write!(&mut out, "@{}", key.unit)?;
+            }
 
             match value {
                 BucketValue::Counter(c) => {

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -458,6 +458,7 @@ impl SharedAggregatorState {
 ///     client.add_metric(metric);
 /// }
 /// ```
+#[derive(Debug)]
 pub struct Metric {
     /// The name of the metric, identifying it in Sentry.
     ///
@@ -609,6 +610,7 @@ impl Metric {
 /// Use one of the [`Metric`] constructors to create a new builder. See the struct-level docs for
 /// examples of how to build metrics.
 #[must_use]
+#[derive(Debug)]
 pub struct MetricBuilder {
     metric: Metric,
 }

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -758,7 +758,7 @@ impl Worker {
         // case throw away the result rather than blocking the transport for too long.
         if let Ok(output) = self.format_payload(buckets) {
             let mut envelope = Envelope::new();
-            envelope.add_item(EnvelopeItem::Metrics(output));
+            envelope.add_item(EnvelopeItem::Statsd(output));
 
             if let Some(ref transport) = *self.transport.read().unwrap() {
                 transport.send_envelope(envelope);
@@ -970,7 +970,7 @@ mod tests {
         assert_eq!(envelopes.len(), 1, "expected exactly one envelope");
 
         let mut items = envelopes[0].items();
-        let Some(EnvelopeItem::Metrics(payload)) = items.next() else {
+        let Some(EnvelopeItem::Statsd(payload)) = items.next() else {
             panic!("expected metrics item");
         };
 

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -293,6 +293,10 @@ impl MetricFlusher {
     }
 
     fn flush_buckets(buckets: AggregateMetrics, transport: &TransportArc) {
+        if buckets.is_empty() {
+            return;
+        }
+
         fn format_payload(buckets: AggregateMetrics) -> std::io::Result<Vec<u8>> {
             use std::io::Write;
             let mut out = vec![];

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -1,0 +1,42 @@
+use relay_metrics::{Bucket, UnixTimestamp};
+
+use crate::client::TransportArc;
+use crate::Client;
+
+pub struct SentryMetricSink {
+    client: Client,
+}
+
+impl cadence::MetricSink for SentryMetricSink {
+    fn emit(&self, metric: &str) -> std::io::Result<usize> {
+        self.client.send_metric(metric);
+        Ok(metric.len())
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        if self.client.flush(None) {
+            Ok(())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Flushing Client failed",
+            ))
+        }
+    }
+}
+
+pub struct MetricFlusher {
+    transport: TransportArc,
+}
+
+impl MetricFlusher {
+    pub fn new(transport: TransportArc) -> Self {
+        Self { transport }
+    }
+
+    pub fn send_metric(&self, metric: &str) {
+        let parsed_metric = Bucket::parse(metric.as_bytes(), UnixTimestamp::now());
+    }
+
+    pub fn flush(&self) {}
+}

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -252,11 +252,6 @@ impl MetricFlusher {
         let mut last_flush = Instant::now();
 
         loop {
-            if shutdown.load(Ordering::SeqCst) {
-                Self::flush_buckets(buckets, &transport);
-                return;
-            }
-
             let timeout = FLUSH_INTERVAL.saturating_sub(last_flush.elapsed());
 
             match receiver.recv_timeout(timeout) {
@@ -286,6 +281,11 @@ impl MetricFlusher {
                     Self::flush_buckets(buckets, &transport);
                     return;
                 }
+            }
+
+            if shutdown.load(Ordering::SeqCst) {
+                Self::flush_buckets(buckets, &transport);
+                return;
             }
         }
     }

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -1,3 +1,9 @@
+//! Utilities to track metrics in Sentry.
+//!
+//! Metrics allow you to track the custom values related to the behavior and performance of your
+//! application and send them to Sentry. See [`Metric`] for more information on how to build and
+//! capture metrics.
+
 use std::borrow::Cow;
 use std::collections::hash_map::{DefaultHasher, Entry};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -11,15 +17,130 @@ use sentry_types::protocol::latest::{Envelope, EnvelopeItem};
 use crate::client::TransportArc;
 use crate::Hub;
 
-use crate::units::DurationUnit;
-pub use crate::units::MetricUnit;
+pub use crate::units::*;
 
 const BUCKET_INTERVAL: Duration = Duration::from_secs(10);
 const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 const MAX_WEIGHT: usize = 100_000;
 
+/// Type alias for strings used in [`Metric`] for names and tags.
+pub type MetricStr = Cow<'static, str>;
+
+/// Type used for [`MetricValue::Counter`].
+pub type CounterType = f64;
+
+/// Type used for [`MetricValue::Distribution`].
+pub type DistributionType = f64;
+
+/// Type used for [`MetricValue::Set`].
+pub type SetType = u32;
+
+/// Type used for [`MetricValue::Gauge`].
+pub type GaugeType = f64;
+
+/// The value of a [`Metric`], indicating its type.
+#[derive(Debug)]
+pub enum MetricValue {
+    /// Counts instances of an event.
+    ///
+    /// Counters can be incremented and decremented. The default operation is to increment a counter
+    /// by `1`, although increments by larger values and even floating point values are possible.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric, MetricValue};
+    ///
+    /// Metric::build("my.counter", MetricValue::Counter(1.0)).send();
+    /// ```
+    Counter(CounterType),
+
+    /// Builds a statistical distribution over values reported.
+    ///
+    /// Based on individual reported values, distributions allow to query the maximum, minimum, or
+    /// average of the reported values, as well as statistical quantiles. With an increasing number
+    /// of values in the distribution, its accuracy becomes approximate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric, MetricValue};
+    ///
+    /// Metric::build("my.distribution", MetricValue::Distribution(42.0)).send();
+    /// ```
+    Distribution(DistributionType),
+
+    /// Counts the number of unique reported values.
+    ///
+    /// Sets allow sending arbitrary discrete values, including strings, and store the deduplicated
+    /// count. With an increasing number of unique values in the set, its accuracy becomes
+    /// approximate. It is not possible to query individual values from a set.
+    ///
+    /// # Example
+    ///
+    /// To create a set value, use [`MetricValue::set_from_str`] or
+    /// [`MetricValue::set_from_display`]. These functions convert the provided argument into a
+    /// unique hash value, which is then used as the set value.
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric, MetricValue};
+    ///
+    /// Metric::build("my.set", MetricValue::set_from_str("foo")).send();
+    /// ```
+    Set(SetType),
+
+    /// Stores absolute snapshots of values.
+    ///
+    /// In addition to plain [counters](Self::Counter), gauges store a snapshot of the maximum,
+    /// minimum and sum of all values, as well as the last reported value. Note that the "last"
+    /// component of this aggregation is not commutative. Which value is preserved as last value is
+    /// implementation-defined.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric, MetricValue};
+    ///
+    /// Metric::build("my.gauge", MetricValue::Gauge(42.0)).send();
+    /// ```
+    Gauge(GaugeType),
+}
+
+impl MetricValue {
+    /// Returns a set value representing the given string.
+    pub fn set_from_str(string: &str) -> Self {
+        Self::Set(hash_set_value(string))
+    }
+
+    /// Returns a set value representing the given argument.
+    pub fn set_from_display(display: impl fmt::Display) -> Self {
+        Self::Set(hash_set_value(&display.to_string()))
+    }
+
+    /// Returns the type of the metric value.
+    fn ty(&self) -> MetricType {
+        match self {
+            Self::Counter(_) => MetricType::Counter,
+            Self::Distribution(_) => MetricType::Distribution,
+            Self::Gauge(_) => MetricType::Gauge,
+            Self::Set(_) => MetricType::Set,
+        }
+    }
+}
+
+/// Hashes the given set value.
+///
+/// Sets only guarantee 32-bit accuracy, but arbitrary strings are allowed on the protocol. Upon
+/// parsing, they are hashed and only used as hashes subsequently.
+fn hash_set_value(string: &str) -> u32 {
+    use std::hash::Hasher;
+    let mut hasher = DefaultHasher::default();
+    hasher.write(string.as_bytes());
+    hasher.finish() as u32
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) enum MetricType {
+enum MetricType {
     Counter,
     Distribution,
     Set,
@@ -58,21 +179,9 @@ impl std::str::FromStr for MetricType {
     }
 }
 
-/// Type used for Counter metric
-pub type CounterType = f64;
-
-/// Type of distribution entries
-pub type DistributionType = f64;
-
-/// Type used for set elements in Set metric
-pub type SetType = u32;
-
-/// Type used for Gauge entries
-pub type GaugeType = f64;
-
 /// A snapshot of values.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GaugeValue {
+struct GaugeValue {
     /// The last value reported in the bucket.
     ///
     /// This aggregation is not commutative.
@@ -109,6 +218,7 @@ impl GaugeValue {
     }
 }
 
+/// The aggregated value of a [`Metric`] bucket.
 enum BucketValue {
     Counter(CounterType),
     Distribution(Vec<DistributionType>),
@@ -117,6 +227,7 @@ enum BucketValue {
 }
 
 impl BucketValue {
+    /// Inserts a new value into the bucket and returns the added weight.
     pub fn insert(&mut self, value: MetricValue) -> usize {
         match (self, value) {
             (Self::Counter(c1), MetricValue::Counter(c2)) => {
@@ -142,6 +253,7 @@ impl BucketValue {
         }
     }
 
+    /// Returns the number of values stored in this bucket.
     pub fn weight(&self) -> usize {
         match self {
             BucketValue::Counter(_) => 1,
@@ -163,10 +275,10 @@ impl From<MetricValue> for BucketValue {
     }
 }
 
-pub type MetricStr = Cow<'static, str>;
-
+/// UNIX timestamp used for buckets.
 type Timestamp = u64;
 
+/// Composite bucket key for [`BucketMap`].
 #[derive(PartialEq, Eq, Hash)]
 struct BucketKey {
     timestamp: Timestamp,
@@ -176,46 +288,15 @@ struct BucketKey {
     tags: BTreeMap<MetricStr, MetricStr>,
 }
 
-#[derive(Debug)]
-pub enum MetricValue {
-    Counter(CounterType),
-    Distribution(DistributionType),
-    Gauge(GaugeType),
-    Set(SetType),
-}
-
-impl MetricValue {
-    /// Returns a bucket value representing a set with a single given string value.
-    pub fn set_from_str(string: &str) -> Self {
-        Self::Set(hash_set_value(string))
-    }
-
-    /// Returns a bucket value representing a set with a single given value.
-    pub fn set_from_display(display: impl fmt::Display) -> Self {
-        Self::Set(hash_set_value(&display.to_string()))
-    }
-
-    fn ty(&self) -> MetricType {
-        match self {
-            Self::Counter(_) => MetricType::Counter,
-            Self::Distribution(_) => MetricType::Distribution,
-            Self::Gauge(_) => MetricType::Gauge,
-            Self::Set(_) => MetricType::Set,
-        }
-    }
-}
-
-/// Hashes the given set value.
+/// A nested map storing metric buckets.
 ///
-/// Sets only guarantee 32-bit accuracy, but arbitrary strings are allowed on the protocol. Upon
-/// parsing, they are hashed and only used as hashes subsequently.
-fn hash_set_value(string: &str) -> u32 {
-    use std::hash::Hasher;
-    let mut hasher = DefaultHasher::default();
-    hasher.write(string.as_bytes());
-    hasher.finish() as u32
-}
-
+/// This map consists of two levels:
+///  1. The rounded UNIX timestamp of buckets.
+///  2. The metric buckets themselves with a corresponding timestamp.
+///
+/// This structure allows for efficient dequeueing of buckets that are older than a certain
+/// threshold. The buckets are dequeued in order of their timestamp, so the oldest buckets are
+/// dequeued first.
 type BucketMap = BTreeMap<Timestamp, HashMap<BucketKey, BucketValue>>;
 
 struct AggregatorInner {
@@ -235,6 +316,10 @@ impl AggregatorInner {
         }
     }
 
+    /// Adds a new bucket to the aggregator.
+    ///
+    /// The bucket timestamp is rounded to the nearest bucket interval. Note that this does NOT
+    /// automatically flush the aggregator if the weight exceeds the weight threshold.
     pub fn add(&mut self, mut key: BucketKey, value: MetricValue) {
         // Floor timestamp to bucket interval
         key.timestamp /= BUCKET_INTERVAL.as_secs();
@@ -246,6 +331,10 @@ impl AggregatorInner {
         }
     }
 
+    /// Removes and returns all buckets that are ready to flush.
+    ///
+    /// Buckets are ready to flush as soon as their time window has closed. For example, a bucket
+    /// from timestamps `[4600, 4610)` is ready to flush immediately at `4610`.
     pub fn take_buckets(&mut self) -> BucketMap {
         if self.force_flush || !self.running {
             self.weight = 0;
@@ -255,7 +344,7 @@ impl AggregatorInner {
             let timestamp = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
-                .saturating_sub(FLUSH_INTERVAL)
+                .saturating_sub(BUCKET_INTERVAL)
                 .as_secs();
 
             // Split all buckets after the cutoff time. `split` contains newer buckets, which should
@@ -278,7 +367,58 @@ impl AggregatorInner {
     }
 }
 
+/// A metric value that contains a numeric value and metadata to be sent to Sentry.
+///
+/// # Units
+///
+/// To make the most out of metrics in Sentry, consider assigning a unit during construction. This
+/// can be achieved using the [`with_unit`](MetricBuilder::with_unit) builder method.
+///
+/// ```
+/// use sentry::metrics::{Metric, MetricUnit, InformationUnit};
+///
+/// Metric::distribution("request.size", 47.2)
+///     .with_unit(MetricUnit::Information(InformationUnit::Byte))
+///     .send();
+/// ```
+///
+/// # Sending Metrics
+///
+/// Metrics can be sent to Sentry directly using the [`send`](MetricBuilder::send) method on the
+/// constructor. This will send the metric to the [`Client`](crate::Client) on the current [`Hub`].
+/// If there is no client on the current hub, the metric is dropped.
+///
+/// ```
+/// use sentry::metrics::Metric;
+///
+/// Metric::count("requests")
+///     .with_tag("method", "GET")
+///     .send();
+/// ```
+///
+/// # Sending to a Custom Client
+///
+/// Metrics can also be sent to a custom client. This is useful if you want to send metrics to a
+/// different Sentry project or with different configuration. To do so, finish building the metric
+/// and then add it to the client:
+///
+/// ```
+/// use sentry::Hub;
+/// use sentry::metrics::Metric;
+///
+/// let metric = Metric::count("requests")
+///    .with_tag("method", "GET")
+///    .finish();
+///
+/// // Obtain a client from somewhere
+/// if let Some(client) = Hub::current().client() {
+///     client.add_metric(metric);
+/// }
+/// ```
 pub struct Metric {
+    /// The name of the metric, identifying it in Sentry.
+    ///
+    /// The name should consist of
     name: MetricStr,
     unit: MetricUnit,
     value: MetricValue,
@@ -287,6 +427,15 @@ pub struct Metric {
 }
 
 impl Metric {
+    /// Creates a new metric with the stated name and value.
+    ///
+    /// The provided name identifies the metric in Sentry. It should consist of alphanumeric
+    /// characters and `_`, `-`, and `.`. While a single forward slash (`/`) is also allowed in
+    /// metric names, it has a special meaning and should not be used in regular metric names. All
+    /// characters that do not match this criteria are sanitized.
+    ///
+    /// The value of the metric determines its type. See the [struct-level](self) docs and
+    /// constructor methods for examples on how to build metrics.
     pub fn build(name: impl Into<MetricStr>, value: MetricValue) -> MetricBuilder {
         let metric = Metric {
             name: name.into(),
@@ -299,57 +448,162 @@ impl Metric {
         MetricBuilder { metric }
     }
 
+    /// Parses a metric from a StatsD string.
+    ///
+    /// This supports regular StatsD payloads with an extension for tags. In the below example, tags
+    /// are optional:
+    ///
+    /// ```plain
+    /// <metricname>:<value>|<type>|#<tag1>:<value1>,<tag2>:<value2>
+    /// ```
+    ///
+    /// Units are encoded into the metric name, separated by an `@`:
+    ///
+    /// ```plain
+    /// <metricname>@<unit>:<value>|<type>|#<tag1>:<value1>,<tag2>:<value2>
+    /// ```
     pub fn parse_statsd(string: &str) -> Result<Self, ParseMetricError> {
         parse_metric_opt(string).ok_or(ParseMetricError(()))
     }
 
-    pub fn incr(name: impl Into<MetricStr>) -> MetricBuilder {
+    /// Builds a metric that increments a [counter](MetricValue::Counter) by the given value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric};
+    ///
+    /// Metric::incr("operation.total_values", 7.0).send();
+    /// ```
+    pub fn incr(name: impl Into<MetricStr>, value: f64) -> MetricBuilder {
+        Self::build(name, MetricValue::Counter(value))
+    }
+
+    /// Builds a metric that [counts](MetricValue::Counter) the single occurrence of an event.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric};
+    ///
+    /// Metric::count("requests").send();
+    /// ```
+    pub fn count(name: impl Into<MetricStr>) -> MetricBuilder {
         Self::build(name, MetricValue::Counter(1.0))
     }
 
+    /// Builds a metric that tracks the duration of an operation.
+    ///
+    /// This is a [distribution](MetricValue::Distribution) metric that is tracked in seconds.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use sentry::metrics::{Metric};
+    ///
+    /// Metric::timing("operation", Duration::from_secs(1)).send();
+    /// ```
     pub fn timing(name: impl Into<MetricStr>, timing: Duration) -> MetricBuilder {
         Self::build(name, MetricValue::Distribution(timing.as_secs_f64()))
             .with_unit(MetricUnit::Duration(DurationUnit::Second))
     }
 
+    /// Builds a metric that tracks the [distribution](MetricValue::Distribution) of values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric};
+    ///
+    /// Metric::distribution("operation.batch_size", 42.0).send();
+    /// ```
     pub fn distribution(name: impl Into<MetricStr>, value: f64) -> MetricBuilder {
         Self::build(name, MetricValue::Distribution(value))
     }
 
+    /// Builds a metric that tracks the [unique number](MetricValue::Set) of values provided.
+    ///
+    /// See [`MetricValue`] for more ways to construct sets.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric};
+    ///
+    /// Metric::set("users", "user1").send();
+    /// ```
     pub fn set(name: impl Into<MetricStr>, string: &str) -> MetricBuilder {
         Self::build(name, MetricValue::set_from_str(string))
     }
 
+    /// Builds a metric that tracks the [snapshot](MetricValue::Gauge) of provided values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sentry::metrics::{Metric};
+    ///
+    /// Metric::gauge("cache.size", 42.0).send();
+    /// ```
     pub fn gauge(name: impl Into<MetricStr>, value: f64) -> MetricBuilder {
         Self::build(name, MetricValue::Gauge(value))
     }
 }
 
+/// A builder for metrics.
+///
+/// Use one of the [`Metric`] constructors to create a new builder. See the struct-level docs for
+/// examples of how to build metrics.
 #[must_use]
 pub struct MetricBuilder {
     metric: Metric,
 }
 
 impl MetricBuilder {
+    /// Sets the unit for the metric.
+    ///
+    /// The unit augments the metric value by giving it a magnitude and semantics. Some units have
+    /// special support when rendering metrics or their values in Sentry, such as for timings. See
+    /// [`MetricUnit`] for more information on the supported units. The unit can be set to
+    /// [`MetricUnit::None`] to indicate that the metric has no unit, or to [`MetricUnit::Custom`]
+    /// to indicate a user-defined unit.
+    ///
+    /// By default, the unit is set to [`MetricUnit::None`].
     pub fn with_unit(mut self, unit: MetricUnit) -> Self {
         self.metric.unit = unit;
         self
     }
 
+    /// Adds a tag to the metric.
+    ///
+    /// Tags allow you to add dimensions to metrics. They are key-value pairs that can be filtered
+    /// or grouped by in Sentry.
+    ///
+    /// When sent to Sentry via [`MetricBuilder::send`] or when added to a
+    /// [`Client`](crate::Client), the client may add default tags to the metrics, such as the
+    /// `release` or the `environment` from the Scope.
     pub fn with_tag(mut self, name: impl Into<MetricStr>, value: impl Into<MetricStr>) -> Self {
         self.metric.tags.insert(name.into(), value.into());
         self
     }
 
+    /// Sets the timestamp for the metric.
+    ///
+    /// By default, the timestamp is set to the current time when the metric is built or sent.
     pub fn with_time(mut self, time: SystemTime) -> Self {
         self.metric.time = Some(time);
         self
     }
 
+    /// Builds the metric.
     pub fn finish(self) -> Metric {
         self.metric
     }
 
+    /// Sends the metric to the current client.
+    ///
+    /// If there is no client on the current [`Hub`], the metric is dropped.
     pub fn send(self) {
         if let Some(client) = Hub::current().client() {
             client.add_metric(self.finish());
@@ -357,6 +611,7 @@ impl MetricBuilder {
     }
 }
 
+/// Error emitted from [`Metric::parse_statsd`] for invalid metric strings.
 #[derive(Debug)]
 pub struct ParseMetricError(());
 
@@ -403,7 +658,7 @@ fn parse_metric_opt(string: &str) -> Option<Metric> {
     Some(builder.finish())
 }
 
-pub struct MetricAggregator {
+pub(crate) struct MetricAggregator {
     inner: Arc<Mutex<AggregatorInner>>,
     handle: Option<JoinHandle<()>>,
 }

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -13,6 +13,10 @@ use sentry_types::protocol::latest::{Envelope, EnvelopeItem};
 use crate::client::TransportArc;
 use crate::{Client, Hub};
 
+/// A [`cadence`] compatible [`MetricSink`].
+///
+/// This will ingest all the emitted metrics to Sentry as well as forward them
+/// to the inner [`MetricSink`].
 #[derive(Debug)]
 pub struct SentryMetricSink<S> {
     client: Arc<Client>,
@@ -20,6 +24,7 @@ pub struct SentryMetricSink<S> {
 }
 
 impl<S> SentryMetricSink<S> {
+    /// Creates a new [`SentryMetricSink`], wrapping the given [`MetricSink`].
     pub fn try_new(sink: S) -> Result<Self, S> {
         let hub = Hub::current();
         let Some(client) = hub.client() else {
@@ -101,7 +106,7 @@ struct GaugeValue {
 enum BucketValue {
     Counter(f64),
     Distribution(Vec<f64>),
-    Set(BTreeSet<u32>),
+    Set(BTreeSet<String>),
     Gauge(GaugeValue),
 }
 impl BucketValue {
@@ -120,7 +125,7 @@ impl BucketValue {
     }
 
     fn set_from_str(value: &str) -> BucketValue {
-        todo!()
+        BucketValue::Set([value.into()].into())
     }
 
     fn merge(&mut self, other: BucketValue) -> Result<(), ()> {

--- a/sentry-core/src/units.rs
+++ b/sentry-core/src/units.rs
@@ -6,10 +6,12 @@ use std::fmt;
 /// The unit of measurement of a metric value.
 ///
 /// Units augment metric values by giving them a magnitude and semantics. There are certain types of
-/// units that are subdivided in their precision, such as the [`DurationUnit`] for time
-/// measurements.
+/// units that are subdivided in their precision:
+///  - [`DurationUnit`]: time durations
+///  - [`InformationUnit`]: sizes of information
+///  - [`FractionUnit`]: fractions
 ///
-/// Units and their precisions are uniquely represented by a string identifier.
+/// You are not restricted to these units, but can use any `&'static str` or `String` as a unit.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub enum MetricUnit {
     /// A time duration, defaulting to `"millisecond"`.

--- a/sentry-core/src/units.rs
+++ b/sentry-core/src/units.rs
@@ -1,0 +1,293 @@
+//! Type definitions for Sentry metrics.
+
+use std::fmt;
+
+/// The unit of measurement of a metric value.
+///
+/// Units augment metric values by giving them a magnitude and semantics. There are certain types of
+/// units that are subdivided in their precision, such as the [`DurationUnit`] for time
+/// measurements.
+///
+/// Units and their precisions are uniquely represented by a string identifier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default)]
+pub enum MetricUnit {
+    /// A time duration, defaulting to `"millisecond"`.
+    Duration(DurationUnit),
+    /// Size of information derived from bytes, defaulting to `"byte"`.
+    Information(InformationUnit),
+    /// Fractions such as percentages, defaulting to `"ratio"`.
+    Fraction(FractionUnit),
+    /// user-defined units without builtin conversion or default.
+    Custom(CustomUnit),
+    /// Untyped value without a unit (`""`).
+    #[default]
+    None,
+}
+
+impl MetricUnit {
+    /// Returns `true` if the metric_unit is [`None`].
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+impl fmt::Display for MetricUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MetricUnit::Duration(u) => u.fmt(f),
+            MetricUnit::Information(u) => u.fmt(f),
+            MetricUnit::Fraction(u) => u.fmt(f),
+            MetricUnit::Custom(u) => u.fmt(f),
+            MetricUnit::None => f.write_str("none"),
+        }
+    }
+}
+
+impl std::str::FromStr for MetricUnit {
+    type Err = ParseMetricUnitError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "nanosecond" | "ns" => Self::Duration(DurationUnit::NanoSecond),
+            "microsecond" => Self::Duration(DurationUnit::MicroSecond),
+            "millisecond" | "ms" => Self::Duration(DurationUnit::MilliSecond),
+            "second" | "s" => Self::Duration(DurationUnit::Second),
+            "minute" => Self::Duration(DurationUnit::Minute),
+            "hour" => Self::Duration(DurationUnit::Hour),
+            "day" => Self::Duration(DurationUnit::Day),
+            "week" => Self::Duration(DurationUnit::Week),
+
+            "bit" => Self::Information(InformationUnit::Bit),
+            "byte" => Self::Information(InformationUnit::Byte),
+            "kilobyte" => Self::Information(InformationUnit::KiloByte),
+            "kibibyte" => Self::Information(InformationUnit::KibiByte),
+            "megabyte" => Self::Information(InformationUnit::MegaByte),
+            "mebibyte" => Self::Information(InformationUnit::MebiByte),
+            "gigabyte" => Self::Information(InformationUnit::GigaByte),
+            "gibibyte" => Self::Information(InformationUnit::GibiByte),
+            "terabyte" => Self::Information(InformationUnit::TeraByte),
+            "tebibyte" => Self::Information(InformationUnit::TebiByte),
+            "petabyte" => Self::Information(InformationUnit::PetaByte),
+            "pebibyte" => Self::Information(InformationUnit::PebiByte),
+            "exabyte" => Self::Information(InformationUnit::ExaByte),
+            "exbibyte" => Self::Information(InformationUnit::ExbiByte),
+
+            "ratio" => Self::Fraction(FractionUnit::Ratio),
+            "percent" => Self::Fraction(FractionUnit::Percent),
+
+            "" | "none" => Self::None,
+            _ => Self::Custom(CustomUnit::parse(s)?),
+        })
+    }
+}
+
+/// Time duration units used in [`MetricUnit::Duration`].
+///
+/// Defaults to `millisecond`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum DurationUnit {
+    /// Nanosecond (`"nanosecond"`), 10^-9 seconds.
+    NanoSecond,
+    /// Microsecond (`"microsecond"`), 10^-6 seconds.
+    MicroSecond,
+    /// Millisecond (`"millisecond"`), 10^-3 seconds.
+    MilliSecond,
+    /// Full second (`"second"`).
+    Second,
+    /// Minute (`"minute"`), 60 seconds.
+    Minute,
+    /// Hour (`"hour"`), 3600 seconds.
+    Hour,
+    /// Day (`"day"`), 86,400 seconds.
+    Day,
+    /// Week (`"week"`), 604,800 seconds.
+    Week,
+}
+
+impl Default for DurationUnit {
+    fn default() -> Self {
+        Self::MilliSecond
+    }
+}
+
+impl fmt::Display for DurationUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NanoSecond => f.write_str("nanosecond"),
+            Self::MicroSecond => f.write_str("microsecond"),
+            Self::MilliSecond => f.write_str("millisecond"),
+            Self::Second => f.write_str("second"),
+            Self::Minute => f.write_str("minute"),
+            Self::Hour => f.write_str("hour"),
+            Self::Day => f.write_str("day"),
+            Self::Week => f.write_str("week"),
+        }
+    }
+}
+
+/// An error parsing a [`MetricUnit`] or one of its variants.
+#[derive(Clone, Copy, Debug)]
+pub struct ParseMetricUnitError(());
+
+/// Size of information derived from bytes, used in [`MetricUnit::Information`].
+///
+/// Defaults to `byte`. See also [Units of
+/// information](https://en.wikipedia.org/wiki/Units_of_information).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum InformationUnit {
+    /// Bit (`"bit"`), corresponding to 1/8 of a byte.
+    ///
+    /// Note that there are computer systems with a different number of bits per byte.
+    Bit,
+    /// Byte (`"byte"`).
+    Byte,
+    /// Kilobyte (`"kilobyte"`), 10^3 bytes.
+    KiloByte,
+    /// Kibibyte (`"kibibyte"`), 2^10 bytes.
+    KibiByte,
+    /// Megabyte (`"megabyte"`), 10^6 bytes.
+    MegaByte,
+    /// Mebibyte (`"mebibyte"`), 2^20 bytes.
+    MebiByte,
+    /// Gigabyte (`"gigabyte"`), 10^9 bytes.
+    GigaByte,
+    /// Gibibyte (`"gibibyte"`), 2^30 bytes.
+    GibiByte,
+    /// Terabyte (`"terabyte"`), 10^12 bytes.
+    TeraByte,
+    /// Tebibyte (`"tebibyte"`), 2^40 bytes.
+    TebiByte,
+    /// Petabyte (`"petabyte"`), 10^15 bytes.
+    PetaByte,
+    /// Pebibyte (`"pebibyte"`), 2^50 bytes.
+    PebiByte,
+    /// Exabyte (`"exabyte"`), 10^18 bytes.
+    ExaByte,
+    /// Exbibyte (`"exbibyte"`), 2^60 bytes.
+    ExbiByte,
+}
+
+impl Default for InformationUnit {
+    fn default() -> Self {
+        Self::Byte
+    }
+}
+
+impl fmt::Display for InformationUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bit => f.write_str("bit"),
+            Self::Byte => f.write_str("byte"),
+            Self::KiloByte => f.write_str("kilobyte"),
+            Self::KibiByte => f.write_str("kibibyte"),
+            Self::MegaByte => f.write_str("megabyte"),
+            Self::MebiByte => f.write_str("mebibyte"),
+            Self::GigaByte => f.write_str("gigabyte"),
+            Self::GibiByte => f.write_str("gibibyte"),
+            Self::TeraByte => f.write_str("terabyte"),
+            Self::TebiByte => f.write_str("tebibyte"),
+            Self::PetaByte => f.write_str("petabyte"),
+            Self::PebiByte => f.write_str("pebibyte"),
+            Self::ExaByte => f.write_str("exabyte"),
+            Self::ExbiByte => f.write_str("exbibyte"),
+        }
+    }
+}
+
+/// Units of fraction used in [`MetricUnit::Fraction`].
+///
+/// Defaults to `ratio`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum FractionUnit {
+    /// Floating point fraction of `1`.
+    Ratio,
+    /// Ratio expressed as a fraction of `100`. `100%` equals a ratio of `1.0`.
+    Percent,
+}
+
+impl Default for FractionUnit {
+    fn default() -> Self {
+        Self::Ratio
+    }
+}
+
+impl fmt::Display for FractionUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ratio => f.write_str("ratio"),
+            Self::Percent => f.write_str("percent"),
+        }
+    }
+}
+
+const CUSTOM_UNIT_MAX_SIZE: usize = 15;
+
+/// Custom user-defined units without builtin conversion.
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct CustomUnit([u8; CUSTOM_UNIT_MAX_SIZE]);
+
+impl CustomUnit {
+    /// Parses a `CustomUnit` from a string.
+    pub fn parse(s: &str) -> Result<Self, ParseMetricUnitError> {
+        if !s.is_ascii() {
+            return Err(ParseMetricUnitError(()));
+        }
+
+        let mut unit = Self([0; CUSTOM_UNIT_MAX_SIZE]);
+        let slice = unit.0.get_mut(..s.len()).ok_or(ParseMetricUnitError(()))?;
+        slice.copy_from_slice(s.as_bytes());
+        unit.0.make_ascii_lowercase();
+        Ok(unit)
+    }
+
+    /// Returns the string representation of this unit.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        // Safety: The string is already validated to be valid ASCII when
+        // parsing `CustomUnit`.
+        unsafe { std::str::from_utf8_unchecked(&self.0).trim_end_matches('\0') }
+    }
+}
+
+impl fmt::Debug for CustomUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl fmt::Display for CustomUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl std::str::FromStr for CustomUnit {
+    type Err = ParseMetricUnitError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl std::ops::Deref for CustomUnit {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_custom_unit_parse() {
+        assert_eq!("foo", CustomUnit::parse("Foo").unwrap().as_str());
+        assert_eq!(
+            "0123456789abcde",
+            CustomUnit::parse("0123456789abcde").unwrap().as_str()
+        );
+        assert!(CustomUnit::parse("this_is_a_unit_that_is_too_long").is_err());
+    }
+}

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 [features]
 default = ["protocol"]
 protocol = []
+UNSTABLE_metrics = []
 
 [dependencies]
 debugid = { version = "0.8.0", features = ["serde"] }

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -360,7 +360,7 @@ impl Envelope {
                     serde_json::to_writer(&mut item_buf, check_in)?
                 }
                 #[cfg(feature = "UNSTABLE_metrics")]
-                EnvelopeItem::Metrics(metrics) => item_buf.extend_from_slice(metrics.as_bytes()),
+                EnvelopeItem::Metrics(metrics) => item_buf.extend_from_slice(metrics),
                 EnvelopeItem::Raw => {
                     continue;
                 }
@@ -518,7 +518,7 @@ impl Envelope {
                 serde_json::from_slice(payload).map(EnvelopeItem::MonitorCheckIn)
             }
             #[cfg(feature = "UNSTABLE_metrics")]
-            EnvelopeItemType::Metrics => EnvelopeItem::Metrics(payload.into()),
+            EnvelopeItemType::Metrics => Ok(EnvelopeItem::Metrics(payload.into())),
         }
         .map_err(EnvelopeError::InvalidItemPayload)?;
 

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -118,7 +118,7 @@ pub enum EnvelopeItem {
     MonitorCheckIn(MonitorCheckIn),
     /// A Metrics Item.
     #[cfg(feature = "UNSTABLE_metrics")]
-    Metrics(Vec<u8>),
+    Statsd(Vec<u8>),
     /// This is a sentinel item used to `filter` raw envelopes.
     Raw,
     // TODO:
@@ -360,7 +360,7 @@ impl Envelope {
                     serde_json::to_writer(&mut item_buf, check_in)?
                 }
                 #[cfg(feature = "UNSTABLE_metrics")]
-                EnvelopeItem::Metrics(metrics) => item_buf.extend_from_slice(metrics),
+                EnvelopeItem::Statsd(statsd) => item_buf.extend_from_slice(statsd),
                 EnvelopeItem::Raw => {
                     continue;
                 }
@@ -372,7 +372,7 @@ impl Envelope {
                 EnvelopeItem::Transaction(_) => "transaction",
                 EnvelopeItem::MonitorCheckIn(_) => "check_in",
                 #[cfg(feature = "UNSTABLE_metrics")]
-                EnvelopeItem::Metrics(_) => "statsd",
+                EnvelopeItem::Statsd(_) => "statsd",
                 EnvelopeItem::Attachment(_) | EnvelopeItem::Raw => unreachable!(),
             };
             writeln!(
@@ -518,7 +518,7 @@ impl Envelope {
                 serde_json::from_slice(payload).map(EnvelopeItem::MonitorCheckIn)
             }
             #[cfg(feature = "UNSTABLE_metrics")]
-            EnvelopeItemType::Metrics => Ok(EnvelopeItem::Metrics(payload.into())),
+            EnvelopeItemType::Metrics => Ok(EnvelopeItem::Statsd(payload.into())),
         }
         .map_err(EnvelopeError::InvalidItemPayload)?;
 

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -22,6 +22,7 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 
 [features]
 default = ["backtrace", "contexts", "debug-images", "panic", "transport"]
+UNSTABLE_metrics = ["sentry-core/UNSTABLE_metrics"]
 
 # default integrations
 backtrace = ["sentry-backtrace", "sentry-tracing?/backtrace"]

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -12,6 +12,7 @@ pub struct RateLimiter {
     session: Option<SystemTime>,
     transaction: Option<SystemTime>,
     attachment: Option<SystemTime>,
+    statsd: Option<SystemTime>,
 }
 
 impl RateLimiter {
@@ -56,6 +57,7 @@ impl RateLimiter {
                     "session" => self.session = new_time,
                     "transaction" => self.transaction = new_time,
                     "attachment" => self.attachment = new_time,
+                    "statsd" => self.statsd = new_time,
                     _ => {}
                 }
             }
@@ -89,6 +91,7 @@ impl RateLimiter {
             RateLimitingCategory::Session => self.session,
             RateLimitingCategory::Transaction => self.transaction,
             RateLimitingCategory::Attachment => self.attachment,
+            RateLimitingCategory::Statsd => self.statsd,
         }?;
         time_left.duration_since(SystemTime::now()).ok()
     }
@@ -112,6 +115,7 @@ impl RateLimiter {
                 }
                 EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
                 EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
+                EnvelopeItem::Statsd(_) => RateLimitingCategory::Statsd,
                 _ => RateLimitingCategory::Any,
             })
         })
@@ -131,6 +135,8 @@ pub enum RateLimitingCategory {
     Transaction,
     /// Rate Limit pertaining to Attachments.
     Attachment,
+    /// Rate Limit pertaining to metrics.
+    Statsd,
 }
 
 #[cfg(test)]

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -115,7 +115,7 @@ impl RateLimiter {
                 }
                 EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
                 EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
-                EnvelopeItem::Statsd(_) => RateLimitingCategory::Statsd,
+                EnvelopeItem::Metrics(_) => RateLimitingCategory::Statsd,
                 _ => RateLimitingCategory::Any,
             })
         })

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -115,6 +115,7 @@ impl RateLimiter {
                 }
                 EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
                 EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
+                #[cfg(feature = "UNSTABLE_metrics")]
                 EnvelopeItem::Metrics(_) => RateLimitingCategory::Statsd,
                 _ => RateLimitingCategory::Any,
             })
@@ -136,6 +137,7 @@ pub enum RateLimitingCategory {
     /// Rate Limit pertaining to Attachments.
     Attachment,
     /// Rate Limit pertaining to metrics.
+    #[allow(unused)]
     Statsd,
 }
 

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -116,7 +116,7 @@ impl RateLimiter {
                 EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
                 EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
                 #[cfg(feature = "UNSTABLE_metrics")]
-                EnvelopeItem::Metrics(_) => RateLimitingCategory::Statsd,
+                EnvelopeItem::Statsd(_) => RateLimitingCategory::Statsd,
                 _ => RateLimitingCategory::Any,
             })
         })
@@ -157,8 +157,8 @@ mod tests {
 
         rl.update_from_sentry_header(
             r#"
-                30::bar, 
-                120:invalid:invalid, 
+                30::bar,
+                120:invalid:invalid,
                 4711:foo;bar;baz;security:project
             "#,
         );


### PR DESCRIPTION
This adds:
- A new `statsd` EnvelopeItem
- A new `MetricAggregator` which is implemented similarly to the Python prototype implementation 
- The Client instantiates a metric flusher and starts it in the background
- A `Metric` type that allows building and sending metrics, which is the primary user-facing API
- A `cadence`-compatible `SentryMetricSink` that makes it easier to integrate Sentry into existing environments
- Internal types that are mostly adapted from `relay-metrics`

This PR does not yet include support for code locations and span linking; both will follow at a later stage.