### PR TITLE
build: pull in `sentry-actix` optionally when `release-health` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- build: pull in `sentry-actix` optionally when `release-health` is enabled (#806) by @lcian
+  - `sentry-actix` is now being pulled in as a dependency only when explicitly added, either as a direct dependency or through the `actix` feature flag of the `sentry` crate.
+  - Due to a mistake in the `Cargo.toml`, it was previously being pulled in by default when using the `sentry` crate with default features.
+
 ## 0.38.0
 
 ### OpenTelemetry integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixes
 
-- build: pull in `sentry-actix` optionally when `release-health` is enabled (#806) by @lcian
-  - `sentry-actix` is now being pulled in as a dependency only when explicitly added, either as a direct dependency or through the `actix` feature flag of the `sentry` crate.
-  - Due to a mistake in the `Cargo.toml`, it was previously being pulled in by default when using the `sentry` crate with default features.
+- build: include `sentry-actix` optionally when `release-health` is enabled (#806) by @lcian
+  - `sentry-actix` is now being included as a dependency only when explicitly added, either as a direct dependency or through the `actix` feature flag of the `sentry` crate.
+  - Due to a mistake in the `Cargo.toml`, it was previously being included as a dependency by default when using just the `sentry` crate with default features.
 
 ## 0.38.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "sentry",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "backtrace",
  "regex",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "hostname",
  "libc",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "log",
  "pretty_env_logger",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-opentelemetry"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "sentry",
  "sentry-backtrace",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-slog"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "erased-serde",
  "sentry",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "log",
  "sentry",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "debugid",
  "hex",

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -48,7 +48,7 @@ opentelemetry = ["sentry-opentelemetry"]
 # other features
 test = ["sentry-core/test"]
 debug-logs = ["dep:log", "sentry-core/debug-logs"]
-release-health = ["sentry-core/release-health", "sentry-actix/release-health"]
+release-health = ["sentry-core/release-health", "sentry-actix?/release-health"]
 # transports
 transport = ["reqwest", "native-tls"]
 reqwest = ["dep:reqwest", "httpdate", "tokio"]


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-rust/issues/804 
Closes https://github.com/getsentry/sentry-rust/issues/805 