### PR TITLE
Reexport Url and Uuid in `protocol`

### DIFF
--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -18,8 +18,9 @@ use std::time::SystemTime;
 use self::debugid::{CodeId, DebugId};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
-use url::Url;
-use uuid::Uuid;
+
+pub use url::Url;
+pub use uuid::Uuid;
 
 use crate::utils::{ts_rfc3339_opt, ts_seconds_float};
 


### PR DESCRIPTION
These are required to construct some public types, so the good practice is to reexport them so that users can use them without specifying the dependency explicitly themselves and be less likely to break on update.