### PR TITLE
ci: Improve Danger setup

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,9 +5,9 @@ on:
     types: [opened, synchronize, reopened, edited, ready_for_review, labeled, unlabeled]
 
 permissions:
-  contents: read       # To read repository files
-  pull-requests: write # To post comments on pull requests
-  statuses: write      # To post commit status checks
+  contents: read
+  pull-requests: write
+  statuses: write
 
 jobs:
   danger:


### PR DESCRIPTION
This changes the workflow to follow the recommended pattern in https://github.com/getsentry/github-workflows/blob/main/danger/README.md.
Previously we didn't retrigger a run on `labeled` and `unlabeled`, which meant that applying labels like `skip-changelog`  was not effective.