### PR TITLE
chore: elide lifetimes where possible

### DIFF
--- a/sentry-core/src/intodsn.rs
+++ b/sentry-core/src/intodsn.rs
@@ -27,7 +27,7 @@ impl IntoDsn for () {
     }
 }
 
-impl<'a> IntoDsn for &'a str {
+impl IntoDsn for &'_ str {
     fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         if self.is_empty() {
             Ok(None)
@@ -37,14 +37,14 @@ impl<'a> IntoDsn for &'a str {
     }
 }
 
-impl<'a> IntoDsn for Cow<'a, str> {
+impl IntoDsn for Cow<'_, str> {
     fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         let x: &str = &self;
         x.into_dsn()
     }
 }
 
-impl<'a> IntoDsn for &'a OsStr {
+impl IntoDsn for &'_ OsStr {
     fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         self.to_string_lossy().into_dsn()
     }
@@ -62,7 +62,7 @@ impl IntoDsn for String {
     }
 }
 
-impl<'a> IntoDsn for &'a Dsn {
+impl IntoDsn for &'_ Dsn {
     fn into_dsn(self) -> Result<Option<Dsn>, ParseDsnError> {
         Ok(Some(self.clone()))
     }

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -751,7 +751,7 @@ impl Transaction {
 /// A smart pointer to a span's [`data` field](protocol::Span::data).
 pub struct Data<'a>(MutexGuard<'a, protocol::Span>);
 
-impl<'a> Data<'a> {
+impl Data<'_> {
     /// Set some extra information to be sent with this Span.
     pub fn set_data(&mut self, key: String, value: protocol::Value) {
         self.0.data.insert(key, value);
@@ -763,7 +763,7 @@ impl<'a> Data<'a> {
     }
 }
 
-impl<'a> Deref for Data<'a> {
+impl Deref for Data<'_> {
     type Target = BTreeMap<String, protocol::Value>;
 
     fn deref(&self) -> &Self::Target {
@@ -771,7 +771,7 @@ impl<'a> Deref for Data<'a> {
     }
 }
 
-impl<'a> DerefMut for Data<'a> {
+impl DerefMut for Data<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0.data
     }

--- a/sentry-slog/src/converters.rs
+++ b/sentry-slog/src/converters.rs
@@ -22,7 +22,7 @@ macro_rules! impl_into {
         }
     };
 }
-impl<'a> Serializer for MapSerializer<'a> {
+impl Serializer for MapSerializer<'_> {
     fn emit_arguments(&mut self, key: Key, val: &fmt::Arguments) -> slog::Result {
         self.0.insert(key.into(), val.to_string().into());
         Ok(())

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1643,7 +1643,7 @@ pub struct Event<'a> {
     pub sdk: Option<Cow<'a, ClientSdkInfo>>,
 }
 
-impl<'a> Default for Event<'a> {
+impl Default for Event<'_> {
     fn default() -> Self {
         Event {
             event_id: event::default_id(),
@@ -1722,7 +1722,7 @@ impl<'a> Event<'a> {
     }
 }
 
-impl<'a> fmt::Display for Event<'a> {
+impl fmt::Display for Event<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -1994,7 +1994,7 @@ pub struct Transaction<'a> {
     pub server_name: Option<Cow<'a, str>>,
 }
 
-impl<'a> Default for Transaction<'a> {
+impl Default for Transaction<'_> {
     fn default() -> Self {
         Transaction {
             event_id: event::default_id(),
@@ -2049,7 +2049,7 @@ impl<'a> Transaction<'a> {
     }
 }
 
-impl<'a> fmt::Display for Transaction<'a> {
+impl fmt::Display for Transaction<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -60,7 +60,7 @@ pub mod ts_seconds_float {
 
     struct SecondsTimestampVisitor;
 
-    impl<'de> de::Visitor<'de> for SecondsTimestampVisitor {
+    impl de::Visitor<'_> for SecondsTimestampVisitor {
         type Value = SystemTime;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -144,7 +144,7 @@ pub mod ts_rfc3339 {
 
     pub(super) struct Rfc3339Deserializer;
 
-    impl<'de> de::Visitor<'de> for Rfc3339Deserializer {
+    impl de::Visitor<'_> for Rfc3339Deserializer {
         type Value = SystemTime;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
CI is currently failing due to a new clippy lint.