### PR TITLE
actix: Use tx.set_request() to set HTTP request metadata

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -250,7 +250,10 @@ where
                 "http.server",
                 headers,
             );
-            Some(hub.start_transaction(ctx))
+
+            let transaction = hub.start_transaction(ctx);
+            transaction.set_request(sentry_req.clone());
+            Some(transaction)
         } else {
             None
         };


### PR DESCRIPTION
Without this the transaction does not have any HTTP request metadata attached, because apparently the event processor is not running for performance traces

it just follows the changes done for tower from https://github.com/getsentry/sentry-rust/pull/571