### PR TITLE
feat(core): transaction.set_data sets data on TraceContext

### DIFF
--- a/sentry-tracing/tests/smoke.rs
+++ b/sentry-tracing/tests/smoke.rs
@@ -33,21 +33,21 @@ fn should_instrument_function_with_event() {
         unexpected => panic!("Expected transaction, but got {:#?}", unexpected),
     };
     assert_eq!(transaction.tags.len(), 1);
-    assert_eq!(transaction.extra.len(), 2);
+    assert_eq!(trace.data.len(), 2);
 
     let tag = transaction
         .tags
         .get("tag")
         .expect("to have tag with name 'tag'");
     assert_eq!(tag, "key");
-    let not_tag = transaction
-        .extra
+    let not_tag = trace
+        .data
         .get("not_tag")
-        .expect("to have extra with name 'not_tag'");
+        .expect("to have data attribute with name 'not_tag'");
     assert_eq!(not_tag, "value");
-    let value = transaction
-        .extra
+    let value = trace
+        .data
         .get("value")
-        .expect("to have extra with name 'value'");
+        .expect("to have data attribute with name 'value'");
     assert_eq!(value, 1);
 }

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1435,6 +1435,9 @@ pub struct TraceContext {
     /// Describes the status of the span (e.g. `ok`, `cancelled`, etc.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<SpanStatus>,
+    /// Optional data attributes to be associated with the transaction.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub data: Map<String, Value>,
 }
 
 macro_rules! into_context {


### PR DESCRIPTION
The Rust SDK currently sets data on `transaction.extra` when calling `transaction.set_data` on a `Transaction`.
This change makes it so that data is instead set on the `TraceContext` i.e. `transaction.context.trace.data` as other SDKs do (see https://github.com/getsentry/team-sdks/issues/95). 

Required for https://github.com/getsentry/sentry-rust/issues/733