### PR TITLE
feat(tracing): add support for logs

### DIFF
--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 [features]
 default = []
 backtrace = ["dep:sentry-backtrace"]
+logs = ["sentry-core/logs"]
 
 [dependencies]
 sentry-core = { version = "0.39.0", path = "../sentry-core", features = [

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -22,6 +22,9 @@ pub enum EventFilter {
     Breadcrumb,
     /// Create a [`sentry_core::protocol::Event`] from this [`Event`]
     Event,
+    /// Create a [`sentry_core::protocol::Log`] from this [`Event`]
+    #[cfg(feature = "logs")]
+    Log,
 }
 
 /// The type of data Sentry should ingest for a [`Event`]
@@ -34,6 +37,9 @@ pub enum EventMapping {
     Breadcrumb(Breadcrumb),
     /// Captures the [`sentry_core::protocol::Event`] to Sentry.
     Event(sentry_core::protocol::Event<'static>),
+    /// Captures the [`sentry_core::protocol::Log`] to Sentry.
+    #[cfg(feature = "logs")]
+    Log(sentry_core::protocol::Log),
 }
 
 /// The default event filter.
@@ -215,6 +221,8 @@ where
                         EventMapping::Breadcrumb(breadcrumb_from_event(event, span_ctx))
                     }
                     EventFilter::Event => EventMapping::Event(event_from_event(event, span_ctx)),
+                    #[cfg(feature = "logs")]
+                    EventFilter::Log => EventMapping::Log(log_from_event(event, span_ctx)),
                 }
             }
         };
@@ -224,6 +232,8 @@ where
                 sentry_core::capture_event(event);
             }
             EventMapping::Breadcrumb(breadcrumb) => sentry_core::add_breadcrumb(breadcrumb),
+            #[cfg(feature = "logs")]
+            EventMapping::Log(log) => sentry_core::Hub::with_active(|hub| hub.capture_log(log)),
             _ => (),
         }
     }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -48,7 +48,7 @@ opentelemetry = ["sentry-opentelemetry"]
 # other features
 test = ["sentry-core/test"]
 release-health = ["sentry-core/release-health", "sentry-actix?/release-health"]
-logs = ["sentry-core/logs"]
+logs = ["sentry-core/logs", "sentry-tracing?/logs"]
 # transports
 transport = ["reqwest", "native-tls"]
 reqwest = ["dep:reqwest", "httpdate", "tokio"]

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -193,3 +193,87 @@ fn test_set_transaction() {
     assert_eq!(transaction.name.as_deref().unwrap(), "new name");
     assert!(transaction.request.is_some());
 }
+
+#[cfg(feature = "logs")]
+#[test]
+fn test_tracing_logs() {
+    let sentry_layer = sentry_tracing::layer().event_filter(|_| sentry_tracing::EventFilter::Log);
+
+    let _dispatcher = tracing_subscriber::registry()
+        .with(sentry_layer)
+        .set_default();
+
+    let options = sentry::ClientOptions {
+        enable_logs: true,
+        ..Default::default()
+    };
+
+    let envelopes = sentry::test::with_captured_envelopes_options(
+        || {
+            #[derive(Debug)]
+            struct ConnectionError {
+                message: String,
+                source: Option<std::io::Error>,
+            }
+
+            impl std::fmt::Display for ConnectionError {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "{}", self.message)
+                }
+            }
+
+            impl std::error::Error for ConnectionError {
+                fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                    self.source
+                        .as_ref()
+                        .map(|e| e as &(dyn std::error::Error + 'static))
+                }
+            }
+
+            let io_error =
+                std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "Connection refused");
+            let connection_error = ConnectionError {
+                message: "Failed to connect to database server".to_string(),
+                source: Some(io_error),
+            };
+
+            tracing::error!(
+                my.key = "hello",
+                an.error = &connection_error as &dyn std::error::Error,
+                "This is an error log: {}",
+                "hello"
+            );
+        },
+        options,
+    );
+
+    assert_eq!(envelopes.len(), 1);
+    let envelope = envelopes.first().expect("expected envelope");
+    let item = envelope.items().next().expect("expected envelope item");
+
+    match item {
+        sentry::protocol::EnvelopeItem::ItemContainer(container) => match container {
+            sentry::protocol::ItemContainer::Logs(logs) => {
+                assert_eq!(logs.len(), 1);
+
+                let log = &logs[0];
+                assert_eq!(log.level, sentry::protocol::LogLevel::Error);
+                assert_eq!(log.body, "This is an error log: hello");
+                assert!(log.trace_id.is_some());
+                assert_eq!(
+                    log.attributes.get("my.key").unwrap().clone(),
+                    sentry::protocol::LogAttribute::from("hello")
+                );
+                assert_eq!(
+                    log.attributes.get("an.error").unwrap().clone(),
+                    sentry::protocol::LogAttribute::from(vec![
+                        "ConnectionError: Failed to connect to database server",
+                        "Custom: Connection refused"
+                    ])
+                );
+            }
+            _ => panic!("expected logs container"),
+        },
+        _ => panic!("expected item container"),
+    }
+}


### PR DESCRIPTION
Logs support for `sentry-tracing`.

Open question for the future:
Someone might want to capture multiple things (e.g. if you get an error event, capture both a Sentry error and an error level log).
To do this they can provide a custom `event_mapper`, but perhaps we could consider providing an option to map to multiple things at the same time - it looks like that would require 2**n enum variants, or a breaking change.