### PR TITLE
feat(types): Add custom variant to `AttachmentType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- Add custom variant to `AttachmentType` that holds an arbitrary String. ([#916](https://github.com/getsentry/sentry-rust/pull/916))
+
 ## 0.44.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
   - Breaking change: `sentry::integrations::log::LogFilter` has been changed to a `bitflags` struct.
   - It's now possible to map a `log` record to multiple items in Sentry by combining multiple log filters in the filter, e.g. `log::Level::ERROR => LogFilter::Event | LogFilter::Log`.
   - If using a custom `mapper` instead, it's possible to return a `Vec<sentry::integrations::log::RecordMapping>` to map a `log` record to multiple items in Sentry.
-  - Add custom variant to `AttachmentType` that holds an arbitrary String. ([#916](https://github.com/getsentry/sentry-rust/pull/916))
 
 ### Behavioral changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - feat(log): support combined LogFilters and RecordMappings ([#914](https://github.com/getsentry/sentry-rust/pull/914)) by @lcian
   - Breaking change: `sentry::integrations::log::LogFilter` has been changed to a `bitflags` struct.
   - It's now possible to map a `log` record to multiple items in Sentry by combining multiple log filters in the filter, e.g. `log::Level::ERROR => LogFilter::Event | LogFilter::Log`.
-  - If using a custom `mapper` instead, it's possible to return a `Vec<sentry::integrations::log::RecordMapping>` to map a `log` record to multiple items in Sentry.
+  - If using a custom `mapper` instead, it's possible to return a `Vec<sentry::integrations::log::RecordMapping>` to map a `log` record to multiple items in Sentry. 
 
 ### Behavioral changes
 
@@ -53,6 +53,7 @@
 ### Features
 
 - ref(tracing): rework tracing to Sentry span name/op conversion ([#887](https://github.com/getsentry/sentry-rust/pull/887)) by @lcian
+
   - Additional special fields have been added that allow overriding certain data on the Sentry span:
     - `sentry.op`: override the Sentry span op.
     - `sentry.name`: override the Sentry span name.
@@ -194,10 +195,11 @@
 ### Features
 
 Support for [Sentry structured logs](https://docs.sentry.io/product/explore/logs/) has been added to the SDK.
+
 - To set up logs, enable the `logs` feature of the `sentry` crate and set `enable_logs` to `true` in your client options.
 - Then, use the `logger_trace!`, `logger_debug!`, `logger_info!`, `logger_warn!`, `logger_error!` and `logger_fatal!` macros to capture logs.
 - To filter or update logs before they are sent, you can use the `before_send_log` client option.
-- Please note that breaking changes could occur until the API is finalized. 
+- Please note that breaking changes could occur until the API is finalized.
 
 - feat(logs): add log protocol types (#821) by @lcian
 - feat(logs): add ability to capture and send logs (#823) by @lcian & @Swatinem
@@ -302,7 +304,7 @@ An OpenTelemetry integration has been released. Please refer to the changelog en
   - The metrics feature and the code related to it has been removed from the crate, as the Sentry backend stopped ingesting metrics a while ago.
 - Switch to MIT license (#724) by @cleptric
   - The license for the crates has been changed to MIT.
- 
+
 ### Features
 
 - feat(actix): capture HTTP request body (#731) by @pacifistes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@
 ### Features
 
 - ref(tracing): rework tracing to Sentry span name/op conversion ([#887](https://github.com/getsentry/sentry-rust/pull/887)) by @lcian
-
   - Additional special fields have been added that allow overriding certain data on the Sentry span:
     - `sentry.op`: override the Sentry span op.
     - `sentry.name`: override the Sentry span name.
@@ -195,11 +194,10 @@
 ### Features
 
 Support for [Sentry structured logs](https://docs.sentry.io/product/explore/logs/) has been added to the SDK.
-
 - To set up logs, enable the `logs` feature of the `sentry` crate and set `enable_logs` to `true` in your client options.
 - Then, use the `logger_trace!`, `logger_debug!`, `logger_info!`, `logger_warn!`, `logger_error!` and `logger_fatal!` macros to capture logs.
 - To filter or update logs before they are sent, you can use the `before_send_log` client option.
-- Please note that breaking changes could occur until the API is finalized.
+- Please note that breaking changes could occur until the API is finalized. 
 
 - feat(logs): add log protocol types (#821) by @lcian
 - feat(logs): add ability to capture and send logs (#823) by @lcian & @Swatinem
@@ -304,7 +302,7 @@ An OpenTelemetry integration has been released. Please refer to the changelog en
   - The metrics feature and the code related to it has been removed from the crate, as the Sentry backend stopped ingesting metrics a while ago.
 - Switch to MIT license (#724) by @cleptric
   - The license for the crates has been changed to MIT.
-
+ 
 ### Features
 
 - feat(actix): capture HTTP request body (#731) by @pacifistes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - feat(log): support combined LogFilters and RecordMappings ([#914](https://github.com/getsentry/sentry-rust/pull/914)) by @lcian
   - Breaking change: `sentry::integrations::log::LogFilter` has been changed to a `bitflags` struct.
   - It's now possible to map a `log` record to multiple items in Sentry by combining multiple log filters in the filter, e.g. `log::Level::ERROR => LogFilter::Event | LogFilter::Log`.
-  - If using a custom `mapper` instead, it's possible to return a `Vec<sentry::integrations::log::RecordMapping>` to map a `log` record to multiple items in Sentry. 
+  - If using a custom `mapper` instead, it's possible to return a `Vec<sentry::integrations::log::RecordMapping>` to map a `log` record to multiple items in Sentry.
+  - Add custom variant to `AttachmentType` that holds an arbitrary String. ([#916](https://github.com/getsentry/sentry-rust/pull/916))
 
 ### Behavioral changes
 

--- a/sentry-types/src/protocol/attachment.rs
+++ b/sentry-types/src/protocol/attachment.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::Deserialize;
 
 /// The different types an attachment can have.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
 pub enum AttachmentType {
     #[serde(rename = "event.attachment")]
     /// (default) A standard attachment without special meaning.
@@ -23,6 +23,9 @@ pub enum AttachmentType {
     /// the last logs are extracted into event breadcrumbs.
     #[serde(rename = "unreal.logs")]
     UnrealLogs,
+    /// A custom attachment type with an arbitrary string value.
+    #[serde(untagged)]
+    Custom(String),
 }
 
 impl Default for AttachmentType {
@@ -33,13 +36,14 @@ impl Default for AttachmentType {
 
 impl AttachmentType {
     /// Gets the string value Sentry expects for the attachment type.
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Attachment => "event.attachment",
             Self::Minidump => "event.minidump",
             Self::AppleCrashReport => "event.applecrashreport",
             Self::UnrealContext => "unreal.context",
             Self::UnrealLogs => "unreal.logs",
+            Self::Custom(s) => s,
         }
     }
 }
@@ -68,7 +72,7 @@ impl Attachment {
             r#"{{"type":"attachment","length":{length},"filename":"{filename}","attachment_type":"{at}","content_type":"{ct}"}}"#,
             filename = self.filename,
             length = self.buffer.len(),
-            at = self.ty.unwrap_or_default().as_str(),
+            at = self.ty.clone().unwrap_or_default().as_str(),
             ct = self
                 .content_type
                 .as_ref()
@@ -90,5 +94,20 @@ impl fmt::Debug for Attachment {
             .field("content_type", &self.content_type)
             .field("type", &self.ty)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_attachment_type_deserialize() {
+        let result: AttachmentType = serde_json::from_str(r#""event.minidump""#).unwrap();
+        assert_eq!(result, AttachmentType::Minidump);
+
+        let result: AttachmentType = serde_json::from_str(r#""my.custom.type""#).unwrap();
+        assert_eq!(result, AttachmentType::Custom("my.custom.type".to_string()));
     }
 }

--- a/sentry-types/src/protocol/attachment.rs
+++ b/sentry-types/src/protocol/attachment.rs
@@ -72,7 +72,11 @@ impl Attachment {
             r#"{{"type":"attachment","length":{length},"filename":"{filename}","attachment_type":"{at}","content_type":"{ct}"}}"#,
             filename = self.filename,
             length = self.buffer.len(),
-            at = self.ty.clone().unwrap_or_default().as_str(),
+            at = self
+                .ty
+                .as_ref()
+                .unwrap_or(&AttachmentType::default())
+                .as_str(),
             ct = self
                 .content_type
                 .as_ref()


### PR DESCRIPTION
We would like to be able to send a custom attachment type, this makes it such that this is possible.