### PR TITLE
build: remove some unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,7 +3228,6 @@ dependencies = [
  "log",
  "rand 0.9.0",
  "rayon",
- "regex",
  "sentry",
  "sentry-types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,15 +549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cadence"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fd689c825a93386a2ac05a46f88342c6df9ec3e79416f665650614e92e7475"
-dependencies = [
- "crossbeam-channel",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,15 +808,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -2462,12 +2444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3247,8 +3223,6 @@ name = "sentry-core"
 version = "0.38.1"
 dependencies = [
  "anyhow",
- "cadence",
- "crc32fast",
  "criterion",
  "futures",
  "log",
@@ -3287,7 +3261,6 @@ name = "sentry-opentelemetry"
 version = "0.38.1"
 dependencies = [
  "opentelemetry",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "sentry",
  "sentry-core",

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -29,8 +29,6 @@ test = ["client", "release-health"]
 release-health = []
 
 [dependencies]
-cadence = { version = "1.4.0", optional = true }
-crc32fast = { version = "1.4.0", optional = true }
 log = { version = "0.4.8", optional = true, features = ["std"] }
 rand = { version = "0.9.0", optional = true }
 regex = { version = "1.7.3", optional = true }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -31,7 +31,6 @@ release-health = []
 [dependencies]
 log = { version = "0.4.8", optional = true, features = ["std"] }
 rand = { version = "0.9.0", optional = true }
-regex = { version = "1.7.3", optional = true }
 sentry-types = { version = "0.38.1", path = "../sentry-types" }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = { version = "1.0.46" }

--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -23,7 +23,6 @@ opentelemetry = { version = "0.29.0", default-features = false }
 opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
     "trace",
 ] }
-opentelemetry-semantic-conventions = "0.29.0"
 
 [dev-dependencies]
 sentry = { path = "../sentry", features = ["test", "opentelemetry"] }


### PR DESCRIPTION
Just removes some unused deps.
The ones in `sentry-core` were used for metrics. (not sure why `cargo udeps` doesn't detect these but grepping through the crate they are not found anywhere).
The one in `sentry-opentelemetry` we don't need at the moment because we're not doing any attribute conversion (e.g. https://github.com/getsentry/sentry-rust/issues/793).