### PR TITLE
feat(logs): add ability to send logs and basic API

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -24,6 +24,7 @@ default = []
 client = ["rand"]
 test = ["client", "release-health"]
 release-health = []
+logs = []
 
 [dependencies]
 log = { version = "0.4.8", optional = true, features = ["std"] }

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -2,6 +2,8 @@
 use sentry_types::protocol::v7::SessionStatus;
 
 use crate::protocol::{Event, Level};
+#[cfg(feature = "logs")]
+use crate::protocol::{LogAttribute, LogLevel, Map};
 use crate::types::Uuid;
 use crate::{Hub, Integration, IntoBreadcrumbs, Scope};
 
@@ -301,4 +303,10 @@ pub fn end_session() {
 #[cfg(feature = "release-health")]
 pub fn end_session_with_status(status: SessionStatus) {
     Hub::with_active(|hub| hub.end_session_with_status(status))
+}
+
+/// Captures a log with the given message, level and optional additional attributes.
+#[cfg(feature = "logs")]
+pub fn capture_log(message: &str, level: LogLevel, attributes: Option<Map<String, LogAttribute>>) {
+    Hub::with_active(|hub| hub.capture_log(message, level, attributes))
 }

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -371,6 +371,9 @@ impl Client {
     /// Captures a log and sends it to Sentry.
     #[cfg(feature = "logs")]
     pub fn capture_log(&self, log: Log, scope: &Scope) {
+        if !self.options().enable_logs {
+            return;
+        }
         if let Some(ref transport) = *self.transport.read().unwrap() {
             if let Some(log) = self.prepare_log(log, scope) {
                 let mut envelope = Envelope::new();

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 
 use crate::constants::USER_AGENT;
 use crate::performance::TracesSampler;
+#[cfg(feature = "logs")]
+use crate::protocol::Log;
 use crate::protocol::{Breadcrumb, Event};
 use crate::types::Dsn;
 use crate::{Integration, IntoDsn, TransportFactory};
@@ -144,6 +146,9 @@ pub struct ClientOptions {
     pub before_send: Option<BeforeCallback<Event<'static>>>,
     /// Callback that is executed for each Breadcrumb being added.
     pub before_breadcrumb: Option<BeforeCallback<Breadcrumb>>,
+    /// Callback that is executed for each Log being added.
+    #[cfg(feature = "logs")]
+    pub before_send_log: Option<BeforeCallback<Log>>,
     // Transport options
     /// The transport to use.
     ///
@@ -162,6 +167,12 @@ pub struct ClientOptions {
     pub https_proxy: Option<Cow<'static, str>>,
     /// The timeout on client drop for draining events on shutdown.
     pub shutdown_timeout: Duration,
+    /// Controls how much of request bodies are captured
+    pub max_request_body_size: MaxRequestBodySize,
+    /// Determines whether logs captured through the API/integrations should be captured or not.
+    /// (defaults to false)
+    #[cfg(feature = "logs")]
+    pub enable_logs: bool,
     // Other options not documented in Unified API
     /// Disable SSL verification.
     ///
@@ -186,8 +197,6 @@ pub struct ClientOptions {
     pub trim_backtraces: bool,
     /// The user agent that should be reported.
     pub user_agent: Cow<'static, str>,
-    /// Controls how much of request bodies are captured
-    pub max_request_body_size: MaxRequestBodySize,
 }
 
 impl ClientOptions {
@@ -223,6 +232,12 @@ impl fmt::Debug for ClientOptions {
         #[derive(Debug)]
         struct BeforeBreadcrumb;
         let before_breadcrumb = self.before_breadcrumb.as_ref().map(|_| BeforeBreadcrumb);
+        #[cfg(feature = "logs")]
+        let before_send_log = {
+            #[derive(Debug)]
+            struct BeforeSendLog;
+            self.before_send_log.as_ref().map(|_| BeforeSendLog)
+        };
         #[derive(Debug)]
         struct TransportFactory;
 
@@ -263,6 +278,11 @@ impl fmt::Debug for ClientOptions {
         debug_struct
             .field("auto_session_tracking", &self.auto_session_tracking)
             .field("session_mode", &self.session_mode);
+
+        #[cfg(feature = "logs")]
+        debug_struct
+            .field("enable_logs", &self.enable_logs)
+            .field("before_send_log", &before_send_log);
 
         debug_struct
             .field("extra_border_frames", &self.extra_border_frames)
@@ -305,6 +325,10 @@ impl Default for ClientOptions {
             trim_backtraces: true,
             user_agent: Cow::Borrowed(USER_AGENT),
             max_request_body_size: MaxRequestBodySize::Medium,
+            #[cfg(feature = "logs")]
+            enable_logs: false,
+            #[cfg(feature = "logs")]
+            before_send_log: None,
         }
     }
 }

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+#[cfg(feature = "logs")]
+use crate::protocol::Log;
 use crate::protocol::{Context, Event, Level, User, Value};
 use crate::TransactionOrSpan;
 
@@ -107,6 +109,12 @@ impl Scope {
     /// Applies the contained scoped data to fill an event.
     pub fn apply_to_event(&self, event: Event<'static>) -> Option<Event<'static>> {
         let _event = event;
+        minimal_unreachable!();
+    }
+
+    /// Applies the contained scoped data to fill a log.
+    #[cfg(feature = "logs")]
+    pub fn apply_to_log(&self, log: &mut Log) {
         minimal_unreachable!();
     }
 

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -5,10 +5,12 @@ use std::fmt;
 use std::sync::Mutex;
 use std::sync::{Arc, PoisonError, RwLock};
 
-use sentry_types::protocol::v7::TraceContext;
-
 use crate::performance::TransactionOrSpan;
-use crate::protocol::{Attachment, Breadcrumb, Context, Event, Level, Transaction, User, Value};
+use crate::protocol::{
+    Attachment, Breadcrumb, Context, Event, Level, TraceContext, Transaction, User, Value,
+};
+#[cfg(feature = "logs")]
+use crate::protocol::{Log, LogAttribute};
 #[cfg(feature = "release-health")]
 use crate::session::Session;
 use crate::{Client, SentryTrace, TraceHeader, TraceHeadersIter};
@@ -344,6 +346,57 @@ impl Scope {
                 .iter()
                 .map(|(k, v)| (k.to_owned(), v.to_owned())),
         );
+    }
+
+    /// Applies the contained scoped data to a log, setting the `trace_id` and certain default
+    /// attributes.
+    #[cfg(feature = "logs")]
+    pub fn apply_to_log(&self, log: &mut Log, send_default_pii: bool) {
+        if let Some(span) = self.span.as_ref() {
+            log.trace_id = Some(span.get_trace_context().trace_id);
+        } else {
+            log.trace_id = Some(self.propagation_context.trace_id);
+        }
+
+        if !log.attributes.contains_key("sentry.trace.parent_span_id") {
+            if let Some(span) = self.get_span() {
+                let span_id = match span {
+                    crate::TransactionOrSpan::Transaction(transaction) => {
+                        transaction.get_trace_context().span_id
+                    }
+                    crate::TransactionOrSpan::Span(span) => span.get_span_id(),
+                };
+                log.attributes.insert(
+                    "parent_span_id".to_owned(),
+                    LogAttribute(span_id.to_string().into()),
+                );
+            }
+        }
+
+        if send_default_pii {
+            if !log.attributes.contains_key("user.id") {
+                if let Some(id) = self.user().and_then(|user| user.id.as_ref()) {
+                    log.attributes
+                        .insert("user.id".to_owned(), LogAttribute(id.to_owned().into()));
+                }
+            }
+
+            if !log.attributes.contains_key("user.name") {
+                if let Some(name) = self.user().and_then(|user| user.username.as_ref()) {
+                    log.attributes
+                        .insert("user.name".to_owned(), LogAttribute(name.to_owned().into()));
+                }
+            }
+
+            if !log.attributes.contains_key("user.email") {
+                if let Some(email) = self.user().and_then(|user| user.email.as_ref()) {
+                    log.attributes.insert(
+                        "user.email".to_owned(),
+                        LogAttribute(email.to_owned().into()),
+                    );
+                }
+            }
+        }
     }
 
     /// Set the given [`TransactionOrSpan`] as the active span for this scope.

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -1071,17 +1071,17 @@ some content
             Log {
                 level: protocol::LogLevel::Warn,
                 body: "test".to_owned(),
-                trace_id: "335e53d614474acc9f89e632b776cc28".parse().unwrap(),
-                timestamp: timestamp("2022-07-25T14:51:14.296Z"),
-                severity_number: 1.try_into().unwrap(),
+                trace_id: Some("335e53d614474acc9f89e632b776cc28".parse().unwrap()),
+                timestamp: Some(timestamp("2022-07-25T14:51:14.296Z")),
+                severity_number: Some(1.try_into().unwrap()),
                 attributes,
             },
             Log {
                 level: protocol::LogLevel::Error,
                 body: "a body".to_owned(),
-                trace_id: "332253d614472a2c9f89e232b7762c28".parse().unwrap(),
-                timestamp: timestamp("2021-07-21T14:51:14.296Z"),
-                severity_number: 1.try_into().unwrap(),
+                trace_id: Some("332253d614472a2c9f89e232b7762c28".parse().unwrap()),
+                timestamp: Some(timestamp("2021-07-21T14:51:14.296Z")),
+                severity_number: Some(1.try_into().unwrap()),
                 attributes: attributes_2,
             },
         ]

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -28,6 +28,7 @@ default = [
     "panic",
     "transport",
     "release-health",
+    "logs",
 ]
 
 # default integrations
@@ -48,6 +49,7 @@ opentelemetry = ["sentry-opentelemetry"]
 # other features
 test = ["sentry-core/test"]
 release-health = ["sentry-core/release-health", "sentry-actix?/release-health"]
+logs = ["sentry-core/logs"]
 # transports
 transport = ["reqwest", "native-tls"]
 reqwest = ["dep:reqwest", "httpdate", "tokio"]


### PR DESCRIPTION
Adds the ability to capture `Log`s and a basic API.
Link to the [spec](https://develop.sentry.dev/sdk/telemetry/logs/#public-api)

#### Sending logs
- The features are gated behind a "logs" flag. It could be a bit confusing because we have a "log" flag that pulls in "sentry-log" already, but at least we removed "debug-logs".
- We need it to be a feature flag for the same reason as `release-health`: we will use a thread to batch and flush the logs, which would not be compatible with e.g. WASM. So, we need to make it optional.
- TODO: disable the flag by default on `sentry` and mark it as `experimental`/`unstable` until we are good with the API.
- According to the spec, an additional init option `enable_logs` was added to enable capturing them.

#### API
- In a followup PR I plan to create macros equivalent to those of `tracing` that will construct the `Log` and capture it. 
- Usage would look like: `sentry::logger::warn!("warning", attribute = 42);`
- `sentry::capture_log` and `Hub::capture_log` will be removed in that PR in favor of the macros.

Part of https://github.com/getsentry/sentry-rust/issues/798
Comes after https://github.com/getsentry/sentry-rust/pull/821