### PR TITLE
Add in the permission for OIDC to work on the prevent action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - "release/**"
   pull_request:
 
+permissions:
+  id-token: write
+
 jobs:
   lints:
     name: Lints


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- Add an entry to CHANGELOG.md, following the format of existing entries
- The PR title should use [Conventional Commits](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`, etc.)
- Useful links for external contributors: [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/sentry)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Grants workflow-wide `id-token: write` permission in CI to support OIDC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 128e2bb1aa040a4d915c6ad20438c499a55fe572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->