### PR TITLE
fix: use `release-health` flag in `sentry-actix` and remove it from subcrates where unneeded

### DIFF
--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -45,8 +45,6 @@
 //! The actix middleware will automatically start a new session for each request
 //! when `auto_session_tracking` is enabled and the client is configured to
 //! use `SessionMode::Request`.
-//! The `release-health` feature flag also needs to be enabled on either
-//! `sentry` or `sentry-actix` for this to work.
 //!
 //! ```
 //! let _sentry = sentry::init(sentry::ClientOptions {

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -294,6 +294,7 @@ where
             .map(|client| client.options().max_request_body_size)
             .unwrap_or(MaxRequestBodySize::None);
         if track_sessions {
+            #[cfg(feature = "release-health")]
             hub.start_session();
         }
         let with_pii = client

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -45,6 +45,8 @@
 //! The actix middleware will automatically start a new session for each request
 //! when `auto_session_tracking` is enabled and the client is configured to
 //! use `SessionMode::Request`.
+//! The `release-health` feature flag also needs to be enabled on either
+//! `sentry` or `sentry-actix` for this to work.
 //!
 //! ```
 //! let _sentry = sentry::init(sentry::ClientOptions {
@@ -52,6 +54,7 @@
 //!     session_mode: sentry::SessionMode::Request,
 //!     auto_session_tracking: true,
 //!     ..Default::default()
+
 //! });
 //! ```
 //!

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -681,6 +681,7 @@ mod tests {
         assert_eq!(request.method, Some("GET".into()));
     }
 
