### PR TITLE
fix(otel): fix span and trace ids for distributed tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ An OpenTelemetry integration has been released. Please refer to the changelog en
 - build: add `sentry-opentelemetry` to workspace (#789) by @lcian
 - docs: update docs including OTEL and other integrations (#790) by @lcian
 - fix(otel): fix doctests (#794) by @lcian
+- fix(otel): fix span and trace ids for distributed tracing (#801) by @lcian
 
 ## 0.37.0
 

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -180,7 +180,7 @@ impl TransactionContext {
         headers: I,
     ) -> Self {
         parse_headers(headers)
-            .map(|sentry_trace| Self::continue_from_sentry_trace(name, op, &sentry_trace))
+            .map(|sentry_trace| Self::continue_from_sentry_trace(name, op, &sentry_trace, None))
             .unwrap_or_else(|| Self {
                 name: name.into(),
                 op: op.into(),
@@ -193,7 +193,12 @@ impl TransactionContext {
     }
 
     /// Creates a new Transaction Context based on the provided distributed tracing data.
-    pub fn continue_from_sentry_trace(name: &str, op: &str, sentry_trace: &SentryTrace) -> Self {
+    pub fn continue_from_sentry_trace(
+        name: &str,
+        op: &str,
+        sentry_trace: &SentryTrace,
+        span_id: Option<SpanId>,
+    ) -> Self {
         let (trace_id, parent_span_id, sampled) =
             (sentry_trace.0, Some(sentry_trace.1), sentry_trace.2);
         Self {
@@ -201,8 +206,8 @@ impl TransactionContext {
             op: op.into(),
             trace_id,
             parent_span_id,
-            span_id: Default::default(),
             sampled,
+            span_id: span_id.unwrap_or_default(),
             custom: None,
         }
     }

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -193,7 +193,7 @@ impl TransactionContext {
     }
 
     /// Creates a new Transaction Context based on the provided distributed tracing data,
-    /// optionally creating the `TransactionContext` with the provided `span_id`
+    /// optionally creating the `TransactionContext` with the provided `span_id`.
     pub fn continue_from_sentry_trace(
         name: &str,
         op: &str,

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -192,7 +192,8 @@ impl TransactionContext {
             })
     }
 
-    /// Creates a new Transaction Context based on the provided distributed tracing data.
+    /// Creates a new Transaction Context based on the provided distributed tracing data,
+    /// optionally creating the `TransactionContext` with the provided `span_id`
     pub fn continue_from_sentry_trace(
         name: &str,
         op: &str,

--- a/sentry-opentelemetry/src/processor.rs
+++ b/sentry-opentelemetry/src/processor.rs
@@ -110,8 +110,6 @@ impl SpanProcessor for SentrySpanProcessor {
         let span_description = span_description.as_str();
         let span_op = span_op.as_str();
 
-        println!("starting span with id {}", span_id.to_string(),);
-
         let sentry_span = {
             if let Some(parent_sentry_span) = parent_sentry_span {
                 // continue local trace
@@ -124,10 +122,6 @@ impl SpanProcessor for SentrySpanProcessor {
             } else {
                 let sentry_ctx = {
                     if let Some(sentry_trace) = ctx.get::<SentryTrace>() {
-                        println!(
-                            "continuing remote trace with span id {}",
-                            span_id.to_string(),
-                        );
                         // continue remote trace
                         TransactionContext::continue_from_sentry_trace(
                             span_description,
@@ -156,7 +150,6 @@ impl SpanProcessor for SentrySpanProcessor {
 
     fn on_end(&self, data: SpanData) {
         let span_id = data.span_context.span_id();
-        println!("ending span with id {}", span_id.to_string(),);
 
         let mut span_map = SPAN_MAP.lock().unwrap();
 

--- a/sentry-opentelemetry/src/processor.rs
+++ b/sentry-opentelemetry/src/processor.rs
@@ -35,7 +35,7 @@ static SPAN_MAP: LazyLock<SpanMap> = LazyLock::new(|| Arc::new(Mutex::new(HashMa
 
 /// An OpenTelemetry SpanProcessor that converts OTEL spans to Sentry spans/transactions and sends
 /// them to Sentry.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SentrySpanProcessor {}
 
 impl SentrySpanProcessor {
@@ -85,6 +85,13 @@ impl SentrySpanProcessor {
             });
         });
         Self {}
+    }
+}
+
+impl Default for SentrySpanProcessor {
+    /// Creates a default `SentrySpanProcessor`.
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/sentry-opentelemetry/src/processor.rs
+++ b/sentry-opentelemetry/src/processor.rs
@@ -48,13 +48,15 @@ impl SentrySpanProcessor {
                 get_active_span(|otel_span| {
                     let span_map = SPAN_MAP.lock().unwrap();
 
-                    let Some(sentry_span) = span_map.get(&convert_span_id(&otel_span.span_context().span_id())) else {
+                    let Some(sentry_span) =
+                        span_map.get(&convert_span_id(&otel_span.span_context().span_id()))
+                    else {
                         return;
                     };
 
                     let (span_id, trace_id) = match sentry_span {
                         TransactionOrSpan::Transaction(transaction) => (
-                            transaction.get_trace_context().span_id, 
+                            transaction.get_trace_context().span_id,
                             transaction.get_trace_context().trace_id,
                         ),
                         TransactionOrSpan::Span(span) => {

--- a/sentry-opentelemetry/tests/creates_distributed_trace.rs
+++ b/sentry-opentelemetry/tests/creates_distributed_trace.rs
@@ -32,8 +32,13 @@ fn test_creates_distributed_trace() {
     });
 
     // Now simulate the second service receiving the headers and continuing the trace
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_span_processor(SentrySpanProcessor::new())
+        .build();
+    let tracer = tracer_provider.tracer("test_2".to_string());
+    let propagator = SentryPropagator::new();
     let second_service_ctx =
-        propagator.extract_with_context(&Context::current(), &TestExtractor(&headers));
+        propagator.extract_with_context(&Context::new(), &TestExtractor(&headers));
 
     // Create a second service span that continues the trace
     // We need to use start_with_context here to connect with the previous context


### PR DESCRIPTION
- We're not guaranteed that OTEL `trace id` == Sentry `trace id` in the scenario where we continue a remote trace, therefore we need to go back to the static `SPAN_MAP` to rely on the Sentry `trace_id`.
- We also need to force OTEL `span id` == Sentry `span id` when continuing a remote trace, so I've updated that API.

Noticed this during manual testing.
I should update the integration tests to cover more scenarios.