### PR TITLE
fix: Don't block on sending envelopes (ureq/curl transports)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Envelopes will be discarded rather than blocking if the transport channel fills up (previously fixed in async-capable transports, now applied to the curl/ureq transports). ([#701](https://github.com/getsentry/sentry-rust/pull/701))
+
 ## 0.34.0
 
 **Features**:

--- a/sentry/src/transports/thread.rs
+++ b/sentry/src/transports/thread.rs
@@ -74,7 +74,12 @@ impl TransportThread {
     }
 
     pub fn send(&self, envelope: Envelope) {
-        let _ = self.sender.send(Task::SendEnvelope(envelope));
+        // Using send here would mean that when the channel fills up for whatever
+        // reason, trying to send an envelope would block everything. We'd rather
+        // drop the envelope in that case.
+        if let Err(e) = self.sender.try_send(Task::SendEnvelope(envelope)) {
+            sentry_debug!("envelope dropped: {e}");
+        }
     }
 
     pub fn flush(&self, timeout: Duration) -> bool {


### PR DESCRIPTION
This is a followup to #546 (for #543):

Any transport is susceptible to #543, where sending too many events to Sentry can block. So the `thread::TransportThread` impl should similarly drop events instead of blocking, just as the similar `tokio_thread::TransportThread` began doing with the fix in #546.