### PR TITLE
feat(core): add `scope.get_transaction` API

### DIFF
--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -725,7 +725,6 @@ impl Transaction {
                     let mut envelope = protocol::Envelope::new();
                     envelope.add_item(transaction);
 
-
                     client.send_envelope(envelope)
                 }
             }

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -355,11 +355,11 @@ impl From<Transaction> for TransactionOrSpan {
     }
 }
 
-impl From<TransactionArc> for TransactionOrSpan {
+impl From<TransactionArc> for Transaction {
     fn from(transaction_arc: TransactionArc) -> Self {
-        Self::Transaction(Transaction {
+        Self {
             inner: transaction_arc,
-        })
+        }
     }
 }
 

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -722,8 +722,6 @@ impl Transaction {
 
                     drop(inner);
 
-                    dbg!(transaction.clone());
-
                     let mut envelope = protocol::Envelope::new();
                     envelope.add_item(transaction);
 

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -355,6 +355,14 @@ impl From<Transaction> for TransactionOrSpan {
     }
 }
 
+impl From<TransactionArc> for TransactionOrSpan {
+    fn from(transaction_arc: TransactionArc) -> Self {
+        Self::Transaction(Transaction {
+            inner: transaction_arc,
+        })
+    }
+}
+
 impl From<Span> for TransactionOrSpan {
     fn from(span: Span) -> Self {
         Self::Span(span)
@@ -714,8 +722,11 @@ impl Transaction {
 
                     drop(inner);
 
+                    dbg!(transaction.clone());
+
                     let mut envelope = protocol::Envelope::new();
                     envelope.add_item(transaction);
+
 
                     client.send_envelope(envelope)
                 }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
+use crate::performance;
 use crate::performance::TransactionOrSpan;
 use crate::protocol::{Attachment, Breadcrumb, Context, Event, Level, Transaction, User, Value};
 use crate::session::Session;
@@ -339,6 +340,14 @@ impl Scope {
     /// Returns the currently active span.
     pub fn get_span(&self) -> Option<TransactionOrSpan> {
         self.span.as_ref().clone()
+    }
+
+    /// Returns the currently active transaction.
+    pub fn get_transaction(&self) -> Option<TransactionOrSpan> {
+        self.get_span().map(|trx| match trx {
+            TransactionOrSpan::Span(span) => span.transaction.into(),
+            TransactionOrSpan::Transaction(_) => trx,
+        })
     }
 
     pub(crate) fn update_session_from_event(&self, event: &Event<'static>) {

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
+use crate::performance;
 use crate::performance::TransactionOrSpan;
 use crate::protocol::{Attachment, Breadcrumb, Context, Event, Level, Transaction, User, Value};
 use crate::session::Session;
@@ -342,10 +343,10 @@ impl Scope {
     }
 
     /// Returns the currently active transaction.
-    pub fn get_transaction(&self) -> Option<TransactionOrSpan> {
+    pub fn get_transaction(&self) -> Option<performance::Transaction> {
         self.get_span().map(|trx| match trx {
             TransactionOrSpan::Span(span) => span.transaction.into(),
-            TransactionOrSpan::Transaction(_) => trx,
+            TransactionOrSpan::Transaction(transaction) => transaction,
         })
     }
 

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
-use crate::performance;
 use crate::performance::TransactionOrSpan;
 use crate::protocol::{Attachment, Breadcrumb, Context, Event, Level, Transaction, User, Value};
 use crate::session::Session;


### PR DESCRIPTION
This adds a `scope.get_transaction` API to get the currently active transaction from a Scope.
This will make it possible for customers to get the currently active transaction to add data attributes to it, which can then be used for queries in the Trace Explorer.
It also aligns the SDK with other SDKs that have this API.
Needed for https://github.com/getsentry/sentry-rust/issues/733