### PR TITLE
feat: allow retrieving the current user of a scope

### DIFF
--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -197,6 +197,11 @@ impl Scope {
         self.user = user.map(Arc::new);
     }
 
+    /// Retrieves the user of the current scope.
+    pub fn user(&self) -> Option<&User> {
+        self.user.as_deref()
+    }
+
     /// Sets a tag to a specific value.
     pub fn set_tag<V: ToString>(&mut self, key: &str, value: V) {
         Arc::make_mut(&mut self.tags).insert(key.to_string(), value.to_string());


### PR DESCRIPTION
In our application, not all information of the current user is known immediately upfront. The user ID is loaded directly on startup but the account that they log in to is only known later.

Currently, we have to separately track this information because we always have to set the entire user at once. To avoid this, this PR adds a `user` getter to get the current user from the scope. This solves our use-case because we can get the current user and produce a new one that has additional fields and set it again.

Resolves: #706.