### PR TITLE
ci(release): Switch from action-prepare-release to Craft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - run: cargo install cargo-readme
 
       - name: Prepare release
-        uses: getsentry/craft@beea4aba589c66381258cbd131c5551ae8245b82 # v2.20.1
+        uses: getsentry/craft@906009a1b771956757e521555b561379307eb667 # v2.21.4
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:


### PR DESCRIPTION
## Summary

This PR migrates from the deprecated `action-prepare-release` to the new Craft GitHub Actions.

## Changes

- Migrated `.github/workflows/release.yml` to Craft reusable workflow

## Documentation

See https://getsentry.github.io/craft/github-actions/ for more information.
