### PR TITLE
refactor: honor `send_default_pii` in `sentry-actix` and `sentry-tower`

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -88,6 +88,7 @@ use futures_util::future::{ok, Future, Ready};
 use futures_util::{FutureExt as _, TryStreamExt as _};
 
 use sentry_core::protocol::{self, ClientSdkPackage, Event, Request};
+use sentry_core::utils::is_sensitive_header;
 use sentry_core::MaxRequestBodySize;
 use sentry_core::{Hub, SentryFutureExt};
 
@@ -424,6 +425,7 @@ fn sentry_request_from_http(request: &ServiceRequest, with_pii: bool) -> Request
             .headers()
             .iter()
             .filter(|(_, v)| !v.is_sensitive())
+            .filter(|(k, _)| with_pii || !is_sensitive_header(k.as_str()))
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
             .collect(),
         ..Default::default()

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -222,16 +222,16 @@ fn should_capture_request_body(
         .map(|transfer_encoding| transfer_encoding.contains("chunked"))
         .unwrap_or(false);
 
-    let is_valid_content_type = headers
-        .get(header::CONTENT_TYPE)
-        .and_then(|h| h.to_str().ok())
-        .is_some_and(|content_type| {
-            with_pii
-                || matches!(
+    let is_valid_content_type = with_pii
+        || headers
+            .get(header::CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok())
+            .is_some_and(|content_type| {
+                matches!(
                     content_type,
                     "application/json" | "application/x-www-form-urlencoded"
                 )
-        });
+            });
 
     let is_within_size_limit = headers
         .get(header::CONTENT_LENGTH)

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -120,7 +120,7 @@ pub struct ClientOptions {
     pub max_breadcrumbs: usize,
     /// Attaches stacktraces to messages.
     pub attach_stacktrace: bool,
-    /// If turned on some default PII informat is attached.
+    /// If turned on, some information that can be considered PII is captured, such as potentially sensitive HTTP headers and user IP address in HTTP server integrations.
     pub send_default_pii: bool,
     /// The server name to be reported.
     pub server_name: Option<Cow<'static, str>>,

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -159,3 +159,6 @@ pub mod test;
 pub use sentry_types as types;
 pub use sentry_types::protocol::v7 as protocol;
 pub use sentry_types::protocol::v7::{Breadcrumb, Envelope, Level, User};
+
+// utilities reused across integrations
+pub mod utils;

--- a/sentry-core/src/utils.rs
+++ b/sentry-core/src/utils.rs
@@ -1,0 +1,17 @@
+//! Utilities reused across dependant crates and integrations.
+
+const SENSITIVE_HEADERS_UPPERCASE: &[&str] = &[
+    "AUTHORIZATION",
+    "PROXY_AUTHORIZATION",
+    "COOKIE",
+    "SET_COOKIE",
+    "X_FORWARDED_FOR",
+    "X_REAL_IP",
+    "X_API_KEY",
+];
+
+/// Determines if the HTTP header with the given name shall be considered as potentially carrying
+/// sensitive data.
+pub fn is_sensitive_header(name: &str) -> bool {
+    SENSITIVE_HEADERS_UPPERCASE.contains(&name.to_ascii_uppercase().replace("-", "_").as_str())
+}

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -37,8 +37,7 @@ impl SentryHttpLayer {
         let mut slf = Self::default();
         Hub::main()
             .client()
-            .map(|client| client.options().send_default_pii)
-            .inspect(|send_default_pii| slf.with_pii = *send_default_pii);
+            .inspect(|client| slf.with_pii = client.options().send_default_pii);
         slf
     }
 
@@ -48,6 +47,7 @@ impl SentryHttpLayer {
     pub fn with_transaction() -> Self {
         Self {
             start_transaction: true,
+            with_pii: false,
         }
     }
 

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -42,6 +42,15 @@ impl SentryHttpLayer {
         slf
     }
 
+    /// Creates a new Layer which starts a new performance monitoring transaction
+    /// for each incoming request.
+    #[deprecated(since = "0.38.0", note = "please use `enable_transaction` instead")]
+    pub fn with_transaction() -> Self {
+        Self {
+            start_transaction: true,
+        }
+    }
+
     /// Enable starting a new performance monitoring transaction for each incoming request.
     #[must_use]
     pub fn enable_transaction(mut self) -> Self {

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -5,13 +5,14 @@ use std::task::{Context, Poll};
 
 use http::{header, uri, Request, Response, StatusCode};
 use pin_project::pinned_drop;
-use sentry_core::protocol;
+use sentry_core::utils::is_sensitive_header;
+use sentry_core::{protocol, Hub};
 use tower_layer::Layer;
 use tower_service::Service;
 
-/// Tower Layer that logs Http Request Headers.
+/// Tower Layer that logs Http Request information.
 ///
-/// The Service created by this Layer can also optionally start a new
+/// The Service created by this Layer can optionally start a new
 /// performance monitoring transaction for each incoming request,
 /// continuing the trace based on incoming distributed tracing headers.
 ///
@@ -20,35 +21,54 @@ use tower_service::Service;
 /// or similar. In this case, users should manually override the transaction name
 /// in the request handler using the [`Scope::set_transaction`](sentry_core::Scope::set_transaction)
 /// method.
+///
+/// By default, the service will filter out potentially sensitive headers from the captured
+/// requests. By enabling `with_pii`, you can opt in to capturing all headers instead.
 #[derive(Clone, Default)]
 pub struct SentryHttpLayer {
     start_transaction: bool,
+    with_pii: bool,
 }
 
 impl SentryHttpLayer {
-    /// Creates a new Layer that only logs Request Headers.
+    /// Creates a new Layer that only captures request information.
+    /// If a client is bound to the main Hub (i.e. the SDK has already been initialized), set `with_pii` based on the `send_default_pii` client option.
     pub fn new() -> Self {
-        Self::default()
+        let mut slf = Self::default();
+        Hub::main()
+            .client()
+            .map(|client| client.options().send_default_pii)
+            .inspect(|send_default_pii| slf.with_pii = *send_default_pii);
+        slf
     }
 
-    /// Creates a new Layer which starts a new performance monitoring transaction
-    /// for each incoming request.
-    pub fn with_transaction() -> Self {
-        Self {
-            start_transaction: true,
-        }
+    /// Enable starting a new performance monitoring transaction for each incoming request.
+    #[must_use]
+    pub fn enable_transaction(mut self) -> Self {
+        self.start_transaction = true;
+        self
+    }
+
+    /// Include PII in captured requests. Potentially sensitive headers are not filtered out.
+    #[must_use]
+    pub fn enable_pii(mut self) -> Self {
+        self.with_pii = true;
+        self
     }
 }
 
-/// Tower Service that logs Http Request Headers.
+/// Tower Service that captures Http Request information.
 ///
-/// The Service can also optionally start a new performance monitoring transaction
+/// The Service can optionally start a new performance monitoring transaction
 /// for each incoming request, continuing the trace based on incoming
 /// distributed tracing headers.
+///
+/// If `with_pii` is disabled, sensitive headers will be filtered out.
 #[derive(Clone)]
 pub struct SentryHttpService<S> {
     service: S,
     start_transaction: bool,
+    with_pii: bool,
 }
 
 impl<S> Layer<S> for SentryHttpLayer {
@@ -58,6 +78,7 @@ impl<S> Layer<S> for SentryHttpLayer {
         Self::Service {
             service,
             start_transaction: self.start_transaction,
+            with_pii: self.with_pii,
         }
     }
 }
@@ -161,6 +182,7 @@ where
                 .headers()
                 .into_iter()
                 .filter(|(_, value)| !value.is_sensitive())
+                .filter(|(header, _)| self.with_pii || !is_sensitive_header(header.as_str()))
                 .map(|(header, value)| {
                     (
                         header.to_string(),

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -10,7 +10,7 @@ use sentry_core::{protocol, Hub};
 use tower_layer::Layer;
 use tower_service::Service;
 
-/// Tower Layer that logs Http Request information.
+/// Tower Layer that captures Http Request information.
 ///
 /// The Service created by this Layer can optionally start a new
 /// performance monitoring transaction for each incoming request,

--- a/sentry-tower/src/lib.rs
+++ b/sentry-tower/src/lib.rs
@@ -126,7 +126,7 @@
 //! # type Request = http::Request<String>;
 //! let layer = tower::ServiceBuilder::new()
 //!     .layer(sentry_tower::NewSentryLayer::<Request>::new_from_top())
-//!     .layer(sentry_tower::SentryHttpLayer::with_transaction());
+//!     .layer(sentry_tower::SentryHttpLayer::new().enable_transaction());
 //! # }
 //! ```
 //!


### PR DESCRIPTION
Follows the spec defined here: https://develop.sentry.dev/sdk/expected-features/data-handling/.

When `send-default-pii = true`, then capture all headers.
When `send-default-pii = false`, filter out sensitive headers.
Also send non-json/form request bodies when `send-default-pii=true`, as that's allowed according to spec.

I've deprecated the old `SentryHttpLayer::with_transaction` constructor so that this is not a breaking change in terms of API.
