### PR TITLE
fix: delay sampling of tracing spans to `finish`

### DIFF
--- a/sentry-tracing/tests/breadcrumbs.rs
+++ b/sentry-tracing/tests/breadcrumbs.rs
@@ -2,12 +2,12 @@ mod shared;
 
 #[test]
 fn breadcrumbs_should_capture_span_fields() {
-    let transport = shared::init_sentry();
+    let transport = shared::init_sentry(0.0); // This test should work even if we are not sampling transactions.
 
     foo();
 
     let data = transport.fetch_and_clear_envelopes();
-    assert_eq!(data.len(), 2);
+    assert_eq!(data.len(), 1);
 
     let event = data.first().expect("should have 1 event");
     let event = match event.items().next().unwrap() {

--- a/sentry-tracing/tests/shared.rs
+++ b/sentry-tracing/tests/shared.rs
@@ -3,7 +3,7 @@ use sentry_core::test::TestTransport;
 
 use std::sync::Arc;
 
-pub fn init_sentry() -> Arc<TestTransport> {
+pub fn init_sentry(traces_sample_rate: f32) -> Arc<TestTransport> {
     use tracing_subscriber::prelude::*;
 
     let transport = TestTransport::new();
@@ -11,7 +11,7 @@ pub fn init_sentry() -> Arc<TestTransport> {
         dsn: Some("https://test@sentry-tracing.com/test".parse().unwrap()),
         transport: Some(Arc::new(transport.clone())),
         sample_rate: 1.0,
-        traces_sample_rate: 1.0,
+        traces_sample_rate,
         ..ClientOptions::default()
     };
     Hub::current().bind_client(Some(Arc::new(options.into())));

--- a/sentry-tracing/tests/smoke.rs
+++ b/sentry-tracing/tests/smoke.rs
@@ -7,7 +7,7 @@ fn function_with_tags(value: i32) {
 
 #[test]
 fn should_instrument_function_with_event() {
-    let transport = shared::init_sentry();
+    let transport = shared::init_sentry(1.0); // Sample all spans.
 
     function_with_tags(1);
 


### PR DESCRIPTION
This PR is an attempt to completely resolve #617.

Currently, fields from spans are only recorded when the span gets sampled. This currently happens very early, right when the `Transaction` gets created. As a result, any event that gets recorded afterwards (i.e. as a breadcrumb) does not have access to the current span fields.

By delaying the discarding of `Transaction` to `finish`, we get to retain all the contextual data and still honor the configured sampling.

I ran a performance test of our software with this local branch applied and could not measure any impact of this.