### PR TITLE
fix(tracing): skip default span attributes when propagating to event

### DIFF
--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -101,6 +101,9 @@ where
                 match &span_data.sentry_span {
                     TransactionOrSpan::Span(span) => {
                         for (key, value) in span.data().iter() {
+                            if is_sentry_span_attribute(key) {
+                                continue;
+                            }
                             if key != "message" {
                                 let key = format!("{name}:{key}");
                                 visitor.json_values.insert(key, value.clone());
@@ -109,6 +112,9 @@ where
                     }
                     TransactionOrSpan::Transaction(transaction) => {
                         for (key, value) in transaction.data().iter() {
+                            if is_sentry_span_attribute(key) {
+                                continue;
+                            }
                             if key != "message" {
                                 let key = format!("{name}:{key}");
                                 visitor.json_values.insert(key, value.clone());
@@ -121,6 +127,15 @@ where
     }
 
     (message, visitor)
+}
+
+/// Checks whether the given attribute name is one of those set on a span by the Sentry layer.
+/// In that case, we want to skip materializing it when propagating attributes, as it would mostly create noise.
+fn is_sentry_span_attribute(name: &str) -> bool {
+    matches!(
+        name,
+        "sentry.tracing.target" | "code.module.name" | "code.file.path" | "code.line.number"
+    )
 }
 
 /// Records the fields of a [`tracing_core::Event`].


### PR DESCRIPTION
### Description
<!-- What changed and why? -->
In https://github.com/getsentry/sentry-rust/pull/887 we added some attributes that are attached by default on all spans to surface more metadata.
We have an option on the `tracing` layer called `enable_span_attributes` that, when emitting an error/log out of a `tracing` event, attaches all the attributes of each span in the currently active span hierarchy to the error/log.

This results in a lot of noise, as you will see those attributes for every span that is currently active, which doesn't provide much value when looking at an error/log.
See this example with a log:
<img width="811" height="671" alt="Screenshot 2025-09-22 at 12 56 37" src="https://github.com/user-attachments/assets/ca6b44a5-3fa8-49bb-9306-e2987f48cc4b" />

With this change, we'll only propagate user-provided attributes to the error/log, skipping those we set by default on the spans.
When looking at the trace in Sentry, you'll still be able to see those on the corresponding span, as it provides valuable information.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->
Close https://github.com/getsentry/sentry-rust/issues/895
Close RUST-104

#skip-changelog because this fixes a bug for something that wasn't released