### PR TITLE
fix(sentry-tracing): switch sentry spans on enter and exit

### DIFF
--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -4,6 +4,7 @@
 
 use std::sync::{Arc, RwLock};
 
+use crate::hub_impl::SwitchGuard;
 use crate::protocol::{Event, Level, SessionStatus};
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
@@ -241,5 +242,11 @@ impl Hub {
                 }
             })
         }}
+    }
+
+    #[inline(always)]
+    /// Consumes self to create switch guard, that can be used to modify current hub in thread local storage
+    pub fn into_switch_guard(self: Arc<Hub>) -> SwitchGuard {
+        crate::hub_impl::SwitchGuard::new(self)
     }
 }

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -4,7 +4,6 @@
 
 use std::sync::{Arc, RwLock};
 
-use crate::hub_impl::SwitchGuard;
 use crate::protocol::{Event, Level, SessionStatus};
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
@@ -242,11 +241,5 @@ impl Hub {
                 }
             })
         }}
-    }
-
-    #[inline(always)]
-    /// Consumes self to create switch guard, that can be used to modify current hub in thread local storage
-    pub fn into_switch_guard(self: Arc<Hub>) -> SwitchGuard {
-        crate::hub_impl::SwitchGuard::new(self)
     }
 }

--- a/sentry-core/src/hub_impl.rs
+++ b/sentry-core/src/hub_impl.rs
@@ -21,7 +21,10 @@ thread_local! {
     );
 }
 
-pub(crate) struct SwitchGuard {
+///Hub switch guard
+///
+///Used to temporarily swap active hub in thread local storage.
+pub struct SwitchGuard {
     inner: Option<(Arc<Hub>, bool)>,
 }
 

--- a/sentry-core/src/hub_impl.rs
+++ b/sentry-core/src/hub_impl.rs
@@ -21,15 +21,17 @@ thread_local! {
     );
 }
 
