### PR TITLE
Allow settings tags directly on transactions/spans

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -260,6 +260,14 @@ impl TransactionOrSpan {
         }
     }
 
+    /// Sets a tag to a specific value.
+    pub fn set_tag<V: ToString>(&self, key: &str, value: V) {
+        match self {
+            TransactionOrSpan::Transaction(transaction) => transaction.set_tag(key, value),
+            TransactionOrSpan::Span(span) => span.set_tag(key, value),
+        }
+    }
+
     /// Get the TransactionContext of the Transaction/Span.
     ///
     /// Note that this clones the underlying value.
@@ -492,6 +500,14 @@ impl Transaction {
         }
     }
 
+    /// Sets a tag to a specific value.
+    pub fn set_tag<V: ToString>(&self, key: &str, value: V) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(transaction) = inner.transaction.as_mut() {
+            transaction.tags.insert(key.into(), value.to_string());
+        }
+    }
+
     /// Returns an iterating accessor to the transaction's
     /// [`extra` field](protocol::Transaction::extra).
     ///
@@ -643,6 +659,12 @@ impl Span {
     pub fn set_data(&self, key: &str, value: protocol::Value) {
         let mut span = self.span.lock().unwrap();
         span.data.insert(key.into(), value);
+    }
+
+    /// Sets a tag to a specific value.
+    pub fn set_tag<V: ToString>(&self, key: &str, value: V) {
+        let mut span = self.span.lock().unwrap();
+        span.tags.insert(key.into(), value.to_string());
     }
 
     /// Returns a smart pointer to the span's [`data` field](protocol::Span::data).


### PR DESCRIPTION
currently the only tags added to transactions are the tags on the scope at the time you finish a transaction. Sometimes, however, it is useful to have tags that aren't for the scope but just for the transaction. 

I am using the same signature as the equivalent method in `Scope`. 

I know there are currently other PRs related to tags in transactions but I think those are more specific to the tracing integration so having methods  to do it explicitly in a transaction (or span) is still useful. 