### PR TITLE
chore: export `BeforeCallback` type

### DIFF
--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -126,7 +126,7 @@ mod transport;
 // public api or exports from this crate
 pub use crate::api::*;
 pub use crate::breadcrumbs::IntoBreadcrumbs;
-pub use crate::clientoptions::{ClientOptions, SessionMode};
+pub use crate::clientoptions::{BeforeCallback, ClientOptions, SessionMode};
 pub use crate::error::{capture_error, event_from_error, parse_type_from_debug};
 pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;


### PR DESCRIPTION
I needed the type during sentry init for conditional callback depending on context, and ended up having to duplicate this type to pass it around. Figured it would be much better to actually import it but it is currently not possible.

Cheers