### PR TITLE
ref(logs): enable logs by default if logs feature flag is used

### DIFF
--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -325,7 +325,7 @@ impl Default for ClientOptions {
             user_agent: Cow::Borrowed(USER_AGENT),
             max_request_body_size: MaxRequestBodySize::Medium,
             #[cfg(feature = "logs")]
-            enable_logs: false,
+            enable_logs: true,
             #[cfg(feature = "logs")]
             before_send_log: None,
         }


### PR DESCRIPTION
### Description
<!-- What changed and why? -->
This enables log by default if the crate is used with the `logs` feature flag.
Otherwise, the user would have to enable the feature flag and then set `enable_logs` on top.
