### PR TITLE
feat(core): emit debug log when calling capture_log but logs are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features 
+
+- feat(core): emit debug log when calling capture_log but logs are disabled (#849) by @lcian
+
 ### Fixes
 
 - fix(logs): stringify u64 attributes greater than `i64::MAX` (#846) by @lcian

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -464,7 +464,8 @@ impl Client {
     /// Captures a log and sends it to Sentry.
     #[cfg(feature = "logs")]
     pub fn capture_log(&self, log: Log, scope: &Scope) {
-        if !self.options().enable_logs {
+        if !self.options.enable_logs {
+            sentry_debug!("[Client] called capture_log, but options.enable_logs is set to false");
             return;
         }
         if let Some(log) = self.prepare_log(log, scope) {


### PR DESCRIPTION
Maybe this can be useful in case someone forgets to set `enable_logs`.