### PR TITLE
refactor: remove `debug-logs` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### Unreleased
+
+### Breaking changes
+
+- refactor: remove `debug-logs` feature (#820) by @lcian
+  - The deprecated `debug-logs` feature of the `sentry` crate has been removed.
+
 ## 0.38.1
 
 ### Fixes

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -22,9 +22,6 @@ harness = false
 [features]
 default = []
 client = ["rand"]
-# I would love to just have a `log` feature, but this is used inside a macro,
-# and macros actually expand features (and extern crate) where they are used!
-debug-logs = ["dep:log"]
 test = ["client", "release-health"]
 release-health = []
 

--- a/sentry-core/README.md
+++ b/sentry-core/README.md
@@ -95,9 +95,6 @@ functionality.
 - `feature = "test"`: Activates the [`test`] module, which can be used to
   write integration tests. It comes with a test transport which can capture
   all sent events for inspection.
-- `feature = "debug-logs"`: Uses the `log` crate for debug output, instead
-  of printing to `stderr`. This feature is **deprecated** and will be
-  replaced by a dedicated log callback in the future.
 
 [Sentry]: https://sentry.io/
 [`sentry`]: https://crates.io/crates/sentry

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -93,9 +93,6 @@
 //! - `feature = "test"`: Activates the [`test`] module, which can be used to
 //!   write integration tests. It comes with a test transport which can capture
 //!   all sent events for inspection.
-//! - `feature = "debug-logs"`: Uses the `log` crate for debug output, instead
-//!   of printing to `stderr`. This feature is **deprecated** and will be
-//!   replaced by a dedicated log callback in the future.
 //!
 //! [Sentry]: https://sentry.io/
 //! [`sentry`]: https://crates.io/crates/sentry

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -55,17 +55,12 @@ macro_rules! with_client_impl {
 #[doc(hidden)]
 macro_rules! sentry_debug {
     ($($arg:tt)*) => {
-        #[cfg(feature = "debug-logs")] {
-            ::log::debug!(target: "sentry", $($arg)*);
-        }
-        #[cfg(not(feature = "debug-logs"))] {
-            $crate::Hub::with(|hub| {
-                if hub.client().map_or(false, |c| c.options().debug) {
-                    eprint!("[sentry] ");
-                    eprintln!($($arg)*);
-                }
-            });
-        }
+        $crate::Hub::with(|hub| {
+            if hub.client().map_or(false, |c| c.options().debug) {
+                eprint!("[sentry] ");
+                eprintln!($($arg)*);
+            }
+        });
     }
 }
 

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -47,7 +47,6 @@ tracing = ["sentry-tracing"]
 opentelemetry = ["sentry-opentelemetry"]
 # other features
 test = ["sentry-core/test"]
-debug-logs = ["dep:log", "sentry-core/debug-logs"]
 release-health = ["sentry-core/release-health", "sentry-actix?/release-health"]
 # transports
 transport = ["reqwest", "native-tls"]

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -73,7 +73,6 @@ sentry-slog = { version = "0.38.1", path = "../sentry-slog", optional = true }
 sentry-tower = { version = "0.38.1", path = "../sentry-tower", optional = true }
 sentry-tracing = { version = "0.38.1", path = "../sentry-tracing", optional = true }
 sentry-opentelemetry = { version = "0.38.1", path = "../sentry-opentelemetry", optional = true }
-log = { version = "0.4.8", optional = true, features = ["std"] }
 reqwest = { version = "0.12", optional = true, features = [
     "blocking",
     "json",

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -76,7 +76,6 @@ extra setup to function properly.
 | `test`            |         |                |            |                                                                                          |
 | `debug-images`    | ✅      | 🔌             |            |                                                                                          |
 | `log`             |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
-| `debug-logs`      |         |                | ❗         | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 | `slog`            |         | 🔌             |            | Requires extra setup; See [`sentry-slog`]'s documentation.                               |
 | `reqwest`         | ✅      |                |            |                                                                                          |
 | `native-tls`      | ✅      |                |            | `reqwest` must be enabled.                                                               |
@@ -110,7 +109,6 @@ extra setup to function properly.
 ### Logging
 - `log`: Enables support for the `log` crate.
 - `slog`: Enables support for the `slog` crate.
-- `debug-logs`: **Deprecated**. Uses the `log` crate for internal logging.
 
 ### Transports
 - `reqwest`: **Default**. Enables the `reqwest` transport.

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -68,7 +68,6 @@
 //! | `test`            |         |                |            |                                                                                          |
 //! | `debug-images`    | ✅      | 🔌             |            |                                                                                          |
 //! | `log`             |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
-//! | `debug-logs`      |         |                | ❗         | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 //! | `slog`            |         | 🔌             |            | Requires extra setup; See [`sentry-slog`]'s documentation.                               |
 //! | `reqwest`         | ✅      |                |            |                                                                                          |
 //! | `native-tls`      | ✅      |                |            | `reqwest` must be enabled.                                                               |
@@ -102,7 +101,6 @@
 //! ## Logging
 //! - `log`: Enables support for the `log` crate.
 //! - `slog`: Enables support for the `slog` crate.
-//! - `debug-logs`: **Deprecated**. Uses the `log` crate for internal logging.
 //!
 //! ## Transports
 //! - `reqwest`: **Default**. Enables the `reqwest` transport.


### PR DESCRIPTION
Removes this feature that was already marked as deprecated.
This will allow us to use the `sentry_debug` macro in the other subcrates to log more stuff useful for troubleshooting.
Part of #620 