### PR TITLE
ci: bump actions, move to `rustsec/audit-check`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,5 +6,5 @@ coverage:
     patch: false
 
 comment:
-  layout: "diff, flags, files"
+  layout: "diff"
   require_changes: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,5 +6,5 @@ coverage:
     patch: false
 
 comment:
-  layout: "diff"
+  layout: "diff, flags, files"
   require_changes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   doc:
     name: Build-test documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - run: rustup component add rustfmt clippy
 
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
 
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
 
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install rust ${{ matrix.rust }} toolchain
         run: |
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup component add llvm-tools-preview
 
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - run: rustup component add rust-docs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
       - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
-      - uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # FIXME: find a maintained alternative to audit-check
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository_owner == 'getsentry'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install rust stable toolchain
         run: |
@@ -36,7 +36,7 @@ jobs:
     if: github.repository_owner == 'getsentry'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # FIXME: find a maintained alternative to audit-check
       - uses: actions-rs/audit-check@v1


### PR DESCRIPTION
- bump `actions/checkout` to `v4`
- bump`codecov/codecov-action` to `v5` and pass `secrets.CODECOV_TOKEN`
- move from `actions-rs/audit-check@v1` to `rustsec/audit-check@v2` (pinned) which is more or less maintained