### PR TITLE
ci: enforce workflow-level RUSTFLAGS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - "release/**"
   pull_request:
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   lints:
     name: Lints
@@ -42,43 +45,29 @@ jobs:
 
       - name: Check all features
         run: cargo check --all-features
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Check sentry-core without default features
         run: cargo check --no-default-features
         working-directory: sentry-core
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Check default features
         run: cargo check
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Check sentry panic feature without defaults
         run: cargo check --no-default-features --features panic
         working-directory: sentry
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Check sentry curl feature
         run: cargo check --features curl
         working-directory: sentry
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Check sentry curl+panic without defaults
         run: cargo check --no-default-features --features curl,panic
         working-directory: sentry
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Check sentry-actix
         run: cargo check
         working-directory: sentry-actix
-        env:
-          RUSTFLAGS: -Dwarnings
 
   test:
     strategy:
@@ -122,13 +111,9 @@ jobs:
       - name: Check sentry-core without default features
         run: cargo check --no-default-features
         working-directory: sentry-core
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Check default features
         run: cargo check
-        env:
-          RUSTFLAGS: -Dwarnings
 
       - name: Test sentry test feature
         run: cargo test --features=test


### PR DESCRIPTION
### Description

Move RUSTFLAGS=-Dwarnings to workflow-level env in ci.yml and remove duplicated step-level env blocks from check and MSRV jobs.

_Stacked on #987_

#### Issues

Closes #976
Closes [RUST-142](https://linear.app/getsentry/issue/RUST-142/enforce-rustflags=-dwarnings-across-all-ci-jobs)
