### PR TITLE
Don't generate a random to choose whether we should sample if sampling is fully disabled (rate = 0.0)

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -2,8 +2,7 @@ use std::any::TypeId;
 use std::borrow::Cow;
 use std::fmt;
 use std::panic::RefUnwindSafe;
-use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use rand::random;
@@ -377,6 +376,8 @@ impl Client {
     pub fn sample_should_send(&self, rate: f32) -> bool {
         if rate >= 1.0 {
             true
+        } else if rate <= 0.0 {
+            false
         } else {
             random::<f32>() < rate
         }


### PR DESCRIPTION
Hopefully this will improve const propagation and avoid making calls to rng (which may be slow) when sampling is entirely disabled anyway.