-///Hub switch guard
-///
-///Used to temporarily swap active hub in thread local storage.
+/// A Hub switch guard used to temporarily swap
+/// active hub in thread local storage.
 pub struct SwitchGuard {
     inner: Option<(Arc<Hub>, bool)>,
 }
 
 impl SwitchGuard {
-    pub(crate) fn new(mut hub: Arc<Hub>) -> Self {
+    /// Swaps the current thread's Hub by the one provided
+    /// and returns a guard that, when dropped, replaces it
+    /// to the previous one.
+    pub fn new(mut hub: Arc<Hub>) -> Self {
         let inner = THREAD_HUB.with(|(thread_hub, is_process_hub)| {
             // SAFETY: `thread_hub` will always be a valid thread local hub,
             // by definition not shared between threads.

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -130,6 +130,7 @@ pub use crate::clientoptions::{BeforeCallback, ClientOptions, SessionMode};
 pub use crate::error::{capture_error, event_from_error, parse_type_from_debug};
 pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
+pub use crate::hub_impl::SwitchGuard as HubSwitchGuard;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
 pub use crate::performance::*;

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -130,7 +130,6 @@ pub use crate::clientoptions::{BeforeCallback, ClientOptions, SessionMode};
 pub use crate::error::{capture_error, event_from_error, parse_type_from_debug};
 pub use crate::futures::{SentryFuture, SentryFutureExt};
 pub use crate::hub::Hub;
-pub use crate::hub_impl::SwitchGuard as HubSwitchGuard;
 pub use crate::integration::Integration;
 pub use crate::intodsn::IntoDsn;
 pub use crate::performance::*;
@@ -150,8 +149,9 @@ pub mod metrics;
 mod session;
 #[cfg(all(feature = "client", feature = "metrics"))]
 mod units;
+
 #[cfg(feature = "client")]
-pub use crate::client::Client;
+pub use crate::{client::Client, hub_impl::SwitchGuard as HubSwitchGuard};
 
 // test utilities
 #[cfg(feature = "test")]

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -717,6 +717,12 @@ impl Span {
         transaction.context.clone()
     }
 
+    /// Get the current span ID.
+    pub fn get_span_id(&self) -> protocol::SpanId {
+        let span = self.span.lock().unwrap();
+        span.span_id
+    }
+
     /// Get the status of the Span.
     pub fn get_status(&self) -> Option<protocol::SpanStatus> {
         let span = self.span.lock().unwrap();

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use sentry_core::protocol::Value;
 use sentry_core::{Breadcrumb, TransactionOrSpan};
@@ -197,6 +198,8 @@ fn record_fields<'a, K: AsRef<str> + Into<Cow<'a, str>>>(
 pub(super) struct SentrySpanData {
     pub(super) sentry_span: TransactionOrSpan,
     parent_sentry_span: Option<TransactionOrSpan>,
+    hub: Arc<sentry_core::Hub>,
+    hub_switch_guard: Option<sentry_core::HubSwitchGuard>,
 }
 
 impl<S> Layer<S> for SentryLayer<S>
@@ -256,7 +259,9 @@ where
             }
         });
 
-        let parent_sentry_span = sentry_core::configure_scope(|s| s.get_span());
+        let hub = sentry_core::Hub::current();
+        let parent_sentry_span = hub.configure_scope(|scope| scope.get_span());
+
         let sentry_span: sentry_core::TransactionOrSpan = match &parent_sentry_span {
             Some(parent) => parent.start_child(op, &description).into(),
             None => {
@@ -272,42 +277,42 @@ where
         extensions.insert(SentrySpanData {
             sentry_span,
             parent_sentry_span,
+            hub,
+            hub_switch_guard: None,
         });
     }
 
     /// Sets entered span as *current* sentry span. A tracing span can be
     /// entered and existed multiple times, for example, when using a `tracing::Instrumented` future.
     fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
-        let span = match ctx.span(&id) {
+        let span = match ctx.span(id) {
             Some(span) => span,
             None => return,
         };
 
-        let extensions = span.extensions();
-        let SentrySpanData { sentry_span, .. } = match extensions.get::<SentrySpanData>() {
-            Some(data) => data,
-            None => return,
-        };
-
-        sentry_core::configure_scope(|scope| scope.set_span(Some(sentry_span.clone())));
+        let mut extensions = span.extensions_mut();
+        if let Some(data) = extensions.get_mut::<SentrySpanData>() {
+            data.hub_switch_guard = Some(data.hub.clone().into_switch_guard());
+            data.hub.configure_scope(|scope| {
+                scope.set_span(Some(data.sentry_span.clone()));
+            })
+        }
     }
 
     /// Set exited span's parent as *current* sentry span.
     fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
-        let span = match ctx.span(&id) {
+        let span = match ctx.span(id) {
             Some(span) => span,
             None => return,
         };
 
-        let extensions = span.extensions();
-        let SentrySpanData {
-            parent_sentry_span, ..
-        } = match extensions.get::<SentrySpanData>() {
-            Some(data) => data,
-            None => return,
-        };
-
-        sentry_core::configure_scope(|scope| scope.set_span(parent_sentry_span.clone()));
+        let mut extensions = span.extensions_mut();
+        if let Some(data) = extensions.get_mut::<SentrySpanData>() {
+            data.hub.configure_scope(|scope| {
+                scope.set_span(data.parent_sentry_span.clone());
+            });
+            data.hub_switch_guard = None;
+        }
     }
 
     /// When a span gets closed, finish the underlying sentry span, and set back

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -292,7 +292,7 @@ where
 
         let mut extensions = span.extensions_mut();
         if let Some(data) = extensions.get_mut::<SentrySpanData>() {
-            data.hub_switch_guard = Some(data.hub.clone().into_switch_guard());
+            data.hub_switch_guard = Some(sentry_core::HubSwitchGuard::new(data.hub.clone()));
             data.hub.configure_scope(|scope| {
                 scope.set_span(Some(data.sentry_span.clone()));
             })
@@ -311,7 +311,7 @@ where
             data.hub.configure_scope(|scope| {
                 scope.set_span(data.parent_sentry_span.clone());
             });
-            data.hub_switch_guard = None;
+            data.hub_switch_guard.take();
         }
     }
 

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -268,13 +268,46 @@ where
         // This comes from typically the `fields` in `tracing::instrument`.
         record_fields(&sentry_span, data);
 
-        sentry_core::configure_scope(|scope| scope.set_span(Some(sentry_span.clone())));
-
         let mut extensions = span.extensions_mut();
         extensions.insert(SentrySpanData {
             sentry_span,
             parent_sentry_span,
         });
+    }
+
+    /// Sets entered span as *current* sentry span. A tracing span can be
+    /// entered and existed multiple times, for example, when using a `tracing::Instrumented` future.
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = match ctx.span(&id) {
+            Some(span) => span,
+            None => return,
+        };
+
+        let extensions = span.extensions();
+        let SentrySpanData { sentry_span, .. } = match extensions.get::<SentrySpanData>() {
+            Some(data) => data,
+            None => return,
+        };
+
+        sentry_core::configure_scope(|scope| scope.set_span(Some(sentry_span.clone())));
+    }
+
+    /// Set exited span's parent as *current* sentry span.
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = match ctx.span(&id) {
+            Some(span) => span,
+            None => return,
+        };
+
+        let extensions = span.extensions();
+        let SentrySpanData {
+            parent_sentry_span, ..
+        } = match extensions.get::<SentrySpanData>() {
+            Some(data) => data,
+            None => return,
+        };
+
+        sentry_core::configure_scope(|scope| scope.set_span(parent_sentry_span.clone()));
     }
 
     /// When a span gets closed, finish the underlying sentry span, and set back
@@ -286,16 +319,12 @@ where
         };
 
         let mut extensions = span.extensions_mut();
-        let SentrySpanData {
-            sentry_span,
-            parent_sentry_span,
-        } = match extensions.remove::<SentrySpanData>() {
+        let SentrySpanData { sentry_span, .. } = match extensions.remove::<SentrySpanData>() {
             Some(data) => data,
             None => return,
         };
 
         sentry_span.finish();
-        sentry_core::configure_scope(|scope| scope.set_span(parent_sentry_span));
     }
 
     /// Implement the writing of extra data to span


### PR DESCRIPTION
I've been facing a bug with Sentry Trace where concurrent spans end up wrongly nested. At first, I thought this was some strange autogrouping bug and event sent a feedback (sorry Sentry support member 😅).

After digging a little bit, I discovered that the current tracing layer implementation sets the sentry span as active as soon as a tracing span is _created_, which should not be the case, as spans are only active once _entered_. Following the same logic, it also reverts to the parent span only when a span is _closed_, and not when it's exited.

A span can be entered and exited multiple times, for example, when a tracing `Instrumented` future polls and returns Pending. In case of concurrent Instrumented futures, the current impl ends up nesting Futures under the first created one.

### `sentry-tracing` layer (wrong)
<img width="479" alt="Screenshot 2024-09-25 at 14 22 57" src="https://github.com/user-attachments/assets/8e5e32df-1312-459e-aa7c-89f9d852aea3">

### `tracing-opentelemetry` layer (correct)
<img width="520" alt="Screenshot 2024-09-25 at 14 28 11" src="https://github.com/user-attachments/assets/cd99db29-230a-4dec-bb3a-4398a43456d3">

> I'd say that the best idea would be to not use `sentry_core::configure_scope(|s| s.get_span());` when creating a new span to get the parent, and get it from the span extensions instead, but the current behavior might be relied upon already by someone.
