### PR TITLE
ref(transports): Define cfg aliases to DRY cfg guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,7 @@ version = "0.46.1"
 dependencies = [
  "actix-web",
  "anyhow",
+ "cfg_aliases",
  "curl",
  "embedded-svc",
  "esp-idf-svc",

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -107,3 +107,6 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "tracing-log"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+
+[build-dependencies]
+cfg_aliases = "0.2.1"

--- a/sentry/build.rs
+++ b/sentry/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    // Define cfg aliases for better readability, and to reduce repetition.
+    cfg_aliases::cfg_aliases! {
+        sentry_embedded_svc_http: { all(target_os = "espidf", feature = "embedded-svc-http") },
+        sentry_any_http_transport: { any(
+            feature = "reqwest",
+            feature = "curl",
+            feature = "ureq",
+            sentry_embedded_svc_http
+        )},
+    }
+}

--- a/sentry/src/transports/mod.rs
+++ b/sentry/src/transports/mod.rs
@@ -18,9 +18,9 @@ mod reqwest;
 #[cfg(feature = "reqwest")]
 pub use self::reqwest::ReqwestHttpTransport;
 
-#[cfg(all(target_os = "espidf", feature = "embedded-svc-http"))]
+#[cfg(sentry_embedded_svc_http)]
 mod embedded_svc_http;
-#[cfg(all(target_os = "espidf", feature = "embedded-svc-http"))]
+#[cfg(sentry_embedded_svc_http)]
 pub use self::embedded_svc_http::EmbeddedSVCHttpTransport;
 
 #[cfg(feature = "curl")]
@@ -33,20 +33,10 @@ mod ureq;
 #[cfg(feature = "ureq")]
 pub use self::ureq::UreqHttpTransport;
 
-#[cfg(any(
-    feature = "reqwest",
-    feature = "curl",
-    feature = "ureq",
-    all(target_os = "espidf", feature = "embedded-svc-http")
-))]
+#[cfg(sentry_any_http_transport)]
 pub(crate) const HTTP_PAYLOAD_TOO_LARGE: u16 = 413;
 
-#[cfg(any(
-    feature = "reqwest",
-    feature = "curl",
-    feature = "ureq",
-    all(target_os = "espidf", feature = "embedded-svc-http")
-))]
+#[cfg(sentry_any_http_transport)]
 pub(crate) const HTTP_PAYLOAD_TOO_LARGE_MESSAGE: &str =
     "Envelope was discarded due to size limits (HTTP 413).";
 
@@ -55,7 +45,7 @@ type DefaultTransport = ReqwestHttpTransport;
 
 #[cfg(all(
     feature = "curl",
-    not(all(target_os = "espidf", feature = "embedded-svc-http")),
+    not(sentry_embedded_svc_http),
     not(feature = "reqwest"),
     not(feature = "ureq")
 ))]
@@ -63,15 +53,14 @@ type DefaultTransport = CurlHttpTransport;
 
 #[cfg(all(
     feature = "ureq",
-    not(all(target_os = "espidf", feature = "embedded-svc-http")),
+    not(sentry_embedded_svc_http),
     not(feature = "reqwest"),
     not(feature = "curl"),
 ))]
 type DefaultTransport = UreqHttpTransport;
 
 #[cfg(all(
-    target_os = "espidf",
-    feature = "embedded-svc-http",
+    sentry_embedded_svc_http,
     not(feature = "reqwest"),
     not(feature = "curl"),
     not(feature = "ureq")
@@ -79,12 +68,7 @@ type DefaultTransport = UreqHttpTransport;
 type DefaultTransport = EmbeddedSVCHttpTransport;
 
 /// The default http transport.
-#[cfg(any(
-    all(target_os = "espidf", feature = "embedded-svc-http"),
-    feature = "reqwest",
-    feature = "curl",
-    feature = "ureq"
-))]
+#[cfg(sentry_any_http_transport)]
 pub type HttpTransport = DefaultTransport;
 
 /// Creates the default HTTP transport.
@@ -97,21 +81,11 @@ pub struct DefaultTransportFactory;
 
 impl TransportFactory for DefaultTransportFactory {
     fn create_transport(&self, options: &ClientOptions) -> Arc<dyn Transport> {
-        #[cfg(any(
-            all(target_os = "espidf", feature = "embedded-svc-http"),
-            feature = "reqwest",
-            feature = "curl",
-            feature = "ureq"
-        ))]
+        #[cfg(sentry_any_http_transport)]
         {
             Arc::new(HttpTransport::new(options))
         }
-        #[cfg(not(any(
-            all(target_os = "espidf", feature = "embedded-svc-http"),
-            feature = "reqwest",
-            feature = "curl",
-            feature = "ureq"
-        )))]
+        #[cfg(not(sentry_any_http_transport))]
         {
             let _ = options;
             panic!("sentry crate was compiled without transport")


### PR DESCRIPTION
While working on #966, I noticed we have a lot of repeated `cfg` strings here. With the [`cfg_aliases` crate](https://docs.rs/cfg_aliases/0.2.1/cfg_aliases/index.html), we can define reusable aliases to these.