### PR TITLE
ci: Don't upload Prevent report from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: cargo nextest run --profile ci --all-features --all-targets
       
       - name: Upload test results to Sentry Prevent
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: getsentry/prevent-action@v0
         with:
           files: target/nextest/ci/junit.xml


### PR DESCRIPTION
The original issue discussed in https://github.com/getsentry/sentry-rust/pull/929 around the CI workflow failing when running from a fork has been fixed.

However, there's another issue that still makes the workflow fail when running from a fork due to some org-wide settings we have, apparently. I've tried to raise this internally but haven't got any response.
Full discussion (internal link): https://sentry.slack.com/archives/C04DL8SRBUZ/p1760109046445589

As a quick and effective solution, we can simply skip uploading the report when running from a fork.

#skip-changelog