### PR TITLE
Update README.md

### DIFF
--- a/sentry/README.md
+++ b/sentry/README.md
@@ -75,7 +75,7 @@ extra setup to function properly.
 | `anyhow`          |         | 🔌             |            |                                                                                          |
 | `test`            |         |                |            |                                                                                          |
 | `debug-images`    | ✅      | 🔌             |            |                                                                                          |
-| `log`             |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
+| `logs`            |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 | `slog`            |         | 🔌             |            | Requires extra setup; See [`sentry-slog`]'s documentation.                               |
 | `reqwest`         | ✅      |                |            |                                                                                          |
 | `native-tls`      | ✅      |                |            | `reqwest` must be enabled.                                                               |
@@ -107,7 +107,7 @@ extra setup to function properly.
 - `test`: Enables testing support.
 
 ### Logging
-- `log`: Enables support for the `log` crate.
+- `logs`: Enables support for the `log` crate.
 - `slog`: Enables support for the `slog` crate.
 
 ### Transports


### PR DESCRIPTION
The Readme has a typo AFAIK. The `logs` feature is called `log` but the code says it should be `logs`. I updated it to `logs` now :)