### PR TITLE
fix(otel): fix doctests

### DIFF
--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -27,7 +27,7 @@ opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
 opentelemetry-semantic-conventions = "0.29.0"
 
 [dev-dependencies]
-sentry = { version = "0.37.0", path = "../sentry", features = ["test"] }
+sentry = { version = "0.37.0", path = "../sentry", features = ["test", "opentelemetry"] }
 sentry-core = { version = "0.37.0", path = "../sentry-core", features = [
     "test",
 ] }

--- a/sentry-opentelemetry/src/lib.rs
+++ b/sentry-opentelemetry/src/lib.rs
@@ -25,7 +25,7 @@
 //! Initialize Sentry with a `traces_sample_rate`, then register the [`SentryPropagator`] and the
 //! [`SentrySpanProcessor`]:
 //!
-//! ```
+//! ```ignore
 //! use opentelemetry::{
 //!     global,
 //!     trace::{TraceContextExt, Tracer},
@@ -65,7 +65,7 @@
 //!
 //! Use the OpenTelemetry API to create spans. They will be captured by Sentry:
 //!
-//! ```no_run
+//! ```ignore
 //! let tracer = global::tracer("tracer");
 //! // Creates a Sentry span (transaction) with the name set to "example"
 //! tracer.in_span("example", |_| {

--- a/sentry-opentelemetry/src/lib.rs
+++ b/sentry-opentelemetry/src/lib.rs
@@ -25,7 +25,7 @@
 //! Initialize Sentry with a `traces_sample_rate`, then register the [`SentryPropagator`] and the
 //! [`SentrySpanProcessor`]:
 //!
-//! ```ignore
+//! ```
 //! use opentelemetry::{
 //!     global,
 //!     trace::{TraceContextExt, Tracer},
@@ -65,7 +65,13 @@
 //!
 //! Use the OpenTelemetry API to create spans. They will be captured by Sentry:
 //!
-//! ```ignore
+//! ```
+//! # use opentelemetry::{
+//! #     global,
+//! #     trace::{TraceContextExt, Tracer},
+//! #     KeyValue,
+//! # };
+//!
 //! let tracer = global::tracer("tracer");
 //! // Creates a Sentry span (transaction) with the name set to "example"
 //! tracer.in_span("example", |_| {


### PR DESCRIPTION
The doctests show usage from the point of view of the `sentry` crate, as we are importing the subcrate as `use sentry::integrations::opentelemetry as sentry_opentelemetry;`.
Therefore the first doctest will not compile.
The second will also not compile because we have the imports in the first.
Let's just use `ignore` on both of them.