### PR TITLE
feat(logs): send logs in batches

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -5,14 +5,14 @@ use std::panic::RefUnwindSafe;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-#[cfg(feature = "UNSTABLE_logs")]
-use crate::protocol::EnvelopeItem;
 #[cfg(feature = "release-health")]
 use crate::protocol::SessionUpdate;
 use rand::random;
 use sentry_types::random_uuid;
 
 use crate::constants::SDK_INFO;
+#[cfg(feature = "UNSTABLE_logs")]
+use crate::logs::LogsBatcher;
 use crate::protocol::{ClientSdkInfo, Event};
 #[cfg(feature = "release-health")]
 use crate::session::SessionFlusher;
@@ -53,6 +53,8 @@ pub struct Client {
     transport: TransportArc,
     #[cfg(feature = "release-health")]
     session_flusher: RwLock<Option<SessionFlusher>>,
+    #[cfg(feature = "UNSTABLE_logs")]
+    logs_batcher: RwLock<Option<LogsBatcher>>,
     integrations: Vec<(TypeId, Arc<dyn Integration>)>,
     pub(crate) sdk_info: ClientSdkInfo,
 }
@@ -76,11 +78,20 @@ impl Clone for Client {
             self.options.session_mode,
         )));
 
+        #[cfg(feature = "UNSTABLE_logs")]
+        let logs_batcher = RwLock::new(if self.options.enable_logs {
+            Some(LogsBatcher::new(transport.clone()))
+        } else {
+            None
+        });
+
         Client {
             options: self.options.clone(),
             transport,
             #[cfg(feature = "release-health")]
             session_flusher,
+            #[cfg(feature = "UNSTABLE_logs")]
+            logs_batcher,
             integrations: self.integrations.clone(),
             sdk_info: self.sdk_info.clone(),
         }
@@ -150,11 +161,20 @@ impl Client {
             options.session_mode,
         )));
 
+        #[cfg(feature = "UNSTABLE_logs")]
+        let logs_batcher = RwLock::new(if options.enable_logs {
+            Some(LogsBatcher::new(transport.clone()))
+        } else {
+            None
+        });
+
         Client {
             options,
             transport,
             #[cfg(feature = "release-health")]
             session_flusher,
+            #[cfg(feature = "UNSTABLE_logs")]
+            logs_batcher,
             integrations,
             sdk_info,
         }
