### PR TITLE
ci: Add CI concurrency cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - "release/**"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   RUSTFLAGS: -Dwarnings
 


### PR DESCRIPTION

### Description
Configure workflow-level concurrency in ci.yml so newer runs for the same workflow+ref cancel older in-progress runs.

Use github.head_ref || github.ref to keep PR and branch pushes grouped correctly without changing any job logic.

#### Issues
Closes #979
Closes [RUST-145](https://linear.app/getsentry/issue/RUST-145/add-ci-concurrency-with-cancel-in-progress)
