### PR TITLE
ref(client): Make prepare_event public

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -172,7 +172,8 @@ impl Client {
         integration.as_ref().as_any().downcast_ref()
     }
 
-    fn prepare_event(
+    /// Prepares an event for transmission to sentry.
+    pub fn prepare_event(
         &self,
         mut event: Event<'static>,
         scope: Option<&Scope>,


### PR DESCRIPTION
Make `prepare_event` public so that sentry-cli can use it directly instead of via `capture_event`. This allows sentry-cli to do the actual transmission (with its envelopes client), enabling debug logging and non-zero exit codes on transmission failure.