### PR TITLE
fix(actix): process request in other middleware using correct Hub

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -66,11 +66,11 @@
 //!
 //! # Reusing the Hub in other middleware
 //!
-//! This integration stores the per-request Hub in the request extensions. Therefore, if you want
-//! to capture events within the context of the correct Hub, make sure you are retrieving it from
-//! the extensions and using it.
-//! You also need to make sure that the Sentry middleware is the last to be applied to your
-//! application, i.e. the first to be executed when processing a request.
+//! This integration stores the per-request Hub in the request extensions. If you want to capture
+//! events when processing a request, retrieve the Hub from the request extensions.
+//! When processing a response, the per-request Hub will already be set as the current.
+//! You also need to make sure that the Sentry middleware is the last to be registered, i.e. the
+//! first to be executed when processing a request.
 //! Example:
 //!
 //! ```no_run
@@ -107,7 +107,7 @@
 //!                             ..Default::default()
 //!                         });
 //!
-//!                         srv.call(req).bind_hub(hub).map(|res| {
+//!                         srv.call(req).map(|res| {
 //!                             sentry::add_breadcrumb(Breadcrumb {
 //!                                 message: Some(format!("breadcrumb in middleware - after handler")),
 //!                                 level: Level::Info,

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -99,11 +99,7 @@
 //!             HttpServer::new(|| {
 //!                 App::new()
 //!                     .wrap_fn(|req, srv| {
-//!                         let hub = req
-//!                             .extensions()
-//!                             .get::<Arc<Hub>>()
-//!                             .unwrap_or(&Hub::current()) // should never happen
-//!                             .clone();
+//!                         let hub = req.extensions().get::<Arc<Hub>>().cloned().unwrap();
 //!
 //!                         hub.add_breadcrumb(Breadcrumb {
 //!                             message: Some(format!("breadcrumb in middleware - before handler")),

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -80,7 +80,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use actix_http::header::{self, HeaderMap};
-use actix_http::HttpMessage;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::StatusCode;
 use actix_web::Error;


### PR DESCRIPTION
Extensions are a feature of Actix-web to pass request-local data.
With this change, we pass the Hub that we create with each Actix request in the extensions, so that other middleware can access it and use it to capture events within the correct hub.

Closes https://github.com/getsentry/sentry-rust/issues/624