+    #[cfg(feature = "release-health")]
     #[actix_web::test]
     async fn test_track_session() {
         let envelopes = sentry::test::with_captured_envelopes_options(
@@ -703,9 +704,7 @@ mod tests {
             },
             sentry::ClientOptions {
                 release: Some("some-release".into()),
-                #[cfg(feature = "release-health")]
                 session_mode: sentry::SessionMode::Request,
-                #[cfg(feature = "release-health")]
                 auto_session_tracking: true,
                 ..Default::default()
             },

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -54,7 +54,6 @@
 //!     session_mode: sentry::SessionMode::Request,
 //!     auto_session_tracking: true,
 //!     ..Default::default()
-
 //! });
 //! ```
 //!

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -174,14 +174,10 @@ pub struct ClientOptions {
     /// When automatic session tracking is enabled, a new "user-mode" session
     /// is started at the time of `sentry::init`, and will persist for the
     /// application lifetime.
-    ///
-    /// **NOTE**: The `release-health` feature (enabled by default) needs to be enabled for this option to have
-    /// any effect.
+    #[cfg(feature = "release-health")]
     pub auto_session_tracking: bool,
     /// Determine how Sessions are being tracked.
-    ///
-    /// **NOTE**: The `release-health` feature (enabled by default) needs to be enabled for this option to have
-    /// any effect.
+    #[cfg(feature = "release-health")]
     pub session_mode: SessionMode,
     /// Border frames which indicate a border from a backtrace to
     /// useless internals. Some are automatically included.
@@ -232,7 +228,8 @@ impl fmt::Debug for ClientOptions {
 
         let integrations: Vec<_> = self.integrations.iter().map(|i| i.name()).collect();
 
-        f.debug_struct("ClientOptions")
+        let mut debug_struct = f.debug_struct("ClientOptions");
+        debug_struct
             .field("dsn", &self.dsn)
             .field("debug", &self.debug)
             .field("release", &self.release)
@@ -260,9 +257,14 @@ impl fmt::Debug for ClientOptions {
             .field("http_proxy", &self.http_proxy)
             .field("https_proxy", &self.https_proxy)
             .field("shutdown_timeout", &self.shutdown_timeout)
-            .field("accept_invalid_certs", &self.accept_invalid_certs)
+            .field("accept_invalid_certs", &self.accept_invalid_certs);
+
+        #[cfg(feature = "release-health")]
+        debug_struct
             .field("auto_session_tracking", &self.auto_session_tracking)
-            .field("session_mode", &self.session_mode)
+            .field("session_mode", &self.session_mode);
+
+        debug_struct
             .field("extra_border_frames", &self.extra_border_frames)
             .field("trim_backtraces", &self.trim_backtraces)
             .field("user_agent", &self.user_agent)
@@ -295,7 +297,9 @@ impl Default for ClientOptions {
             https_proxy: None,
             shutdown_timeout: Duration::from_secs(2),
             accept_invalid_certs: false,
+            #[cfg(feature = "release-health")]
             auto_session_tracking: false,
+            #[cfg(feature = "release-health")]
             session_mode: SessionMode::Application,
             extra_border_frames: vec![],
             trim_backtraces: true,

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -20,10 +20,8 @@ mod session_impl {
         SessionStatus, SessionUpdate,
     };
 
-    #[cfg(feature = "release-health")]
     use crate::scope::StackLayer;
 
-    #[cfg(feature = "release-health")]
     use crate::types::random_uuid;
     use crate::{Client, Envelope};
 
@@ -45,7 +43,6 @@ mod session_impl {
     }
 
     impl Session {
-        #[cfg(feature = "release-health")]
         pub fn from_stack(stack: &StackLayer) -> Option<Self> {
             let client = stack.client.as_ref()?;
             let options = client.options();
@@ -121,7 +118,6 @@ mod session_impl {
             }
         }
 
-        #[cfg(feature = "release-health")]
         pub(crate) fn create_envelope_item(&mut self) -> Option<EnvelopeItem> {
             if self.dirty {
                 let item = self.session_update.clone().into();
@@ -135,7 +131,6 @@ mod session_impl {
 
     // as defined here: https://develop.sentry.dev/sdk/envelopes/#size-limits
     const MAX_SESSION_ITEMS: usize = 100;
-    #[cfg(feature = "release-health")]
     const FLUSH_INTERVAL: Duration = Duration::from_secs(60);
 
     #[derive(Debug, Default)]
@@ -202,7 +197,6 @@ mod session_impl {
 
     impl SessionFlusher {
         /// Creates a new Flusher that will submit envelopes to the given `transport`.
-        #[cfg(feature = "release-health")]
         pub fn new(transport: TransportArc, mode: SessionMode) -> Self {
             let queue = Arc::new(Mutex::new(Default::default()));
             #[allow(clippy::mutex_atomic)]
@@ -432,7 +426,6 @@ mod session_impl {
         }
 
         #[test]
-        #[cfg(feature = "release-health")]
         fn test_session_aggregation() {
             let envelopes = crate::test::with_captured_envelopes_options(
                 || {

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -432,6 +432,7 @@ mod session_impl {
         }
 
         #[test]
+        #[cfg(feature = "release-health")]
         fn test_session_aggregation() {
             let envelopes = crate::test::with_captured_envelopes_options(
                 || {
@@ -464,7 +465,6 @@ mod session_impl {
                 },
                 crate::ClientOptions {
                     release: Some("some-release".into()),
-                    #[cfg(feature = "release-health")]
                     session_mode: SessionMode::Request,
                     ..Default::default()
                 },

--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -18,7 +18,6 @@ all-features = true
 [dependencies]
 sentry-core = { version = "0.37.0", path = "../sentry-core", features = [
     "client",
-    "release-health"
 ] }
 opentelemetry = { version = "0.29.0", default-features = false }
 opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -16,10 +16,9 @@ rust-version = "1.81"
 all-features = true
 
 [features]
-default = ["release-health"]
+default = []
 http = ["dep:http", "pin-project", "url"]
 axum-matched-path = ["http", "axum/matched-path"]
-release-health = ["sentry-core/release-health"]
 
 [dependencies]
 axum = { version = "0.8", optional = true, default-features = false }

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -16,9 +16,8 @@ rust-version = "1.81"
 all-features = true
 
 [features]
-default = ["release-health"]
+default = []
 backtrace = ["dep:sentry-backtrace"]
-release-health = ["sentry-core/release-health"]
 
 [dependencies]
 sentry-core = { version = "0.37.0", path = "../sentry-core", features = [

--- a/sentry/src/init.rs
+++ b/sentry/src/init.rs
@@ -97,9 +97,9 @@ where
 {
     let opts = apply_defaults(opts.into());
 
-    #[allow(unused)]
+    #[cfg(feature = "release-health")]
     let auto_session_tracking = opts.auto_session_tracking;
-    #[allow(unused)]
+    #[cfg(feature = "release-health")]
     let session_mode = opts.session_mode;
 
     let client = Arc::new(Client::from(opts));


### PR DESCRIPTION
Removes the `release-health` feature from `sentry-tower` and `sentry-tracing`, where it was used unnecessarily.

It's still a feature flag, enabled by default, in `sentry-actix`, as it's used there to create a session per request.
This was the default behavior previously, with no way of opting out, so it makes sense to keep it enabled by default there.
https://github.com/getsentry/sentry-rust/blob/3cc461a279d5a6ac45ea73268344d01318d8719e/sentry-actix/Cargo.toml#L16
I've fixed it to actually be used in the code because compilation would fail otherwise due to the `hub.start_session();` call.

There is no change to the `sentry` crate, where this flag is part of the default features as intended: https://github.com/getsentry/sentry-rust/blob/3cc461a279d5a6ac45ea73268344d01318d8719e/sentry/Cargo.toml#L30

Note that `sentry` has no way to bring in `sentry-actix` via feature flags.
Is there a reason for that?
I'll create a separate PR to enable it, similarly to other integrations.