### PR TITLE
refactor(core): remove support for `traceparent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "sentry",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "backtrace",
  "regex",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "hostname",
  "libc",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "cadence",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "log",
  "pretty_env_logger",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-opentelemetry"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "sentry",
  "sentry-backtrace",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-slog"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "erased-serde",
  "sentry",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "log",
  "sentry",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "debugid",
  "hex",


### PR DESCRIPTION
We have decided to not support parsing `traceparent` from incoming requests anymore, see https://github.com/getsentry/sentry-php/pull/1833 https://github.com/getsentry/sentry-docs/pull/13686