### PR TITLE
feat(sentry-types): Add `Envelope::into_items` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- Added a `Envelope::into_items` method, which returns an iterator over owned [`EnvelopeItem`s](https://docs.rs/sentry/0.46.2/sentry/protocol/enum.EnvelopeItem.html) in the [`Envelope`](https://docs.rs/sentry/0.46.2/sentry/struct.Envelope.html) ([#983](https://github.com/getsentry/sentry-rust/pull/983)).
+
 ## 0.46.2
 
 ### New Features

--- a/sentry-opentelemetry/tests/creates_distributed_trace.rs
+++ b/sentry-opentelemetry/tests/creates_distributed_trace.rs
@@ -60,9 +60,9 @@ fn test_creates_distributed_trace() {
     let mut first_tx = None;
     let mut second_tx = None;
 
-    for envelope in &envelopes {
-        let tx = match envelope.items().next().unwrap() {
-            sentry::protocol::EnvelopeItem::Transaction(tx) => tx.clone(),
+    for envelope in envelopes {
+        let tx = match envelope.into_items().next().unwrap() {
+            sentry::protocol::EnvelopeItem::Transaction(tx) => tx,
             unexpected => panic!("Expected transaction, but got {unexpected:#?}"),
         };
 

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -377,6 +377,17 @@ impl Envelope {
         EnvelopeItemIter { inner }
     }
 
+    /// Consume the Envelope and create an [`Iterator`] over all
+    /// owned [`EnvelopeItem`]s.
+    ///
+    /// Raw envelopes yield an empty iterator.
+    pub fn into_items(self) -> impl Iterator<Item = EnvelopeItem> {
+        match self.items {
+            Items::EnvelopeItems(items) => items.into_iter(),
+            Items::Raw(_) => Default::default(),
+        }
+    }
+
     /// Returns the Envelope headers.
     pub fn headers(&self) -> &EnvelopeHeaders {
         &self.headers


### PR DESCRIPTION
Add a new method called `into_items` to the [`Envelope`](https://docs.rs/sentry/0.46.2/sentry/struct.Envelope.html) type. This method is similar to the existing [`items`](https://docs.rs/sentry/0.46.2/sentry/struct.Envelope.html#method.items) method, except that it yields owned [`EnvelopeItem`s](https://docs.rs/sentry/0.46.2/sentry/protocol/enum.EnvelopeItem.html) rather than references.

Also, refactor a test where we can use this new method to avoid a clone.

I intend to use this method elsewhere in the future, that is why I am adding it.