### PR TITLE
build: add `sentry-opentelemetry` to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "sentry-core",
     "sentry-debug-images",
     "sentry-log",
+    "sentry-opentelemetry",
     "sentry-panic",
     "sentry-slog",
     "sentry-tower",


### PR DESCRIPTION
I forgot to add it in the previous PR, I guess craft will not work without it.