### PR TITLE
refactor(logs): apply user attributes to log regardless of `send_default_pii`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- refactor(core): apply user attributes to log regardless of `send_default_pii` (#843) by @lcian
+  - User attributes should be applied to logs regardless of `send_default_pii`. Therefore, that parameter was removed from `sentry_core::Scope::apply_to_log`.
+
 ### Fixes
 
 - fix(logs): send environment in `sentry.environment` default attribute (#837) by @lcian

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -411,7 +411,7 @@ impl Client {
     /// processing it through `before_send_log`.
     #[cfg(feature = "logs")]
     fn prepare_log(&self, mut log: Log, scope: &Scope) -> Option<Log> {
-        scope.apply_to_log(&mut log, self.options.send_default_pii);
+        scope.apply_to_log(&mut log);
 
         self.set_log_default_attributes(&mut log);
 

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -351,7 +351,7 @@ impl Scope {
     /// Applies the contained scoped data to a log, setting the `trace_id` and certain default
     /// attributes.
     #[cfg(feature = "logs")]
-    pub fn apply_to_log(&self, log: &mut Log, send_default_pii: bool) {
+    pub fn apply_to_log(&self, log: &mut Log) {
         if let Some(span) = self.span.as_ref() {
             log.trace_id = Some(span.get_trace_context().trace_id);
         } else {
@@ -373,29 +373,27 @@ impl Scope {
             }
         }
 
-        if send_default_pii {
-            if let Some(user) = self.user.as_ref() {
-                if !log.attributes.contains_key("user.id") {
-                    if let Some(id) = user.id.as_ref() {
-                        log.attributes
-                            .insert("user.id".to_owned(), LogAttribute(id.to_owned().into()));
-                    }
+        if let Some(user) = self.user.as_ref() {
+            if !log.attributes.contains_key("user.id") {
+                if let Some(id) = user.id.as_ref() {
+                    log.attributes
+                        .insert("user.id".to_owned(), LogAttribute(id.to_owned().into()));
                 }
+            }
 
-                if !log.attributes.contains_key("user.name") {
-                    if let Some(name) = user.username.as_ref() {
-                        log.attributes
-                            .insert("user.name".to_owned(), LogAttribute(name.to_owned().into()));
-                    }
+            if !log.attributes.contains_key("user.name") {
+                if let Some(name) = user.username.as_ref() {
+                    log.attributes
+                        .insert("user.name".to_owned(), LogAttribute(name.to_owned().into()));
                 }
+            }
 
-                if !log.attributes.contains_key("user.email") {
-                    if let Some(email) = user.email.as_ref() {
-                        log.attributes.insert(
-                            "user.email".to_owned(),
-                            LogAttribute(email.to_owned().into()),
-                        );
-                    }
+            if !log.attributes.contains_key("user.email") {
+                if let Some(email) = user.email.as_ref() {
+                    log.attributes.insert(
+                        "user.email".to_owned(),
+                        LogAttribute(email.to_owned().into()),
+                    );
                 }
             }
         }


### PR DESCRIPTION
We have decided that SDKs should ignore `send_default_pii` when setting user attributes on logs because that's what we do for other data types such as events.

(explanation: any integration that can set the user must honor `send_default_pii`, so they won't set the user if that flag is off. Then, the only way to have a `user` on the scope is for the Sentry user to manually set it, in which case we always want to let them do it and send the data, regardless of `send_default_pii`.)

Technically this is a breaking change even though it's pretty unlikely that someone is already using this.
As an alternative we could just ignore the parameter.