### PR TITLE
feat: reduce stack-size of threads

### DIFF
--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -213,6 +213,7 @@ mod session_impl {
             let worker_shutdown = shutdown.clone();
             let worker = std::thread::Builder::new()
                 .name("sentry-session-flusher".into())
+                .stack_size(100 * 1024)
                 .spawn(move || {
                     let (lock, cvar) = worker_shutdown.as_ref();
                     let mut shutdown = lock.lock().unwrap();

--- a/sentry/src/transports/thread.rs
+++ b/sentry/src/transports/thread.rs
@@ -29,6 +29,7 @@ impl TransportThread {
         let shutdown_worker = shutdown.clone();
         let handle = thread::Builder::new()
             .name("sentry-transport".into())
+            .stack_size(500 * 1024)
             .spawn(move || {
                 let mut rl = RateLimiter::new();
 

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -31,6 +31,7 @@ impl TransportThread {
         let shutdown_worker = shutdown.clone();
         let handle = thread::Builder::new()
             .name("sentry-transport".into())
+            .stack_size(500 * 1024)
             .spawn(move || {
                 // create a runtime on the transport thread
                 let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Certain environments like iOS are very resource-constrained. A network extension on iOS is allowed to at most consume 50MB of RAM. By default, a thread in Rust allocates 2MB of RAM for the stack of the new thread. This can be tweaked if one knows that the particular thread doesn't need as much RAM.