### PR TITLE
fix(logs): send environment in `sentry.environment` default attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix(logs): send environment in `sentry.environment` default attribute (#837) by @lcian
+
 ## 0.39.0
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "sentry",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "backtrace",
  "regex",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "hostname",
  "libc",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "log",
  "pretty_env_logger",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-opentelemetry"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "sentry",
  "sentry-backtrace",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-slog"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "erased-serde",
  "sentry",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "log",
  "sentry",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "debugid",
  "hex",

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -427,7 +427,7 @@ impl Client {
         if !log.attributes.contains_key("sentry.environment") {
             if let Some(environment) = self.options.environment.as_ref() {
                 log.attributes.insert(
-                    "sentry.sdk.version".to_owned(),
+                    "sentry.environment".to_owned(),
                     LogAttribute(environment.clone().into()),
                 );
             }


### PR DESCRIPTION
Writes the `environment` in the right place.