### PR TITLE
fix: fix clippy lints on stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ lint:
 	cargo +stable clippy --all-features --tests --examples -- -D clippy::all
 .PHONY: lint
 
+fix:
+	@rustup component add clippy --toolchain stable 2> /dev/null
+	cargo +stable clippy --all-features --workspace --tests --examples --fix -- -D clippy::all
+.PHONY: fix
+
 # Tests
 
 test: checkall testall

--- a/sentry-backtrace/src/utils.rs
+++ b/sentry-backtrace/src/utils.rs
@@ -57,7 +57,7 @@ pub fn filename(s: &str) -> &str {
     s.rsplit(&['/', '\\'][..]).next().unwrap()
 }
 
-pub fn strip_symbol(s: &str) -> Cow<str> {
+pub fn strip_symbol(s: &str) -> Cow<'_, str> {
     let stripped_trailing_hash = HASH_FUNC_RE
         .captures(s)
         .map(|c| c.get(1).unwrap().as_str())

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -757,7 +757,7 @@ impl Transaction {
     /// for as long as it lives. Therefore you must take care not to keep the returned
     /// `TransactionData` around too long or it will never relinquish the lock and you may run into
     /// a deadlock.
-    pub fn data(&self) -> TransactionData {
+    pub fn data(&self) -> TransactionData<'_> {
         TransactionData(self.inner.lock().unwrap())
     }
 
@@ -988,7 +988,7 @@ impl Span {
     /// for as long as it lives. Therefore you must take care not to keep the returned
     /// `Data` around too long or it will never relinquish the lock and you may run into
     /// a deadlock.
-    pub fn data(&self) -> Data {
+    pub fn data(&self) -> Data<'_> {
         Data(self.span.lock().unwrap())
     }
 


### PR DESCRIPTION
Fixes clippy lints on stable.
Also adds a `make fix` command to auto apply fixes (even though these ones were not autofixable).