### PR TITLE
Add option to enable propagation of parent span tags

### DIFF
--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -147,3 +147,32 @@ pub use converters::*;
 pub use layer::*;
 
 const TAGS_PREFIX: &str = "tags.";
+
+#[derive(Debug, Clone, Copy)]
+/// Controls propagation of span data when creating event
+///
+/// Note that the root span is considered a [transaction][sentry_core::protocol::Transaction]
+/// so its context will only be grabbed only if you set the transaction to be sampled.
+/// The most straightforward way to do this is to set
+/// the [traces_sample_rate][sentry_core::ClientOptions::traces_sample_rate] to `1.0`
+/// while configuring your sentry client.
+pub enum SpanPropagation {
+    /// Collects all attributes prefixed with span name
+    Attributes,
+    /// Accumulates tags from within attributes as event tags, without overriding existing tags
+    Tags,
+    /// Collects both tags and attributes
+    All,
+}
+
+impl SpanPropagation {
+    #[inline(always)]
+    pub(crate) const fn is_tags_enabled(&self) -> bool {
+        matches!(self, Self::Tags | Self::All)
+    }
+
+    #[inline(always)]
+    pub(crate) const fn is_attrs_enabled(&self) -> bool {
+        matches!(self, Self::Attributes | Self::All)
+    }
+}

--- a/sentry-tracing/tests/shared.rs
+++ b/sentry-tracing/tests/shared.rs
@@ -1,5 +1,6 @@
 use sentry::{ClientOptions, Hub};
 use sentry_core::test::TestTransport;
+use sentry_tracing::SpanPropagation;
 
 use std::sync::Arc;
 
@@ -17,7 +18,7 @@ pub fn init_sentry(traces_sample_rate: f32) -> Arc<TestTransport> {
     Hub::current().bind_client(Some(Arc::new(options.into())));
 
     let _ = tracing_subscriber::registry()
-        .with(sentry_tracing::layer().enable_span_attributes())
+        .with(sentry_tracing::layer().enable_span_propagation(SpanPropagation::All))
         .try_init();
 
     transport

--- a/sentry-tracing/tests/smoke.rs
+++ b/sentry-tracing/tests/smoke.rs
@@ -19,6 +19,13 @@ fn should_instrument_function_with_event() {
         unexpected => panic!("Expected event, but got {:#?}", unexpected),
     };
 
+    //Event must be get tag attached
+    let event_tag = event
+        .tags
+        .get("tag")
+        .expect("event should be associated with span's tag");
+    assert_eq!(event_tag, "key");
+
     //Validate transaction is created
     let trace = match event.contexts.get("trace").expect("to get 'trace' context") {
         sentry::protocol::Context::Trace(trace) => trace,


### PR DESCRIPTION
I would like to suggest option to allow event's spans to automatically insert first available tag as tag within event, rather than propagating it as additional data

Old behavior can be used together with this feature too

But I often find it inconvenient that events may not contain tags from within span (especially if spans get rate limited at sentry)
What do you think about this addition?
Let me know if you'd like me to make some adjustments to PR