### PR TITLE
feat(types): add all the missing supported envelope headers

### DIFF
--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::utils::ts_rfc3339_opt;
 use crate::Dsn;
 
-use super::v7::{self as protocol};
+use super::v7 as protocol;
 
 use protocol::{
     Attachment, AttachmentType, ClientSdkInfo, DynamicSamplingContext, Event, Log, MonitorCheckIn,

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -409,7 +409,7 @@ impl Envelope {
 
         // write the headers:
         serde_json::to_writer(&mut writer, &self.headers)?;
-        writer.write_all(b"\n")?;
+        writeln!(writer)?;
 
         let mut item_buf = Vec::new();
         // write each item:

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -42,7 +42,7 @@ pub enum EnvelopeError {
 
 /// The supported [Sentry Envelope Headers](https://develop.sentry.dev/sdk/data-model/envelopes/#headers).
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
-pub struct EnvelopeHeaders {
+struct EnvelopeHeaders {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     event_id: Option<Uuid>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -57,63 +57,6 @@ pub struct EnvelopeHeaders {
     sent_at: Option<SystemTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     trace: Option<DynamicSamplingContext>,
-}
-
-impl EnvelopeHeaders {
-    /// Returns the Envelope's Event ID, matching the Event ID of the contained event/transaction,
-    /// if any.
-    pub fn event_id(&self) -> Option<&Uuid> {
-        self.event_id.as_ref()
-    }
-
-    /// Sets the Event ID.
-    pub fn set_event_id(&mut self, event_id: Option<Uuid>) {
-        self.event_id = event_id;
-    }
-
-    /// Returns the DSN.
-    pub fn dsn(&self) -> Option<&Dsn> {
-        self.dsn.as_ref()
-    }
-
-    /// Sets the DSN.
-    pub fn set_dsn(&mut self, dsn: Option<Dsn>) {
-        self.dsn = dsn;
-    }
-
-    /// Returns the SDK information.
-    pub fn sdk(&self) -> Option<&ClientSdkInfo> {
-        self.sdk.as_ref()
-    }
-
-    /// Sets the SDK information.
-    pub fn set_sdk(&mut self, sdk: Option<ClientSdkInfo>) {
-        self.sdk = sdk;
-    }
-
-    /// Returns the time this envelope was sent.
-    pub fn sent_at(&self) -> Option<&SystemTime> {
-        self.sent_at.as_ref()
-    }
-
-    /// Sets the time this envelope was sent.
-    /// The value of this timestamp should be generated as close as possible to the transmission of
-    /// the event.
-    /// If offline caching is implemented, the SDK should avoid writing this value when envelopes
-    /// are saved to disk.
-    pub fn set_sent_at(&mut self, sent_at: Option<SystemTime>) {
-        self.sent_at = sent_at;
-    }
-
-    /// Returns the Dynamic Sampling Context.
-    pub fn trace(&self) -> Option<&DynamicSamplingContext> {
-        self.trace.as_ref()
-    }
-
-    /// Sets the Dynamic Sampling Context.
-    pub fn set_trace(&mut self, trace: Option<DynamicSamplingContext>) {
-        self.trace = trace;
-    }
 }
 
 /// An Envelope Item Type.
@@ -389,16 +332,6 @@ impl Envelope {
         };
 
         EnvelopeItemIter { inner }
-    }
-
-    /// Returns a reference to the Envelope's headers.
-    pub fn headers(&self) -> &EnvelopeHeaders {
-        &self.headers
-    }
-
-    /// Sets the Envelope's headers.
-    pub fn set_headers(&mut self, headers: EnvelopeHeaders) {
-        self.headers = headers;
     }
 
     /// Returns the Envelopes Uuid, if any.

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -7,11 +7,11 @@ use uuid::Uuid;
 use crate::utils::ts_rfc3339_opt;
 use crate::Dsn;
 
-use super::v7::{self as protocol, ClientSdkInfo, DynamicSamplingContext};
+use super::v7::{self as protocol};
 
 use protocol::{
-    Attachment, AttachmentType, Event, Log, MonitorCheckIn, SessionAggregates, SessionUpdate,
-    Transaction,
+    Attachment, AttachmentType, ClientSdkInfo, DynamicSamplingContext, Event, Log, MonitorCheckIn,
+    SessionAggregates, SessionUpdate, Transaction,
 };
 
 /// Raised if a envelope cannot be parsed from a given input.

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -2341,6 +2341,12 @@ impl<'de> Deserialize<'de> for LogAttribute {
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 struct OrganizationId(u64);
 
+impl From<u64> for OrganizationId {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
 impl std::str::FromStr for OrganizationId {
     type Err = std::num::ParseIntError;
 
@@ -2352,6 +2358,30 @@ impl std::str::FromStr for OrganizationId {
 impl std::fmt::Display for OrganizationId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// A random number generated at the start of a trace by the head of trace SDK.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+struct SampleRand(f64);
+
+impl From<f64> for SampleRand {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl std::str::FromStr for SampleRand {
+    type Err = std::num::ParseFloatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl std::fmt::Display for SampleRand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:.6}", self.0)
     }
 }
 
@@ -2376,19 +2406,21 @@ pub(crate) struct DynamicSamplingContext {
         with = "display_from_str_opt"
     )]
     sample_rate: Option<f32>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "display_from_str_opt"
-    )]
-    sampled: Option<bool>,
     // Required fields
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         with = "display_from_str_opt"
     )]
-    sample_rand: Option<f32>,
+    sample_rand: Option<SampleRand>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "display_from_str_opt"
+    )]
+    sampled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    release: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     environment: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -2339,7 +2339,7 @@ impl<'de> Deserialize<'de> for LogAttribute {
 
 /// An ID that identifies an organization in the Sentry backend.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
-pub struct OrganizationId(u64);
+struct OrganizationId(u64);
 
 impl std::str::FromStr for OrganizationId {
     type Err = std::num::ParseIntError;
@@ -2363,7 +2363,7 @@ impl std::fmt::Display for OrganizationId {
 /// The backend needs additional information from the SDK to support these features, contained in
 /// the Dynamic Sampling Context.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct DynamicSamplingContext {
+pub(crate) struct DynamicSamplingContext {
     // Strictly required fields
     // Still typed as optional, as when deserializing an envelope created by an older SDK they might still be missing
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 pub use url::Url;
 pub use uuid::Uuid;
 
-use crate::utils::{ts_rfc3339_opt, ts_seconds_float};
+use crate::utils::{display_from_str_opt, ts_rfc3339_opt, ts_seconds_float};
 
 pub use super::attachment::*;
 pub use super::envelope::*;
@@ -2335,4 +2335,68 @@ impl<'de> Deserialize<'de> for LogAttribute {
 
         deserializer.deserialize_map(LogAttributeVisitor)
     }
+}
+
+/// An ID that identifies an organization in the Sentry backend.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub struct OrganizationId(u64);
+
+impl std::str::FromStr for OrganizationId {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl std::fmt::Display for OrganizationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The [Dynamic Sampling
+/// Context](https://develop.sentry.dev/sdk/telemetry/traces/dynamic-sampling-context/).
+///
+/// Sentry supports sampling at the server level through [Dynamic Sampling](https://docs.sentry.io/organization/dynamic-sampling/).
+/// This feature allows users to specify target sample rates for each project via the frontend instead of requiring an application redeployment.
+/// The backend needs additional information from the SDK to support these features, contained in
+/// the Dynamic Sampling Context.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct DynamicSamplingContext {
+    // Strictly required fields
+    // Still typed as optional, as when deserializing an envelope created by an older SDK they might still be missing
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    trace_id: Option<TraceId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    public_key: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "display_from_str_opt"
+    )]
+    sample_rate: Option<f32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "display_from_str_opt"
+    )]
+    sampled: Option<bool>,
+    // Required fields
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "display_from_str_opt"
+    )]
+    sample_rand: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    environment: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    transaction: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "display_from_str_opt"
+    )]
+    org_id: Option<OrganizationId>,
 }

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -189,6 +189,38 @@ pub mod ts_rfc3339_opt {
     }
 }
 
