### PR TITLE
Fix `Transport::flush` implementation for `TransportThread`

### DIFF
--- a/sentry/src/transports/thread.rs
+++ b/sentry/src/transports/thread.rs
@@ -80,7 +80,7 @@ impl TransportThread {
     pub fn flush(&self, timeout: Duration) -> bool {
         let (sender, receiver) = sync_channel(1);
         let _ = self.sender.send(Task::Flush(sender));
-        receiver.recv_timeout(timeout).is_err()
+        receiver.recv_timeout(timeout).is_ok()
     }
 }
 

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -96,7 +96,7 @@ impl TransportThread {
     pub fn flush(&self, timeout: Duration) -> bool {
         let (sender, receiver) = sync_channel(1);
         let _ = self.sender.send(Task::Flush(sender));
-        receiver.recv_timeout(timeout).is_err()
+        receiver.recv_timeout(timeout).is_ok()
     }
 }
 


### PR DESCRIPTION
The PR for the [issue](https://github.com/getsentry/sentry-rust/issues/677).