### PR TITLE
fix: Ensure Send+Sync bounds on SentryLayer and SentryService

### DIFF
--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -196,7 +196,9 @@ where
     H: Into<Arc<Hub>>,
 {
     provider: P,
-    _hub: PhantomData<(H, Request)>,
+    // `fn` is used to assert that SentryLayer will be Send+Sync
+    // (https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns)
+    _hub: PhantomData<fn(H, Request)>,
 }
 
 impl<S, P, H, Request> Layer<S> for SentryLayer<P, H, Request>
@@ -250,7 +252,9 @@ where
 {
     service: S,
     provider: P,
-    _hub: PhantomData<(H, Request)>,
+    // `fn` is used to assert that SentryService will be Send+Sync
+    // (https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns)
+    _hub: PhantomData<fn(H, Request)>,
 }
 
 impl<S, Request, P, H> Service<Request> for SentryService<S, P, H, Request>


### PR DESCRIPTION
Updates PhantomData usage in SentryLayer and SentryService to explicitly ensure Send+Sync trait bounds using the fn pointer pattern as documented in the Rust Nomicon.

Sync axum 0.8 (also, see #718), the [Router layer call seems to require `Sync` bounds](https://github.com/tokio-rs/axum/commit/52fd139a8).

https://github.com/tokio-rs/axum/pull/2473