### PR TITLE
fix(anyhow): attach stacktrace only if anyhow error has backtrace

### DIFF
--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -72,7 +72,12 @@ pub fn event_from_error(err: &anyhow::Error) -> Event<'static> {
         // exception records are sorted in reverse
         if let Some(exc) = event.exception.iter_mut().last() {
             let backtrace = err.backtrace();
-            exc.stacktrace = sentry_backtrace::parse_stacktrace(&format!("{backtrace:#}"));
+            if matches!(
+                backtrace.status(),
+                std::backtrace::BacktraceStatus::Captured
+            ) {
+                exc.stacktrace = sentry_backtrace::parse_stacktrace(&format!("{backtrace:#}"));
+            }
         }
     }
 


### PR DESCRIPTION
This is similar to https://github.com/getsentry/sentry-rust/pull/755 but for the anyhow integration

Without this change, if we're running without `RUST_BACKTRACE` set, then `backtrace` will have value `"<disabled>"`.
We would try to parse it and get an empty vec as a result.
The consequence is that all anyhows would be grouped in a single issue due to having the same (empty) stack trace.

After the change, there will be no stack trace, so grouping will happen according to the error message.

Side effect: when running with `attach_stacktrace: true`, `sentry-backtrace` will kick in and provide a backtrace (this didn't happen before because we had a stack trace, even though it was an empty one).
It could be argued whether we want this or not.

Closes https://github.com/getsentry/sentry-rust/issues/745