### PR TITLE
ci: adopt Danger with Sentry's shared config

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,9 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+jobs:
+  danger:
+    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2


### PR DESCRIPTION
Enables Danger with our shared config.
I prefer to be forced to write the changelog directly with each PR.

#skip-changelog