### PR TITLE
build: expose `sentry-actix` as a feature flag of `sentry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ dependencies = [
  "pretty_env_logger",
  "reqwest",
  "rustls",
+ "sentry-actix",
  "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -36,6 +36,7 @@ contexts = ["sentry-contexts"]
 panic = ["sentry-panic"]
 # other integrations
 anyhow = ["sentry-anyhow"]
+actix = ["sentry-actix"]
 debug-images = ["sentry-debug-images"]
 log = ["sentry-log"]
 slog = ["sentry-slog"]
@@ -47,7 +48,7 @@ opentelemetry = ["sentry-opentelemetry"]
 # other features
 test = ["sentry-core/test"]
 debug-logs = ["dep:log", "sentry-core/debug-logs"]
-release-health = ["sentry-core/release-health"]
+release-health = ["sentry-core/release-health", "sentry-actix/release-health"]
 # transports
 transport = ["reqwest", "native-tls"]
 reqwest = ["dep:reqwest", "httpdate", "tokio"]
@@ -63,6 +64,7 @@ sentry-core = { version = "0.37.0", path = "../sentry-core", features = [
     "client",
 ] }
 sentry-anyhow = { version = "0.37.0", path = "../sentry-anyhow", optional = true }
+sentry-actix = { version = "0.37.0", path = "../sentry-actix", optional = true, default-features = false }
 sentry-backtrace = { version = "0.37.0", path = "../sentry-backtrace", optional = true }
 sentry-contexts = { version = "0.37.0", path = "../sentry-contexts", optional = true }
 sentry-debug-images = { version = "0.37.0", path = "../sentry-debug-images", optional = true }

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -184,6 +184,10 @@ pub use crate::init::{init, ClientInitGuard};
 /// [`ClientOptions::default_integrations`]: crate::ClientOptions::default_integrations
 /// [`apply_defaults()`]: ../fn.apply_defaults.html
 pub mod integrations {
+    #[cfg(feature = "actix")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "actix")))]
+    #[doc(inline)]
+    pub use sentry_actix as actix;
     #[cfg(feature = "anyhow")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "anyhow")))]
     #[doc(inline)]


### PR DESCRIPTION
Expose `sentry-actix` as a feature flag of `sentry` itself, like we do for other integrations.