### PR TITLE
refactor(logs): cache default attributes and add OS attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- refactor(logs): cache default attributes and add OS attributes (#842) by @lcian
+  - `os.name` and `os.version` are now being attached to logs as default attributes.
+
 ### Fixes
 
 - fix(logs): send environment in `sentry.environment` default attribute (#837) by @lcian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-### Features
-
 ### Breaking changes
 
 - refactor(logs): apply user attributes to log regardless of `send_default_pii` (#843) by @lcian

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -201,27 +201,21 @@ impl Client {
         let mut attributes = BTreeMap::new();
 
         if let Some(environment) = self.options.environment.as_ref() {
-            attributes.insert(
-                "sentry.environment".to_owned(),
-                LogAttribute(environment.clone().into()),
-            );
+            attributes.insert("sentry.environment".to_owned(), environment.clone().into());
         }
 
         if let Some(release) = self.options.release.as_ref() {
-            attributes.insert(
-                "sentry.release".to_owned(),
-                LogAttribute(release.clone().into()),
-            );
+            attributes.insert("sentry.release".to_owned(), release.clone().into());
         }
 
         attributes.insert(
             "sentry.sdk.name".to_owned(),
-            LogAttribute(self.sdk_info.name.to_owned().into()),
+            self.sdk_info.name.to_owned().into(),
         );
 
         attributes.insert(
             "sentry.sdk.version".to_owned(),
-            LogAttribute(self.sdk_info.version.to_owned().into()),
+            self.sdk_info.version.to_owned().into(),
         );
 
         // Process a fake event through integrations, so that `ContextIntegration` (if available)

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -239,21 +239,15 @@ impl Client {
 
         if let Some(Context::Os(os)) = fake_event.contexts.get("os") {
             if let Some(name) = os.name.as_ref() {
-                attributes.insert("os.name".to_owned(), LogAttribute(name.to_owned().into()));
+                attributes.insert("os.name".to_owned(), name.to_owned().into());
             }
             if let Some(version) = os.version.as_ref() {
-                attributes.insert(
-                    "os.version".to_owned(),
-                    LogAttribute(version.to_owned().into()),
-                );
+                attributes.insert("os.version".to_owned(), version.to_owned().into());
             }
         }
 
         if let Some(server) = &self.options.server_name {
-            attributes.insert(
-                "server.address".to_owned(),
-                LogAttribute(server.clone().into()),
-            );
+            attributes.insert("server.address".to_owned(), server.clone().into());
         }
 
         self.default_log_attributes = Some(attributes);

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -492,9 +492,9 @@ impl Client {
     fn prepare_log(&self, mut log: Log, scope: &Scope) -> Option<Log> {
         scope.apply_to_log(&mut log, self.options.send_default_pii);
 
-        if let Some(default_attributes) = self.default_log_attributes.clone() {
-            for (key, val) in default_attributes.into_iter() {
-                log.attributes.entry(key).or_insert(val);
+        if let Some(default_attributes) = self.default_log_attributes.as_ref() {
+            for (key, val) in default_attributes.iter() {
+                log.attributes.entry(key.to_owned()).or_insert(val.clone());
             }
         }
 


### PR DESCRIPTION
- Cache default attributes and store them on the client
- They are always the same anyway. This way we clone once (from the cached attributes map to the actual log attributes) instead of doing multiple smaller clones.
- Add `os.name` and `os.version` attributes to the log, which are mandatory for native SDKs according to the spec, and personally I think they could be useful.
- The best way I've found to retrieve the OS context in `sentry-core` without making breaking changes or exposing additional API surface is the one I'm proposing, which still sucks.