### PR TITLE
ref(cargo): Extract common items to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,10 @@ members = [
     "sentry-tracing",
     "sentry-types",
 ]
+
+[workspace.package]
+authors = ["Sentry <hello@sentry.io>"]
+repository = "https://github.com/getsentry/sentry-rust"
+homepage = "https://sentry.io/welcome/"
+edition = "2021"
+rust-version = "1.81"

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-actix"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for actix-web 4.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [features]
 default = ["release-health"]

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-anyhow"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for anyhow.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [features]
 default = ["backtrace"]

--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-backtrace"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration and utilities for dealing with stacktraces.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 backtrace = "0.3.44"

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "sentry-contexts"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for os, device, and rust contexts.
 """
 build = "build.rs"
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 sentry-core = { version = "0.46.2", path = "../sentry-core" }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-core"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Core Sentry library used for instrumentation and integration development.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-debug-images"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration that adds the list of loaded libraries to events.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 findshlibs = "=0.10.2"

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-log"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for the log and env_logger crates.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [features]
 default = []

--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-opentelemetry"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for OpenTelemetry.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-panic"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for capturing panics.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 sentry-core = { version = "0.46.2", path = "../sentry-core", features = ["client"] }

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-slog"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for the slog crate.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 sentry-core = { version = "0.46.2", path = "../sentry-core" }

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-tower"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for tower-based crates.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry-tracing"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry integration for the tracing and tracing-subscriber crates.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "sentry-types"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Common reusable types for implementing the sentry.io protocol.
 """
 keywords = ["sentry", "protocol"]
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "sentry"
 version = "0.46.2"
-authors = ["Sentry <hello@sentry.io>"]
+authors = { workspace = true }
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/getsentry/sentry-rust"
-homepage = "https://sentry.io/welcome/"
+repository = { workspace = true }
+homepage = { workspace = true }
 description = """
 Sentry (sentry.io) client for Rust.
 """
-edition = "2021"
-rust-version = "1.81"
+edition = { workspace = true }
+rust-version = { workspace = true }
 autoexamples = true
 
 # To build locally:


### PR DESCRIPTION
Extract all common package items, [which can be extracted](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table), to the workspace `Cargo.toml`, except for the `version` field.

## Note on `version` & `license`

We cannot extract `version` because it causes a parse error when [generating the crate `README.md` files](https://github.com/getsentry/sentry-rust/blob/c203754655ea2cbb62632ad43ceac9547b1da2e9/scripts/update-readme.sh#L9) while [bumping the version](https://github.com/getsentry/sentry-rust/blob/c203754655ea2cbb62632ad43ceac9547b1da2e9/scripts/bump-version.sh#L16) prior to release, as the [`cargo-readme`](https://crates.io/crates/cargo-readme) tool we use to generate these files apparently cannot parse `version = { workspace = true }`, as it expects version to be set to a string. Similarly, `cargo readme` also fails if `license` is set with `{ workspace = true }`

@Dav1dde, do you have any suggestions for how to get around this? I think the way forward may be to simply stop using `cargo readme`, as our README files are quite verbose. Instead, I would propose having a short static README for each crate, directing users interested in full docs over to our docs.rs pages. What do you think?

In any case, this should happen in a separate PR.