### PR TITLE
build(otel): exclude version from circular dev-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ An OpenTelemetry integration has been released. Please refer to the changelog en
 - docs: update docs including OTEL and other integrations (#790) by @lcian
 - fix(otel): fix doctests (#794) by @lcian
 - fix(otel): fix span and trace ids for distributed tracing (#801) by @lcian
+- build(otel): exclude version from circular dev-dependencies (#802) by @lcian
 
 ## 0.37.0
 

--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -26,10 +26,8 @@ opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
 opentelemetry-semantic-conventions = "0.29.0"
 
 [dev-dependencies]
-sentry = { version = "0.37.0", path = "../sentry", features = ["test", "opentelemetry"] }
-sentry-core = { version = "0.37.0", path = "../sentry-core", features = [
-    "test",
-] }
+sentry = { path = "../sentry", features = ["test", "opentelemetry"] }
+sentry-core = { path = "../sentry-core", features = [ "test" ] }
 opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
     "trace",
     "testing",


### PR DESCRIPTION
See https://github.com/getsentry/publish/issues/740