### PR TITLE
ci: Add required jobs aggregator check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,21 @@ jobs:
 
       - name: Run cargo doc
         run: cargo doc --workspace --all-features --document-private-items --no-deps
+
+  required:
+    name: Check required jobs
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    # Keep this list in sync with all CI jobs that should be required.
+    # `codecov` is intentionally excluded from this aggregator.
+    needs: [lints, check, test, MSRV, doc]
+
+    steps:
+      - name: Fail if any required job did not succeed
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') ||
+            contains(needs.*.result, 'cancelled') ||
+            contains(needs.*.result, 'skipped')
+          }}
+        run: exit 1


### PR DESCRIPTION
Add a single required-check aggregator job to CI.

This makes branch protection easier to manage while still enforcing the full required CI set, and keeps `codecov` intentionally out of the gate.

Closes #977
Closes [RUST-143](https://linear.app/getsentry/issue/RUST-143/add-aggregator-required-ci-job)