### PR TITLE
Tower and Actix: Filter out sensitive headers

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -355,6 +355,7 @@ fn sentry_request_from_http(request: &ServiceRequest, with_pii: bool) -> Request
         headers: request
             .headers()
             .iter()
+            .filter(|(_, v)| !v.is_sensitive())
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
             .collect(),
         ..Default::default()

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -142,6 +142,7 @@ where
             headers: request
                 .headers()
                 .into_iter()
+                .filter(|(_, value)| !value.is_sensitive())
                 .map(|(header, value)| {
                     (
                         header.to_string(),


### PR DESCRIPTION
I've noticed that when constructing a `sentry_core::protocol::Request`, all headers are copied even if they are marked as sensitive.

This PR filters out sensitive headers.