### PR TITLE
docs: match description of `debug` option with behavior since #820

### DIFF
--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -99,8 +99,7 @@ pub struct ClientOptions {
     /// Enables debug mode.
     ///
     /// In debug mode debug information is printed to stderr to help you understand what
-    /// sentry is doing.  When the `log` feature is enabled, Sentry will instead
-    /// log to the `sentry` logger independently of this flag with the `Debug` level.
+    /// sentry is doing.
     pub debug: bool,
     /// The release to be sent with events.
     pub release: Option<Cow<'static, str>>,


### PR DESCRIPTION
PR #820 removed the `debug-logs` crate feature, but failed to update the documentation for the related `debug` field in the client options struct, which falsely asserts that the `log` feature changes the behavior of the `sentry_debug!` macro.

This change fixes that discrepancy by removing all references to features in the documentation for that field.