### PR TITLE
fix 1-in-a-billion chance to sample with 0.0 sample rate

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -377,7 +377,7 @@ impl Client {
         if rate >= 1.0 {
             true
         } else {
-            random::<f32>() <= rate
+            random::<f32>() < rate
         }
     }
 }


### PR DESCRIPTION
The `Standard` distribution in `rand` produces a half-open range for floating points: https://docs.rs/rand/latest/rand/distributions/struct.Standard.html#floating-point-implementation. This means there is a 1-in-a-billion chance that a random number will be <= a sample rate of 0.0, even though 0.0 should disable the transactions feature.

I've actually seen this happen exactly once haha