### PR TITLE
fix(actix): capture only server errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- fix(actix): capture only server errors ([#877](https://github.com/getsentry/sentry-rust/pull/877))
+  - The Actix integration now properly honors the `capture_server_errors` option (enabled by default), capturing errors returned by middleware only if they are server errors (HTTP status code 5xx).
+  - Previously, if a middleware were to process the request after the Sentry middleware and return an error, our middleware would always capture it and send it to Sentry, regardless if it was a client or server error.
+  - With this change, we capture errors returned by middleware only if those errors can be classified as server errors.
+  - There is no change in behavior when it comes to errors returned by services, in which case the Sentry middleware only captures server errors exclusively.
+
 ## 0.42.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - fix(actix): capture only server errors ([#877](https://github.com/getsentry/sentry-rust/pull/877))
   - The Actix integration now properly honors the `capture_server_errors` option (enabled by default), capturing errors returned by middleware only if they are server errors (HTTP status code 5xx).
-  - Previously, if a middleware were to process the request after the Sentry middleware and return an error, our middleware would always capture it and send it to Sentry, regardless if it was a client or server error.
+  - Previously, if a middleware were to process the request after the Sentry middleware and return an error, our middleware would always capture it and send it to Sentry, regardless if it was a client, server or some other kind of error.
   - With this change, we capture errors returned by middleware only if those errors can be classified as server errors.
   - There is no change in behavior when it comes to errors returned by services, in which case the Sentry middleware only captures server errors exclusively.
 


### PR DESCRIPTION
Before this change, if a middleware processing the request after the Sentry one returned an error, we would capture it unconditionally.
With this change, we capture it only if it's a server error.
(note that the behavior was correct for responses returned by services (i.e. request handler, not middleware), as at line 373 we check if it's a server error).

This is one of the possible ways to tackle this, and I think this is the one that makes most sense for the following reasons:
- Client errors could be spammy and don't usually provide much value to the user of Sentry.
- Capturing errors can be expensive when attaching stack traces.
- Better experience for new users that won't be surprised by this unintended behavior.

It must be said that there is a small possibility that someone misses this in the changelog who was actually relying on these errors to show up in Sentry.

Close https://github.com/getsentry/sentry-rust/issues/876