@@ -329,6 +349,10 @@ impl Client {
         if let Some(ref flusher) = *self.session_flusher.read().unwrap() {
             flusher.flush();
         }
+        #[cfg(feature = "UNSTABLE_logs")]
+        if let Some(ref batcher) = *self.logs_batcher.read().unwrap() {
+            batcher.flush();
+        }
         if let Some(ref transport) = *self.transport.read().unwrap() {
             transport.flush(timeout.unwrap_or(self.options.shutdown_timeout))
         } else {
@@ -346,6 +370,8 @@ impl Client {
     pub fn close(&self, timeout: Option<Duration>) -> bool {
         #[cfg(feature = "release-health")]
         drop(self.session_flusher.write().unwrap().take());
+        #[cfg(feature = "UNSTABLE_logs")]
+        drop(self.logs_batcher.write().unwrap().take());
         let transport_opt = self.transport.write().unwrap().take();
         if let Some(transport) = transport_opt {
             sentry_debug!("client close; request transport to shut down");
@@ -374,12 +400,9 @@ impl Client {
         if !self.options().enable_logs {
             return;
         }
-        if let Some(ref transport) = *self.transport.read().unwrap() {
-            if let Some(log) = self.prepare_log(log, scope) {
-                let mut envelope = Envelope::new();
-                let logs: EnvelopeItem = vec![log].into();
-                envelope.add_item(logs);
-                transport.send_envelope(envelope);
+        if let Some(log) = self.prepare_log(log, scope) {
+            if let Some(ref batcher) = *self.logs_batcher.read().unwrap() {
+                batcher.enqueue(log);
             }
         }
     }

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -140,6 +140,8 @@ mod logger; // structured logging macros exported with `#[macro_export]`
 mod client;
 #[cfg(feature = "client")]
 mod hub_impl;
+#[cfg(all(feature = "client", feature = "UNSTABLE_logs"))]
+mod logs;
 #[cfg(feature = "client")]
 mod session;
 

--- a/sentry-core/src/logs.rs
+++ b/sentry-core/src/logs.rs
@@ -1,4 +1,4 @@
-//! Batching for Sentry [structured logging](https://docs.sentry.io/product/explore/logs/).
+//! Batching for Sentry [structured logs](https://docs.sentry.io/product/explore/logs/).
 
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::JoinHandle;

--- a/sentry-core/src/logs.rs
+++ b/sentry-core/src/logs.rs
@@ -1,0 +1,197 @@
+//! Batching for Sentry [structured logging](https://docs.sentry.io/product/explore/logs/).
+
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::client::TransportArc;
+use crate::protocol::EnvelopeItem;
+use crate::Envelope;
+use sentry_types::protocol::v7::Log;
+
+// Flush when there's 100 logs in the buffer
+const MAX_LOG_ITEMS: usize = 100;
+// Or when 5 seconds have passed from the last flush
+const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Default)]
+struct LogQueue {
+    logs: Vec<Log>,
+}
+
+/// Accumulates logs in the queue and submits them through the transport when one of the flushing
+/// conditions is met.
+pub(crate) struct LogsBatcher {
+    transport: TransportArc,
+    queue: Arc<Mutex<LogQueue>>,
+    shutdown: Arc<(Mutex<bool>, Condvar)>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl LogsBatcher {
+    /// Creates a new LogsBatcher that will submit envelopes to the given `transport`.
+    pub(crate) fn new(transport: TransportArc) -> Self {
+        let queue = Arc::new(Mutex::new(Default::default()));
+        #[allow(clippy::mutex_atomic)]
+        let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
+
+        let worker_transport = transport.clone();
+        let worker_queue = queue.clone();
+        let worker_shutdown = shutdown.clone();
+        let worker = std::thread::Builder::new()
+            .name("sentry-logs-batcher".into())
+            .spawn(move || {
+                let (lock, cvar) = worker_shutdown.as_ref();
+                let mut shutdown = lock.lock().unwrap();
+                // check this immediately, in case the main thread is already shutting down
+                if *shutdown {
+                    return;
+                }
+                let mut last_flush = Instant::now();
+                loop {
+                    let timeout = FLUSH_INTERVAL
+                        .checked_sub(last_flush.elapsed())
+                        .unwrap_or_else(|| Duration::from_secs(0));
+                    shutdown = cvar.wait_timeout(shutdown, timeout).unwrap().0;
+                    if *shutdown {
+                        return;
+                    }
+                    if last_flush.elapsed() >= FLUSH_INTERVAL {
+                        LogsBatcher::flush_queue_internal(
+                            worker_queue.lock().unwrap(),
+                            &worker_transport,
+                        );
+                        last_flush = Instant::now();
+                    }
+                }
+            })
+            .unwrap();
+
+        Self {
+            transport,
+            queue,
+            shutdown,
+            worker: Some(worker),
+        }
+    }
+
+    /// Enqueues a log for delayed sending.
+    ///
+    /// This will automatically flush the queue if it reaches a size of `BATCH_SIZE`.
+    pub(crate) fn enqueue(&self, log: Log) {
+        let mut queue = self.queue.lock().unwrap();
+        queue.logs.push(log);
+        if queue.logs.len() >= MAX_LOG_ITEMS {
+            LogsBatcher::flush_queue_internal(queue, &self.transport);
+        }
+    }
+
+    /// Flushes the queue to the transport.
+    pub(crate) fn flush(&self) {
+        let queue = self.queue.lock().unwrap();
+        LogsBatcher::flush_queue_internal(queue, &self.transport);
+    }
+
+    /// Flushes the queue to the transport.
+    ///
+    /// This is a static method as it will be called from both the background
+    /// thread and the main thread on drop.
+    fn flush_queue_internal(mut queue_lock: MutexGuard<LogQueue>, transport: &TransportArc) {
+        let logs = std::mem::take(&mut queue_lock.logs);
+        drop(queue_lock);
+
+        if logs.is_empty() {
+            return;
+        }
+
+        sentry_debug!("[LogsBatcher] Flushing {} logs", logs.len());
+
+        if let Some(ref transport) = *transport.read().unwrap() {
+            let mut envelope = Envelope::new();
+            let logs_item: EnvelopeItem = logs.into();
+            envelope.add_item(logs_item);
+            transport.send_envelope(envelope);
+        }
+    }
+}
+
+impl Drop for LogsBatcher {
+    fn drop(&mut self) {
+        let (lock, cvar) = self.shutdown.as_ref();
+        *lock.lock().unwrap() = true;
+        cvar.notify_one();
+
+        if let Some(worker) = self.worker.take() {
+            worker.join().ok();
+        }
+        LogsBatcher::flush_queue_internal(self.queue.lock().unwrap(), &self.transport);
+    }
+}
+
+#[cfg(all(test, feature = "test"))]
+mod tests {
+    use crate::logger_info;
+    use crate::test;
+
+    // Test that logs are sent in batches
+    #[test]
+    fn test_logs_batching() {
+        let envelopes = test::with_captured_envelopes_options(
+            || {
+                for i in 0..150 {
+                    logger_info!("test log {}", i);
+                }
+            },
+            crate::ClientOptions {
+                enable_logs: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(2, envelopes.len());
+
+        let mut total_logs = 0;
+        for envelope in &envelopes {
+            for item in envelope.items() {
+                if let crate::protocol::EnvelopeItem::ItemContainer(
+                    crate::protocol::ItemContainer::Logs(logs),
+                ) = item
+                {
+                    total_logs += logs.len();
+                }
+            }
+        }
+
+        assert_eq!(150, total_logs);
+    }
+
+    // Test that the batcher is flushed on client close
+    #[test]
+    fn test_logs_batcher_flush() {
+        let envelopes = test::with_captured_envelopes_options(
+            || {
+                for i in 0..12 {
+                    logger_info!("test log {}", i);
+                }
+            },
+            crate::ClientOptions {
+                enable_logs: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(1, envelopes.len());
+
+        for envelope in &envelopes {
+            for item in envelope.items() {
+                if let crate::protocol::EnvelopeItem::ItemContainer(
+                    crate::protocol::ItemContainer::Logs(logs),
+                ) = item
+                {
+                    assert_eq!(12, logs.len());
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a batcher for logs.
- The implementation is basically the same as the one for the `SessionFlusher`, with different thresholds.
- As an optimization, we don't even create the batcher if `enable_logs` is false.
- The flushing is implemented as per the [spec](https://develop.sentry.dev/sdk/telemetry/logs/#buffering) initial suggestion of flushing every 100 items or 5 seconds. We could also use different thresholds though.
- In the future we are going to change this implementation to use the [batch processor](https://develop.sentry.dev/sdk/telemetry/spans/batch-processor/) approach, which will allow us to batch logs, spans (for span streaming) and possibly other telemetry data.

#skip-changelog