### PR TITLE
ref(tracing): use standard code attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - The `tracing` integration now uses `default` as the default Sentry span op.
   - Before this change, the span op would be set based on the `tracing` span name.
   - When upgrading, please ensure to adapt any queries, metrics or dashboards to use the new span names/ops.
+- ref(tracing): use standard code attributes ([#899](https://github.com/getsentry/sentry-rust/pull/899)) by @lcian
+  - Logs now carry the attributes `code.module.name`, `code.file.path` and `code.line.number` standardized in OTEL to surface the respective information, in contrast with the previously sent `tracing.module_path`, `tracing.file` and `tracing.line`.
 - fix(actix): capture only server errors ([#877](https://github.com/getsentry/sentry-rust/pull/877)) by @lcian
   - The Actix integration now properly honors the `capture_server_errors` option (enabled by default), capturing errors returned by middleware only if they are server errors (HTTP status code 5xx).
   - Previously, if a middleware were to process the request after the Sentry middleware and return an error, our middleware would always capture it and send it to Sentry, regardless if it was a client, server or some other kind of error.
@@ -20,8 +22,6 @@
 
 - feat(tracing): send both breadcrumbs and logs by default ([#878](https://github.com/getsentry/sentry-rust/pull/878)) by @lcian
   - If the `logs` feature flag is enabled, and `enable_logs: true` is set on your client options, the default Sentry `tracing` layer now sends logs for all events at or above INFO.
-- ref(tracing): use standard code attributes ([#899](https://github.com/getsentry/sentry-rust/pull/899)) by @lcian
-  - Logs now carry the attributes `code.module.name`, `code.file.path` and `code.line.number` standardized in OTEL to surface the respective information, in contrast with the previously sent `tracing.module_path`, `tracing.file` and `tracing.line`.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - feat(tracing): send both breadcrumbs and logs by default ([#878](https://github.com/getsentry/sentry-rust/pull/878)) by @lcian
   - If the `logs` feature flag is enabled, and `enable_logs: true` is set on your client options, the default Sentry `tracing` layer now sends logs for all events at or above INFO.
+- ref(tracing): use standard code attributes ([#899](https://github.com/getsentry/sentry-rust/pull/899)) by @lcian
+  - Logs now carry the attributes `code.module.name`, `code.file.path` and `code.line.number` standardized in OTEL to surface the respective information, in contrast with the previously sent `tracing.module_path`, `tracing.file` and `tracing.line`.
 
 ### Features
 

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -344,13 +344,13 @@ where
 
     let event_meta = event.metadata();
     if let Some(module_path) = event_meta.module_path() {
-        attributes.insert("tracing.module_path".to_owned(), module_path.into());
+        attributes.insert("code.module.name".to_owned(), module_path.into());
     }
     if let Some(file) = event_meta.file() {
-        attributes.insert("tracing.file".to_owned(), file.into());
+        attributes.insert("code.file.path".to_owned(), file.into());
     }
     if let Some(line) = event_meta.line() {
-        attributes.insert("tracing.line".to_owned(), line.into());
+        attributes.insert("code.line.number".to_owned(), line.into());
     }
 
     attributes.insert("sentry.origin".to_owned(), "auto.tracing".into());


### PR DESCRIPTION
### Description
<!-- What changed and why? -->
Use the `code` attributes standardized in [OTEL](https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/) to surface module, file and line info when creating logs out of `tracing` events, instead of using "custom" `tracing.<x>` ones.