+// Serialize and deserialize the inner value into/from a string using the `ToString`/`FromStr` implementation.
+pub mod display_from_str_opt {
+    use serde::{de, ser, Deserialize};
+
+    pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: ToString,
+        S: ser::Serializer,
+    {
+        match value {
+            Some(t) => serializer.serialize_str(&t.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    where
+        T: std::str::FromStr,
+        T::Err: std::fmt::Display,
+        D: de::Deserializer<'de>,
+    {
+        let opt_string = Option::<String>::deserialize(deserializer)?;
+
+        match opt_string {
+            Some(s) => T::from_str(&s)
+                .map(Some)
+                .map_err(|e| de::Error::custom(format!("failed to parse string to type: {e}"))),
+            None => Ok(None),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::timestamp_to_datetime;

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -189,7 +189,34 @@ pub mod ts_rfc3339_opt {
     }
 }
 
-// Serialize and deserialize the inner value into/from a string using the `ToString`/`FromStr` implementation.
+/// Serialize and deserialize the inner value into/from a string using the `ToString`/`FromStr` implementation.
+///
+/// # Example
+///
+/// ```rust
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// struct Config {
+///     #[serde(with = "sentry_types::utils::display_from_str_opt")]
+///     host: Option<String>,
+///     #[serde(with = "sentry_types::utils::display_from_str_opt")]
+///     port: Option<u16>,
+///     #[serde(with = "sentry_types::utils::display_from_str_opt")]
+///     enabled: Option<bool>,
+/// }
+///
+/// let config = Config {
+///     host: Some("localhost".to_string()),
+///     port: Some(8080),
+///     enabled: Some(true),
+/// };
+/// let json = serde_json::to_string(&config).unwrap();
+/// assert_eq!(json, r#"{"host":"localhost","port":"8080","enabled":"true"}"#);
+///
+/// let deserialized: Config = serde_json::from_str(&json).unwrap();
+/// assert_eq!(deserialized, config);
+/// ```
 pub(crate) mod display_from_str_opt {
     use serde::{de, ser, Deserialize};
 

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -193,7 +193,7 @@ pub mod ts_rfc3339_opt {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -190,7 +190,7 @@ pub mod ts_rfc3339_opt {
 }
 
 // Serialize and deserialize the inner value into/from a string using the `ToString`/`FromStr` implementation.
-pub mod display_from_str_opt {
+pub(crate) mod display_from_str_opt {
     use serde::{de, ser, Deserialize};
 
     pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>

--- a/sentry/src/transports/thread.rs
+++ b/sentry/src/transports/thread.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 use crate::{sentry_debug, Envelope};
 
+#[expect(clippy::large_enum_variant)]
 enum Task {
     SendEnvelope(Envelope),
     Flush(SyncSender<()>),

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 use crate::{sentry_debug, Envelope};
 
+#[expect(clippy::large_enum_variant)]
 enum Task {
     SendEnvelope(Envelope),
     Flush(SyncSender<()>),


### PR DESCRIPTION
Adds the [documented envelope headers](https://develop.sentry.dev/sdk/data-model/envelopes/#envelope-headers) to the types.
In a separate PR we can start to populate the new values.

Closes https://github.com/getsentry/sentry-rust/issues/866
Required for https://github.com/getsentry/sentry-rust/issues/865

#skip-changelog