### PR TITLE
fix(logs): stringify u64 attributes greater than `i64::MAX`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix(logs): stringify u64 attributes greater than `i64::MAX` (#846) by @lcian
+
 ## 0.40.0
 
 ### Breaking changes

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -2217,6 +2217,10 @@ impl Serialize for LogAttribute {
                 if let Some(i) = n.as_i64() {
                     state.serialize_field("value", &i)?;
                     state.serialize_field("type", "integer")?;
+                } else if let Some(u) = n.as_u64() {
+                    // Converting to a f64 could lead to precision loss
+                    state.serialize_field("value", &u.to_string())?;
+                    state.serialize_field("type", "string")?;
                 } else if let Some(f) = n.as_f64() {
                     state.serialize_field("value", &f)?;
                     state.serialize_field("type", "double")?;

--- a/sentry-types/tests/test_protocol_v7.rs
+++ b/sentry-types/tests/test_protocol_v7.rs
@@ -1536,8 +1536,12 @@ mod test_logs {
             (3.1.into(), r#"{"value":3.1,"type":"double"}"#),
             ("lol".into(), r#"{"value":"lol","type":"string"}"#),
             (false.into(), r#"{"value":false,"type":"boolean"}"#),
-            // Special case
+            // Special cases
             (Value::Null.into(), r#"{"value":"null","type":"string"}"#),
+            (
+                (u64::MAX - 1).into(),
+                r#"{"value":"18446744073709551614","type":"string"}"#,
+            ),
             // Unsupported types (for now)
             (
                 json!(r#"[1,2,3,4]"#).into(),


### PR DESCRIPTION
Previously we were serializing these as floats which could lead to unnecessary precision loss.
Closes #845 