### PR TITLE
build(panic): Fix build without other dependencies

### DIFF
--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.81"
 
 [dependencies]
-sentry-core = { version = "0.42.0", path = "../sentry-core" }
+sentry-core = { version = "0.42.0", path = "../sentry-core", features = ["client"] }
 sentry-backtrace = { version = "0.42.0", path = "../sentry-backtrace" }
 
 [dev-dependencies]


### PR DESCRIPTION
When sentry-panic is the only (or one of a few) dependencies of a crate, it might fail to build — it relies on sentry-core's "client" feature but doesn't declare it.

Reproducer:

1. mkdir sentry-panic-test; cd sentry-panic-test
2. cargo init .
3. cargo add sentry-panic
4. cargo build

This results in:

       Compiling sentry-panic v0.42.0
    error[E0599]: no method named `client` found for reference `&Hub` in the current scope
      --> /home/tomi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sentry-panic-0.42.0/src/lib.rs:39:35
       |
    39 |         if let Some(client) = hub.client() {
       |                                   ^^^^^^ method not found in `&Hub`

The fix is to declare the required "client" feature in the sentry-core dependency.
