### PR TITLE
ci: Use `cargo test` instead of `nextest`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,0 @@
-[profile.ci]
-fail-fast = false
-
-[profile.ci.junit]
-path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
 
     name: Test using Rust stable on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    permissions:
-      id-token: write # required by `getsentry/prevent-action`
 
     steps:
       - name: Checkout sources
@@ -59,17 +57,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - uses: taiki-e/install-action@nextest
-
-      - name: Run tests with nextest
-        run: cargo nextest run --profile ci --all-features --all-targets
-
-      - name: Upload test results to Sentry Prevent
-        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: getsentry/prevent-action@v0
-        with:
-          files: target/nextest/ci/junit.xml
-          disable_search: true
+      - name: Run cargo test
+        run: cargo test --workspace --all-features --all-targets
 
   MSRV:
     strategy:


### PR DESCRIPTION
This reverts commit 750dec01620d77e7f62849b62bcdf20da1faf254, which introduced `cargo nextest` for the Rust stable tests, only (MSRV tests have consistently used `cargo test`).

With this change, we also revert the Sentry Prevent upload.

Resolves #972
Resolves [RUST-138](https://linear.app/getsentry/issue/RUST-138/replace-nextest-and-sentry-prevent-with-cargo-test)
