### PR TITLE
feat(core): implement Tracing without Performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - feat(core): implement Tracing without Performance (#811) by @lcian
   - The SDK now implements Tracing without Performance, which makes it so that each `Scope` is associated with an object holding some tracing information.
   - This information is used as a fallback when capturing an event with tracing disabled or otherwise no ongoing span, to still allow related events to be linked by a trace.
-  - A new API `Scope::iter_trace_propagation_headers` has been provided that will use the fallback tracing information if there is no current `Span`.
+  - A new API `Scope::iter_trace_propagation_headers` has been provided that will use the fallback tracing information if there is no current `Span` on the `Scope`.
 
 ## 0.38.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Behavioral changes
+
+- feat(core): implement Tracing without Performance (#811) by @lcian
+  - The SDK now implements Tracing without Performance, which makes it so that each `Scope` is associated with an object holding some tracing information.
+  - This information is used as a fallback when capturing an event with tracing disabled or otherwise no ongoing span, to still allow related events to be linked by a trace.
+
 ## 0.38.1
 
 ### Fixes

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -778,11 +778,11 @@ impl Transaction {
     /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let inner = self.inner.lock().unwrap();
-        let trace = SentryTrace {
-            trace_id: inner.context.trace_id,
-            span_id: inner.context.span_id,
-            sampled: Some(inner.sampled),
-        };
+        let trace = SentryTrace::new(
+            inner.context.trace_id,
+            inner.context.span_id,
+            Some(inner.sampled),
+        );
         TraceHeadersIter {
             sentry_trace: Some(trace.to_string()),
         }

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -476,8 +476,8 @@ impl TransactionOrSpan {
     }
 
     /// Returns the headers needed for distributed tracing.
-    /// [`crate::Scope::iter_trace_propagation_headers`] is preferred if the intention is to get
-    /// the distributed tracing headers for the currently active span/transaction.
+    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active 
+    /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         match self {
             TransactionOrSpan::Transaction(transaction) => transaction.iter_headers(),

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -776,8 +776,8 @@ impl Transaction {
     }
 
     /// Returns the headers needed for distributed tracing.
-    /// [`crate::Scope::iter_trace_propagation_headers`] is preferred if the intention is to get
-    /// the distributed tracing headers for the currently active transaction.
+    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active 
+    /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let inner = self.inner.lock().unwrap();
         let trace = SentryTrace(

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -1030,8 +1030,8 @@ impl Span {
     }
 
     /// Returns the headers needed for distributed tracing.
-    /// [`crate::Scope::iter_trace_propagation_headers`] is preferred if the intention is to get
-    /// the distributed tracing headers for the currently active span.
+    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active 
+    /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let span = self.span.lock().unwrap();
         let trace = SentryTrace(span.trace_id, span.span_id, Some(self.sampled));

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -476,7 +476,7 @@ impl TransactionOrSpan {
     }
 
     /// Returns the headers needed for distributed tracing.
-    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active 
+    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active
     /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         match self {
@@ -776,7 +776,7 @@ impl Transaction {
     }
 
     /// Returns the headers needed for distributed tracing.
-    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active 
+    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active
     /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let inner = self.inner.lock().unwrap();
@@ -1030,7 +1030,7 @@ impl Span {
     }
 
     /// Returns the headers needed for distributed tracing.
-    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active 
+    /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active
     /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let span = self.span.lock().unwrap();

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -475,7 +475,7 @@ impl TransactionOrSpan {
 
     /// Returns the headers needed for distributed tracing.
     /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active
-    /// span's/transaction's distributed tracing headers.
+    /// trace's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         match self {
             TransactionOrSpan::Transaction(transaction) => transaction.iter_headers(),
@@ -775,7 +775,7 @@ impl Transaction {
 
     /// Returns the headers needed for distributed tracing.
     /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active
-    /// span's/transaction's distributed tracing headers.
+    /// trace's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let inner = self.inner.lock().unwrap();
         let trace = SentryTrace::new(
@@ -1029,7 +1029,7 @@ impl Span {
 
     /// Returns the headers needed for distributed tracing.
     /// Use [`crate::Scope::iter_trace_propagation_headers`] to obtain the active
-    /// span's/transaction's distributed tracing headers.
+    /// trace's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let span = self.span.lock().unwrap();
         let trace = SentryTrace::new(span.trace_id, span.span_id, Some(self.sampled));
@@ -1141,7 +1141,7 @@ pub struct TraceHeadersIter {
 }
 
 impl TraceHeadersIter {
-    #[cfg_attr(not(feature = "client"), allow(dead_code))]
+    #[cfg(feature = "client")]
     pub(crate) fn new(sentry_trace: String) -> Self {
         Self {
             sentry_trace: Some(sentry_trace),

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -1149,7 +1149,7 @@ impl Iterator for TraceHeadersIter {
 
 /// A container for distributed tracing metadata that can be extracted from e.g. the `sentry-trace`
 /// HTTP header.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct SentryTrace(
     pub(crate) protocol::TraceId,
     pub(crate) protocol::SpanId,

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -199,14 +199,12 @@ impl TransactionContext {
         sentry_trace: &SentryTrace,
         span_id: Option<SpanId>,
     ) -> Self {
-        let (trace_id, parent_span_id, sampled) =
-            (sentry_trace.0, Some(sentry_trace.1), sentry_trace.2);
         Self {
             name: name.into(),
             op: op.into(),
-            trace_id,
-            parent_span_id,
-            sampled,
+            trace_id: sentry_trace.trace_id,
+            parent_span_id: Some(sentry_trace.span_id),
+            sampled: sentry_trace.sampled,
             span_id: span_id.unwrap_or_default(),
             custom: None,
         }
@@ -780,11 +778,11 @@ impl Transaction {
     /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let inner = self.inner.lock().unwrap();
-        let trace = SentryTrace(
-            inner.context.trace_id,
-            inner.context.span_id,
-            Some(inner.sampled),
-        );
+        let trace = SentryTrace {
+            trace_id: inner.context.trace_id,
+            span_id: inner.context.span_id,
+            sampled: Some(inner.sampled),
+        };
         TraceHeadersIter {
             sentry_trace: Some(trace.to_string()),
         }
@@ -1034,7 +1032,7 @@ impl Span {
     /// span's/transaction's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let span = self.span.lock().unwrap();
-        let trace = SentryTrace(span.trace_id, span.span_id, Some(self.sampled));
+        let trace = SentryTrace::new(span.trace_id, span.span_id, Some(self.sampled));
         TraceHeadersIter {
             sentry_trace: Some(trace.to_string()),
         }
@@ -1131,12 +1129,24 @@ impl Span {
     }
 }
 
+/// Represents a key-value pair such as an HTTP header.
+pub type TraceHeader = (&'static str, String);
+
 /// An Iterator over HTTP header names and values needed for distributed tracing.
 ///
 /// This currently only yields the `sentry-trace` header, but other headers
 /// may be added in the future.
 pub struct TraceHeadersIter {
-    pub(crate) sentry_trace: Option<String>,
+    sentry_trace: Option<String>,
+}
+
+impl TraceHeadersIter {
+    #[cfg_attr(not(feature = "client"), allow(dead_code))]
+    pub(crate) fn new(sentry_trace: String) -> Self {
+        Self {
+            sentry_trace: Some(sentry_trace),
+        }
+    }
 }
 
 impl Iterator for TraceHeadersIter {
@@ -1149,12 +1159,12 @@ impl Iterator for TraceHeadersIter {
 
 /// A container for distributed tracing metadata that can be extracted from e.g. the `sentry-trace`
 /// HTTP header.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub struct SentryTrace(
-    pub(crate) protocol::TraceId,
-    pub(crate) protocol::SpanId,
-    pub(crate) Option<bool>, // sampled
-);
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub struct SentryTrace {
+    pub(crate) trace_id: protocol::TraceId,
+    pub(crate) span_id: protocol::SpanId,
+    pub(crate) sampled: Option<bool>,
+}
 
 impl SentryTrace {
     /// Creates a new [`SentryTrace`] from the provided parameters
@@ -1163,7 +1173,11 @@ impl SentryTrace {
         span_id: protocol::SpanId,
         sampled: Option<bool>,
     ) -> Self {
-        SentryTrace(trace_id, span_id, sampled)
+        SentryTrace {
+            trace_id,
+            span_id,
+            sampled,
+        }
     }
 }
 
@@ -1179,7 +1193,7 @@ fn parse_sentry_trace(header: &str) -> Option<SentryTrace> {
         _ => None,
     });
 
-    Some(SentryTrace(trace_id, parent_span_id, parent_sampled))
+    Some(SentryTrace::new(trace_id, parent_span_id, parent_sampled))
 }
 
 /// Extracts distributed tracing metadata from headers (or, generally, key-value pairs),
@@ -1199,8 +1213,8 @@ pub fn parse_headers<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(
 
 impl std::fmt::Display for SentryTrace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}-{}", self.0, self.1)?;
-        if let Some(sampled) = self.2 {
+        write!(f, "{}-{}", self.trace_id, self.span_id)?;
+        if let Some(sampled) = self.sampled {
             write!(f, "-{}", if sampled { '1' } else { '0' })?;
         }
         Ok(())
@@ -1221,10 +1235,10 @@ mod tests {
         let trace = parse_sentry_trace("09e04486820349518ac7b5d2adbf6ba5-9cf635fa5b870b3a-0");
         assert_eq!(
             trace,
-            Some(SentryTrace(trace_id, parent_trace_id, Some(false)))
+            Some(SentryTrace::new(trace_id, parent_trace_id, Some(false)))
         );
 
-        let trace = SentryTrace(Default::default(), Default::default(), None);
+        let trace = SentryTrace::new(Default::default(), Default::default(), None);
         let parsed = parse_sentry_trace(&trace.to_string());
         assert_eq!(parsed, Some(trace));
     }
@@ -1243,8 +1257,11 @@ mod tests {
         let header = span.iter_headers().next().unwrap().1;
         let parsed = parse_sentry_trace(&header).unwrap();
 
-        assert_eq!(&parsed.0.to_string(), "09e04486820349518ac7b5d2adbf6ba5");
-        assert_eq!(parsed.2, Some(true));
+        assert_eq!(
+            &parsed.trace_id.to_string(),
+            "09e04486820349518ac7b5d2adbf6ba5"
+        );
+        assert_eq!(parsed.sampled, Some(true));
     }
 
     #[test]

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -21,10 +21,10 @@ pub struct Stack {
 
 pub type EventProcessor = Arc<dyn Fn(Event<'static>) -> Option<Event<'static>> + Send + Sync>;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct PropagationContext {
-    pub(crate) trace_id: TraceId,
-    pub(crate) span_id: SpanId,
+    trace_id: TraceId,
+    span_id: SpanId,
 }
 
 /// Holds contextual data for the current scope.

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1423,7 +1423,7 @@ impl fmt::Display for TraceId {
 
 impl fmt::Debug for TraceId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self)
+        write!(fmt, "TraceId({})", self)
     }
 }
 

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1370,7 +1370,7 @@ impl fmt::Display for SpanId {
 
 impl fmt::Debug for SpanId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self)
+        write!(fmt, "SpanId({})", self)
     }
 }
 

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -1352,7 +1352,7 @@ pub struct OtelContext {
 }
 
 /// Holds the identifier for a Span
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Hash)]
 #[serde(try_from = "String", into = "String")]
 pub struct SpanId([u8; 8]);
 
@@ -1365,6 +1365,12 @@ impl Default for SpanId {
 impl fmt::Display for SpanId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{}", hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for SpanId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self)
     }
 }
 
@@ -1399,7 +1405,7 @@ impl From<[u8; 8]> for SpanId {
 }
 
 /// Holds the identifier for a Trace
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Hash)]
 #[serde(try_from = "String", into = "String")]
 pub struct TraceId([u8; 16]);
 
@@ -1412,6 +1418,12 @@ impl Default for TraceId {
 impl fmt::Display for TraceId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{}", hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for TraceId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self)
     }
 }
 

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -9,11 +9,9 @@ use sentry::types::Uuid;
 #[test]
 fn test_basic_capture_message() {
     let mut last_event_id = None::<Uuid>;
-    let mut span = None;
     let events = sentry::test::with_captured_events(|| {
         sentry::configure_scope(|scope| {
             scope.set_tag("worker", "worker1");
-            span = scope.get_span();
         });
         sentry::capture_message("Hello World!", sentry::Level::Warning);
         last_event_id = sentry::last_event_id();
@@ -28,6 +26,21 @@ fn test_basic_capture_message() {
     );
 
     assert_eq!(Some(event.event_id), last_event_id);
+}
+
+#[test]
+fn test_event_propagation_context() {
+    let mut last_event_id = None::<Uuid>;
+    let mut span = None;
+    let events = sentry::test::with_captured_events(|| {
+        sentry::configure_scope(|scope| {
+            span = scope.get_span();
+        });
+        sentry::capture_message("Hello World!", sentry::Level::Warning);
+        last_event_id = sentry::last_event_id();
+    });
+    assert_eq!(events.len(), 1);
+    let event = events.into_iter().next().unwrap();
 
     let trace_context = event.contexts.get("trace");
     assert!(span.is_none());

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -29,7 +29,7 @@ fn test_basic_capture_message() {
 }
 
 #[test]
-fn test_event_propagation_context() {
+fn test_event_trace_context_from_propagation_context() {
     let mut last_event_id = None::<Uuid>;
     let mut span = None;
     let events = sentry::test::with_captured_events(|| {


### PR DESCRIPTION
Implements Tracing without Performance ([spec](https://develop.sentry.dev/sdk/telemetry/traces/tracing-without-performance/)).

This is done by having an additional `PropagationContext` attribute on the scope that holds a "fake" `trace_id` and `span_id`.
When applying the scope to an event, if there is no ongoing span set on the scope, we create the `trace` context from the `PropagationContext`.
Additionally, adds an API `scope.iter_trace_propagation_headers` that should be preferred over something like:
```rust
sentry::configure_scope(|scope| {
	if let Some(span) = scope.get_span() {
		headers = Some(span.iter_headers());
	} 
});
```
because it will use the `PropagationContext` as a fallback.

Closes #796

Also makes a minor adjustment to trace and span ids where we now use the `Display` impl for `Debug`, otherwise we were getting u8 arrays when using e.g. `dbg!` with the derived one which is not very useful.