### PR TITLE
refactor(logs): remove UNSTABLE prefix from feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 Support for [Sentry structured logs](https://docs.sentry.io/product/explore/logs/) has been added to the SDK.
-- To set up logs, enable the `UNSTABLE_logs` feature of the `sentry` crate and set `enable_logs` to `true` in your client options.
+- To set up logs, enable the `logs` feature of the `sentry` crate and set `enable_logs` to `true` in your client options.
 - Then, use the `logger_trace!`, `logger_debug!`, `logger_info!`, `logger_warn!`, `logger_error!` and `logger_fatal!` macros to capture logs.
 - To filter or update logs before they are sent, you can use the `before_send_log` client option.
 - Please note that breaking changes could occur until the API is finalized. 

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 client = ["rand"]
 test = ["client", "release-health"]
 release-health = []
-UNSTABLE_logs = []
+logs = []
 
 [dependencies]
 log = { version = "0.4.8", optional = true, features = ["std"] }

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::constants::USER_AGENT;
 use crate::performance::TracesSampler;
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 use crate::protocol::Log;
 use crate::protocol::{Breadcrumb, Event};
 use crate::types::Dsn;
@@ -147,7 +147,7 @@ pub struct ClientOptions {
     /// Callback that is executed for each Breadcrumb being added.
     pub before_breadcrumb: Option<BeforeCallback<Breadcrumb>>,
     /// Callback that is executed for each Log being added.
-    #[cfg(feature = "UNSTABLE_logs")]
+    #[cfg(feature = "logs")]
     pub before_send_log: Option<BeforeCallback<Log>>,
     // Transport options
     /// The transport to use.
@@ -171,7 +171,7 @@ pub struct ClientOptions {
     /// server integrations. Needs `send_default_pii` to be enabled to have any effect.
     pub max_request_body_size: MaxRequestBodySize,
     /// Determines whether captured structured logs should be sent to Sentry (defaults to false).
-    #[cfg(feature = "UNSTABLE_logs")]
+    #[cfg(feature = "logs")]
     pub enable_logs: bool,
     // Other options not documented in Unified API
     /// Disable SSL verification.
@@ -232,7 +232,7 @@ impl fmt::Debug for ClientOptions {
         #[derive(Debug)]
         struct BeforeBreadcrumb;
         let before_breadcrumb = self.before_breadcrumb.as_ref().map(|_| BeforeBreadcrumb);
-        #[cfg(feature = "UNSTABLE_logs")]
+        #[cfg(feature = "logs")]
         let before_send_log = {
             #[derive(Debug)]
             struct BeforeSendLog;
@@ -279,7 +279,7 @@ impl fmt::Debug for ClientOptions {
             .field("auto_session_tracking", &self.auto_session_tracking)
             .field("session_mode", &self.session_mode);
 
-        #[cfg(feature = "UNSTABLE_logs")]
+        #[cfg(feature = "logs")]
         debug_struct
             .field("enable_logs", &self.enable_logs)
             .field("before_send_log", &before_send_log);
@@ -325,9 +325,9 @@ impl Default for ClientOptions {
             trim_backtraces: true,
             user_agent: Cow::Borrowed(USER_AGENT),
             max_request_body_size: MaxRequestBodySize::Medium,
-            #[cfg(feature = "UNSTABLE_logs")]
+            #[cfg(feature = "logs")]
             enable_logs: false,
-            #[cfg(feature = "UNSTABLE_logs")]
+            #[cfg(feature = "logs")]
             before_send_log: None,
         }
     }

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -247,7 +247,7 @@ impl Hub {
     }
 
     /// Captures a structured log.
-    #[cfg(feature = "UNSTABLE_logs")]
+    #[cfg(feature = "logs")]
     pub fn capture_log(&self, log: Log) {
         with_client_impl! {{
             let top = self.inner.with(|stack| stack.top().clone());

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -132,7 +132,7 @@ pub use crate::intodsn::IntoDsn;
 pub use crate::performance::*;
 pub use crate::scope::{Scope, ScopeGuard};
 pub use crate::transport::{Transport, TransportFactory};
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 mod logger; // structured logging macros exported with `#[macro_export]`
 
 // client feature
@@ -140,7 +140,7 @@ mod logger; // structured logging macros exported with `#[macro_export]`
 mod client;
 #[cfg(feature = "client")]
 mod hub_impl;
-#[cfg(all(feature = "client", feature = "UNSTABLE_logs"))]
+#[cfg(all(feature = "client", feature = "logs"))]
 mod logs;
 #[cfg(feature = "client")]
 mod session;

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 use crate::protocol::Log;
 use crate::protocol::{Context, Event, Level, User, Value};
 use crate::TransactionOrSpan;
@@ -113,7 +113,7 @@ impl Scope {
     }
 
     /// Applies the contained scoped data to fill a log.
-    #[cfg(feature = "UNSTABLE_logs")]
+    #[cfg(feature = "logs")]
     pub fn apply_to_log(&self, log: &mut Log) {
         let _log = log;
         minimal_unreachable!();

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -9,7 +9,7 @@ use crate::performance::TransactionOrSpan;
 use crate::protocol::{
     Attachment, Breadcrumb, Context, Event, Level, TraceContext, Transaction, User, Value,
 };
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 use crate::protocol::{Log, LogAttribute};
 #[cfg(feature = "release-health")]
 use crate::session::Session;
@@ -350,7 +350,7 @@ impl Scope {
 
     /// Applies the contained scoped data to a log, setting the `trace_id` and certain default
     /// attributes.
-    #[cfg(feature = "UNSTABLE_logs")]
+    #[cfg(feature = "logs")]
     pub fn apply_to_log(&self, log: &mut Log, send_default_pii: bool) {
         if let Some(span) = self.span.as_ref() {
             log.trace_id = Some(span.get_trace_context().trace_id);

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -48,7 +48,7 @@ opentelemetry = ["sentry-opentelemetry"]
 # other features
 test = ["sentry-core/test"]
 release-health = ["sentry-core/release-health", "sentry-actix?/release-health"]
-UNSTABLE_logs = ["sentry-core/UNSTABLE_logs"]
+logs = ["sentry-core/logs"]
 # transports
 transport = ["reqwest", "native-tls"]
 reqwest = ["dep:reqwest", "httpdate", "tokio"]

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -265,7 +265,7 @@ fn test_panic_scope_pop() {
     );
 }
 
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 #[test]
 fn test_basic_capture_log() {
     use std::time::SystemTime;
@@ -314,7 +314,7 @@ fn test_basic_capture_log() {
     }
 }
 
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 #[test]
 fn test_basic_capture_log_macro_message() {
     use sentry_core::logger_info;
@@ -349,7 +349,7 @@ fn test_basic_capture_log_macro_message() {
     }
 }
 
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 #[test]
 fn test_basic_capture_log_macro_message_formatted() {
     use sentry::protocol::LogAttribute;
@@ -416,7 +416,7 @@ fn test_basic_capture_log_macro_message_formatted() {
     }
 }
 
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 #[test]
 fn test_basic_capture_log_macro_message_with_attributes() {
     use sentry::protocol::LogAttribute;
@@ -475,7 +475,7 @@ fn test_basic_capture_log_macro_message_with_attributes() {
     }
 }
 
-#[cfg(feature = "UNSTABLE_logs")]
+#[cfg(feature = "logs")]
 #[test]
 fn test_basic_capture_log_macro_message_formatted_with_attributes() {
     use sentry::protocol::LogAttribute;


### PR DESCRIPTION
Renaming `UNSTABLE_logs` to `logs`.

Reasoning:
- other SDKs are already shipping it without `experimental`
- The only changes I see we would make to the API is extensions, such as allowing more types to be passed in or additional syntax to call e.g. the Display or Debug impl as in `tracing`. For this purpose, types can remain the same, only the macros would change under the hood to allow for these extensions.
- `UNSTABLE` might lead to people not using the feature

#skip-changelog