### PR TITLE
feat(tracing): support combined EventFilters and EventMappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- feat(tracing): support combined EventFilters and EventMappings (#847) by @lcian
+  - `EventFilter` has been changed to a `bitflags` struct.
+  - It's now possible to map a `tracing` event to multiple items in Sentry by combining multiple event filters in the `event_filter`, e.g. `tracing::Level::ERROR => EventFilter::Event | EventFilter::Log`.
+  - It's also possible to use `EventMapping::Combined` to map a `tracing` event to multiple items in Sentry.
+  - `ctx` in the signatures of `event_from_event`, `breadcrumb_from_event` and `log_from_event` has been changed to take `impl Into<Option<&'context Context<'context, S>>>` to avoid cloning the `Context` when mapping to multiple items.
+
 ### Fixes
 
 - fix(logs): stringify u64 attributes greater than `i64::MAX` (#846) by @lcian

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -448,7 +448,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -470,9 +470,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -2152,7 +2152,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -2309,7 +2309,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2407,7 +2407,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2852,7 +2852,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3028,7 +3028,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3041,7 +3041,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3134,7 +3134,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3334,6 +3334,7 @@ dependencies = [
 name = "sentry-tracing"
 version = "0.40.0"
 dependencies = [
+ "bitflags 2.9.1",
  "log",
  "sentry",
  "sentry-backtrace",
@@ -4514,7 +4515,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3.1", default-features = false, features = [
     "std",
 ] }
 sentry-backtrace = { version = "0.40.0", path = "../sentry-backtrace", optional = true }
-bitflags = "2.9.1"
+bitflags = "2"
 
 [dev-dependencies]
 log = "0.4"

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3.1", default-features = false, features = [
     "std",
 ] }
 sentry-backtrace = { version = "0.40.0", path = "../sentry-backtrace", optional = true }
-bitflags = "2"
+bitflags = "2.0.0"
 
 [dev-dependencies]
 log = "0.4"

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = { version = "0.3.1", default-features = false, features = [
     "std",
 ] }
 sentry-backtrace = { version = "0.40.0", path = "../sentry-backtrace", optional = true }
+bitflags = "2.9.1"
 
 [dev-dependencies]
 log = "0.4"

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -77,7 +77,7 @@ fn extract_event_data(
 /// Extracts the message and metadata from an event, including the data in the current span.
 fn extract_event_data_with_context<S>(
     event: &tracing_core::Event,
-    ctx: Option<Context<S>>,
+    ctx: Option<&Context<S>>,
     store_errors_in_values: bool,
 ) -> (Option<String>, FieldVisitor)
 where
@@ -182,7 +182,7 @@ impl Visit for FieldVisitor {
 /// Creates a [`Breadcrumb`] from a given [`tracing_core::Event`].
 pub fn breadcrumb_from_event<'context, S>(
     event: &tracing_core::Event,
-    ctx: impl Into<Option<Context<'context, S>>>,
+    ctx: impl Into<Option<&'context Context<'context, S>>>,
 ) -> Breadcrumb
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
@@ -261,7 +261,7 @@ fn contexts_from_event(
 /// Creates an [`Event`] (possibly carrying exceptions) from a given [`tracing_core::Event`].
 pub fn event_from_event<'context, S>(
     event: &tracing_core::Event,
-    ctx: impl Into<Option<Context<'context, S>>>,
+    ctx: impl Into<Option<&'context Context<'context, S>>>,
 ) -> Event<'static>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
@@ -329,7 +329,7 @@ where
 #[cfg(feature = "logs")]
 pub fn log_from_event<'context, S>(
     event: &tracing_core::Event,
-    ctx: impl Into<Option<Context<'context, S>>>,
+    ctx: impl Into<Option<&'context Context<'context, S>>>,
 ) -> Log
 where
     S: Subscriber + for<'a> LookupSpan<'a>,

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -271,7 +271,11 @@ where
                 }
                 #[cfg(feature = "logs")]
                 EventMapping::Log(log) => sentry_core::Hub::with_active(|hub| hub.capture_log(log)),
-                EventMapping::Combined(_) => sentry_debug!("[SentryLayer] found nested CombinedEventMapping, ignoring"),
+                EventMapping::Combined(_) => {
+                    sentry_core::sentry_debug!(
+                        "[SentryLayer] found nested CombinedEventMapping, ignoring"
+                    )
+                }
             }
         }
     }

--- a/sentry-tracing/src/layer.rs
+++ b/sentry-tracing/src/layer.rs
@@ -43,6 +43,7 @@ pub enum EventMapping {
     #[cfg(feature = "logs")]
     Log(sentry_core::protocol::Log),
     /// Captures multiple items to Sentry.
+    /// Nesting multiple `EventMapping::Combined` inside each other will cause the inner mappings to be ignored.
     Combined(CombinedEventMapping),
 }
 
@@ -270,7 +271,7 @@ where
                 }
                 #[cfg(feature = "logs")]
                 EventMapping::Log(log) => sentry_core::Hub::with_active(|hub| hub.capture_log(log)),
-                _ => (),
+                EventMapping::Combined(_) => sentry_debug!("[SentryLayer] found nested CombinedEventMapping, ignoring"),
             }
         }
     }

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -86,7 +86,7 @@
 //!
 //! Tracing events can be captured as traditional structured logs in Sentry.
 //! This is gated by the `logs` feature flag and requires setting up a custom Event filter/mapper
-//! to capture logs.
+//! to capture logs. You also need to pass `enable_logs: true` in your `sentry::init` call.
 //!
 //! ```
 //! // assuming `tracing::Level::INFO => EventFilter::Log` in your `event_filter`
@@ -140,6 +140,23 @@
 //! let custom_error = io::Error::new(io::ErrorKind::Other, "oh no");
 //! tracing::error!(error = &custom_error as &dyn Error, "my operation failed");
 //! ```
+//!
+//! # Sending multiple items to Sentry
+//!
+//! To map a `tracing` event to multiple items in Sentry, you can combine multiple event filters
+//! using the bitwise or operator:
+//!
+//! ```
+//! let sentry_layer = sentry::integrations::tracing::layer()
+//!     .event_filter(|md| match *md.level() {
+//!         tracing::Level::ERROR => EventFilter::Event | EventFilter::Log,
+//!         tracing::Level::TRACE => EventFilter::Ignore,
+//!         _ => EventFilter::Log,
+//!     })
+//!     .span_filter(|md| matches!(*md.level(), tracing::Level::ERROR | tracing::Level::WARN));
+//! ```
+//!
+//! If you're using a custom event mapper instead of an event filter, use `EventMapping::Combined`.
 //!
 //! # Tracing Spans
 //!


### PR DESCRIPTION
It seems common enough that someone would want to want to map  a `tracing` event to multiple item types, and right now that's not possible, you have to choose between Ignore/Event/Breadcrumb/Log.
For example, in Relay we want to send everything at or above INFO level to logs, while still sending ERROR events to Sentry events at the same time.

This is a proposal for how to implement that.
This particular solution requires 2 breaking changes, even though both could be avoided.
I would argue that they are not actually breaking for most users though, i.e. those that just set up a custom filter, as this is still backwards compatible in terms of syntax, even though the underlying type changes.