### PR TITLE
fix(tracing): fix doctest

### DIFF
--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -148,6 +148,7 @@
 //!
 //! ```
 //! use sentry::integrations::tracing::EventFilter;
+//! use tracing_subscriber::layer::Layer;
 //!
 //! let sentry_layer = sentry::integrations::tracing::layer()
 //!     .event_filter(|md| match *md.level() {

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -155,7 +155,8 @@
 //!         tracing::Level::TRACE => EventFilter::Ignore,
 //!         _ => EventFilter::Log,
 //!     })
-//!     .span_filter(|md| matches!(*md.level(), tracing::Level::ERROR | tracing::Level::WARN));
+//!     .span_filter(|md| matches!(*md.level(), tracing::Level::ERROR | tracing::Level::WARN))
+//!     .boxed();
 //! ```
 //!
 //! If you're using a custom event mapper instead of an event filter, use `EventMapping::Combined`.

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -147,6 +147,8 @@
 //! using the bitwise or operator:
 //!
 //! ```
+//! use sentry::integrations::tracing::EventFilter;
+//!
 //! let sentry_layer = sentry::integrations::tracing::layer()
 //!     .event_filter(|md| match *md.level() {
 //!         tracing::Level::ERROR => EventFilter::Event | EventFilter::Log,

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -146,9 +146,9 @@
 //! To map a `tracing` event to multiple items in Sentry, you can combine multiple event filters
 //! using the bitwise or operator:
 //!
-//! ```no_run
+//! ```
 //! use sentry::integrations::tracing::EventFilter;
-//! use tracing_subscriber::layer::Layer;
+//! use tracing_subscriber::prelude::*;
 //!
 //! let sentry_layer = sentry::integrations::tracing::layer()
 //!     .event_filter(|md| match *md.level() {
@@ -157,6 +157,11 @@
 //!         _ => EventFilter::Log,
 //!     })
 //!     .span_filter(|md| matches!(*md.level(), tracing::Level::ERROR | tracing::Level::WARN));
+//!
+//! tracing_subscriber::registry()
+//!     .with(tracing_subscriber::fmt::layer())
+//!     .with(sentry_layer)
+//!     .init();
 //! ```
 //!
 //! If you're using a custom event mapper instead of an event filter, use `EventMapping::Combined`.

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -146,7 +146,7 @@
 //! To map a `tracing` event to multiple items in Sentry, you can combine multiple event filters
 //! using the bitwise or operator:
 //!
-//! ```
+//! ```no_run
 //! use sentry::integrations::tracing::EventFilter;
 //! use tracing_subscriber::layer::Layer;
 //!
@@ -156,8 +156,7 @@
 //!         tracing::Level::TRACE => EventFilter::Ignore,
 //!         _ => EventFilter::Log,
 //!     })
-//!     .span_filter(|md| matches!(*md.level(), tracing::Level::ERROR | tracing::Level::WARN))
-//!     .boxed();
+//!     .span_filter(|md| matches!(*md.level(), tracing::Level::ERROR | tracing::Level::WARN));
 //! ```
 //!
 //! If you're using a custom event mapper instead of an event filter, use `EventMapping::Combined`.


### PR DESCRIPTION
This would need type annotations, so the doc test would fail to compile.
A way to fix it is to use the layer, so that the type is inferred.

#skip-changelog