### PR TITLE
Make regex an optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,7 +3718,7 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "actix-web",
  "futures",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "sentry",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "hostname",
  "libc",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "log",
  "pretty_env_logger",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "sentry",
  "sentry-backtrace",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-slog"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "erased-serde",
  "sentry",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "axum 0.7.1",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "log",
  "sentry",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.32.3"
+version = "0.33.0"
 dependencies = [
  "debugid",
  "hex",

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -26,7 +26,7 @@ client = ["rand"]
 # and macros actually expand features (and extern crate) where they are used!
 debug-logs = ["dep:log"]
 test = ["client"]
-UNSTABLE_metrics = ["sentry-types/UNSTABLE_metrics"]
+UNSTABLE_metrics = ["sentry-types/UNSTABLE_metrics", "regex"]
 UNSTABLE_cadence = ["dep:cadence", "UNSTABLE_metrics"]
 
 [dependencies]
@@ -36,7 +36,7 @@ itertools = "0.13.0"
 log = { version = "0.4.8", optional = true, features = ["std"] }
 once_cell = "1"
 rand = { version = "0.8.1", optional = true }
-regex = "1.7.3"
+regex = { version = "1.7.3" , optional = true}
 sentry-types = { version = "0.33.0", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0.46" }


### PR DESCRIPTION
The latest release includes `regex` and family—I'd very much like to avoid those if possible, since they are big chunky crates with slow compile times.

For now, the easiest thing seems to be to gate the inclusion of `regex` on `UNSTABLE_metrics` since it is only used in that code path.

Longer-term, I'd appreciate either reverting to the pre- #658 implementation that looks something like `c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/')` (since it's a relatively simple regex) or looking into a lighter crate like [regex-lite](https://crates.io/crates/regex-lite).