### PR TITLE
add server_name to transaction data

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -570,6 +570,7 @@ impl Transaction {
                     transaction.release.clone_from(&opts.release);
                     transaction.environment.clone_from(&opts.environment);
                     transaction.sdk = Some(std::borrow::Cow::Owned(client.sdk_info.clone()));
+                    transaction.server_name.clone_from(&opts.server_name);
 
                     drop(inner);
 

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1989,6 +1989,9 @@ pub struct Transaction<'a> {
     /// Optionally HTTP request data to be sent along.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request: Option<Request>,
+    /// Optionally the server (or device) name of this event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_name: Option<Cow<'a, str>>,
 }
 
 impl<'a> Default for Transaction<'a> {
@@ -2008,6 +2011,7 @@ impl<'a> Default for Transaction<'a> {
             spans: Default::default(),
             contexts: Default::default(),
             request: Default::default(),
+            server_name: Default::default(),
         }
     }
 }
@@ -2035,6 +2039,7 @@ impl<'a> Transaction<'a> {
             spans: self.spans,
             contexts: self.contexts,
             request: self.request,
+            server_name: self.server_name.map(|x| Cow::Owned(x.into_owned())),
         }
     }
 


### PR DESCRIPTION
Currently transactions do not include a `server_name` which makes it harder to know where a transaction occurred. 

According to the [transaction docs](https://develop.sentry.dev/sdk/event-payloads/transaction/):
>Transactions are Events enriched with Span data

And the [events docs](https://develop.sentry.dev/sdk/event-payloads/) include `server_name` so I don't see any reason not to include it. 

Perhaps in the future it might make more sense to have a common struct between the two that gets flattened (through serde) such that when `Event` gets new fields that may be useful in a `Transaction` then it'll already be there (as long as the function to enrich that hypothetical shared struct is used in both places). This, however, is outside of the scope of what I need at this time so I only did the smallest thing I needed. 