### PR TITLE
MonitorSchedule constructor that validates crontab syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1385,12 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -2400,6 +2412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "relative-path"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+
+[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2472,35 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.32",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2820,6 +2867,7 @@ dependencies = [
  "debugid",
  "hex",
  "rand 0.8.5",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror",

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -30,3 +30,6 @@ thiserror = "1.0.15"
 time = { version = "0.3.5", features = ["formatting", "parsing"] }
 url = { version = "2.1.1", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["serde"] }
+
+[dev-dependencies]
+rstest = "0.18.2"

--- a/sentry-types/src/crontab_validator.rs
+++ b/sentry-types/src/crontab_validator.rs
@@ -1,12 +1,4 @@
-use std::fmt::{self, Display};
 use std::ops::RangeInclusive;
-use std::{collections::HashSet, error::Error};
-
-#[derive(PartialEq, Eq, Hash)]
-enum CronToken<'a> {
-    Numeric(u64),
-    Alphabetic(&'a str),
-}
 
 struct SegmentAllowedValues<'a> {
     /// Range of permitted numeric values
@@ -69,7 +61,7 @@ fn validate_step(step: &str) -> bool {
 }
 
 fn validate_steprange(steprange: &str, allowed_values: &SegmentAllowedValues) -> bool {
-    let mut steprange_split = steprange.splitn(2, "/");
+    let mut steprange_split = steprange.splitn(2, '/');
     let range_is_valid = match steprange_split.next() {
         Some(range) => validate_range(range, allowed_values),
         None => false,
@@ -90,8 +82,8 @@ fn validate_listitem(listitem: &str, allowed_values: &SegmentAllowedValues) -> b
 }
 
 fn validate_list(list: &str, allowed_values: &SegmentAllowedValues) -> bool {
-    list.split(",")
-        .all(|listitem| validate_listitem(listitem, &allowed_values))
+    list.split(',')
+        .all(|listitem| validate_listitem(listitem, allowed_values))
 }
 
 fn validate_segment(segment: &str, allowed_values: &SegmentAllowedValues) -> bool {

--- a/sentry-types/src/crontab_validator.rs
+++ b/sentry-types/src/crontab_validator.rs
@@ -99,8 +99,6 @@ pub fn validate(crontab: &str) -> bool {
         return false;
     }
 
-    //let x: Box<dyn Error> = Box::new(CrontabParseError {});
-
     lists
         .iter()
         .zip(ALLOWED_VALUES)

--- a/sentry-types/src/crontab_validator.rs
+++ b/sentry-types/src/crontab_validator.rs
@@ -45,10 +45,9 @@ fn validate_range(range: &str, allowed_values: &SegmentAllowedValues) -> bool {
     let range_limits: Vec<_> = range.split('-').map(str::parse::<u64>).collect();
 
     range_limits.len() == 2
-        && range_limits.iter().all(|limit| {
-            limit
-                .as_ref()
-                .is_ok_and(|limit| allowed_values.numeric_range.contains(limit))
+        && range_limits.iter().all(|limit| match limit {
+            Ok(limit) => allowed_values.numeric_range.contains(limit),
+            Err(_) => false,
         })
         && range_limits[0].as_ref().unwrap() <= range_limits[1].as_ref().unwrap()
 }

--- a/sentry-types/src/crontab_validator.rs
+++ b/sentry-types/src/crontab_validator.rs
@@ -1,0 +1,79 @@
+use std::collections::HashSet;
+
+#[derive(PartialEq, Eq, Hash)]
+enum CronToken<'a> {
+    Numeric(u64),
+    Alphabetic(&'a str),
+}
+
+const MONTHS: &[&str] = &[
+    "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+];
+
+const DAYS: &[&str] = &["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+
+fn value_is_allowed(value: &str, allowed_values: &HashSet<CronToken>) -> bool {
+    match value.parse::<u64>() {
+        Ok(numeric_value) => allowed_values.contains(&CronToken::Numeric(numeric_value)),
+        Err(_) => allowed_values.contains(&CronToken::Alphabetic(&value.to_lowercase())),
+    }
+}
+
+fn validate_range(range: &str, allowed_values: &HashSet<CronToken>) -> bool {
+    range == "*"
+        || range // TODO: Validate that the last range bound is after the previous one.
+            .splitn(2, "-")
+            .all(|bound| value_is_allowed(bound, allowed_values))
+}
+
+/// A valid step is None or Some positive value
+fn validate_step(step: &Option<&str>) -> bool {
+    match *step {
+        Some(value) => match value.parse::<u64>() {
+            Ok(value) => value > 0,
+            Err(_) => false,
+        },
+        None => true,
+    }
+}
+
+fn validate_steprange(steprange: &str, allowed_values: &HashSet<CronToken>) -> bool {
+    let mut steprange_split = steprange.splitn(2, "/");
+    let range = match steprange_split.next() {
+        Some(range) => range,
+        None => {
+            return false;
+        }
+    };
+    let range_is_valid = validate_range(range, allowed_values);
+    let step = steprange_split.next();
+
+    range_is_valid && validate_step(&step)
+}
+
+fn validate_segment(segment: &str, allowed_values: &HashSet<CronToken>) -> bool {
+    segment
+        .split(",")
+        .all(|steprange| validate_steprange(steprange, &allowed_values))
+}
+
+pub fn validate(crontab: &str) -> bool {
+    let allowed_values = vec![
+        (0..60).map(CronToken::Numeric).collect(),
+        (0..24).map(CronToken::Numeric).collect(),
+        (1..32).map(CronToken::Numeric).collect(),
+        (1..13)
+            .map(CronToken::Numeric)
+            .chain(MONTHS.iter().map(|&month| CronToken::Alphabetic(month)))
+            .collect(),
+        (0..8)
+            .map(CronToken::Numeric)
+            .chain(DAYS.iter().map(|&day| CronToken::Alphabetic(day)))
+            .collect(),
+    ];
+
+    crontab
+        .split_whitespace()
+        .zip(allowed_values)
+        .all(|(segment, allowed_values)| validate_segment(segment, &allowed_values))
+}

--- a/sentry-types/src/lib.rs
+++ b/sentry-types/src/lib.rs
@@ -40,6 +40,7 @@
 mod macros;
 
 mod auth;
+mod crontab_validator;
 mod dsn;
 mod project_id;
 pub mod protocol;

--- a/sentry-types/src/protocol/monitor.rs
+++ b/sentry-types/src/protocol/monitor.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{error::Error, fmt::Display};
 
 use serde::{Deserialize, Serialize, Serializer};
 use uuid::Uuid;
@@ -26,6 +26,8 @@ impl Display for CrontabParseError {
         )
     }
 }
+
+impl Error for CrontabParseError {}
 
 impl CrontabParseError {
     /// Constructs a new CrontabParseError from a given invalid crontab string

--- a/sentry-types/src/protocol/monitor.rs
+++ b/sentry-types/src/protocol/monitor.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize, Serializer};
 use uuid::Uuid;
 
+use crate::crontab_validator;
+
 /// Represents the status of the monitor check-in
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -37,6 +39,21 @@ pub enum MonitorSchedule {
         /// The interval unit of the value.
         unit: MonitorIntervalUnit,
     },
+}
+
+impl MonitorSchedule {
+    /// Attempts to create a MonitorSchedule from a provided crontab_str. If the crontab_str is a
+    /// valid crontab schedule, we return the MonitorSchedule wrapped in a Some variant. Otherwise,
+    /// we return None.
+    pub fn from_crontab(crontab_str: &str) -> Option<Self> {
+        if crontab_validator::validate(crontab_str) {
+            Some(Self::Crontab {
+                value: String::from(crontab_str),
+            })
+        } else {
+            None
+        }
+    }
 }
 
 /// The unit for the interval schedule type


### PR DESCRIPTION
I will want to use the new `MonitorSchedule::from_crontab` in getsentry/sentry-cli#1807