### PR TITLE
ci: Split CI lanes into reusable workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,55 @@
+name: Check compile errors
+
+on:
+  workflow_call:
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable, 1.88.0]
+
+    name: Check compile errors using Rust ${{ matrix.rust }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install rust ${{ matrix.rust }} toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check all features
+        run: cargo check --all-features --locked
+
+      - name: Check sentry-core without default features
+        run: cargo check --no-default-features --locked
+        working-directory: sentry-core
+
+      - name: Check default features
+        run: cargo check --locked
+
+      - name: Check sentry panic feature without defaults
+        run: cargo check --no-default-features --features panic --locked
+        working-directory: sentry
+
+      - name: Check sentry curl feature
+        run: cargo check --features curl --locked
+        working-directory: sentry
+
+      - name: Check sentry curl+panic without defaults
+        run: cargo check --no-default-features --features curl,panic --locked
+        working-directory: sentry
+
+      - name: Check sentry-actix
+        run: cargo check --locked
+        working-directory: sentry-actix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,100 +16,16 @@ env:
 
 jobs:
   lints:
-    name: Lints
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - run: rustup component add rustfmt clippy
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: Run cargo clippy
-        run: cargo clippy --all-features --workspace --tests --examples --locked -- -D clippy::all
+    name: Run lint checks
+    uses: ./.github/workflows/lint.yml
 
   check:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, 1.88.0]
-
-    name: Check feature permutations using Rust ${{ matrix.rust }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install rust ${{ matrix.rust }} toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
-          rustup default ${{ matrix.rust }}
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Check all features
-        run: cargo check --all-features --locked
-
-      - name: Check sentry-core without default features
-        run: cargo check --no-default-features --locked
-        working-directory: sentry-core
-
-      - name: Check default features
-        run: cargo check --locked
-
-      - name: Check sentry panic feature without defaults
-        run: cargo check --no-default-features --features panic --locked
-        working-directory: sentry
-
-      - name: Check sentry curl feature
-        run: cargo check --features curl --locked
-        working-directory: sentry
-
-      - name: Check sentry curl+panic without defaults
-        run: cargo check --no-default-features --features curl,panic --locked
-        working-directory: sentry
-
-      - name: Check sentry-actix
-        run: cargo check --locked
-        working-directory: sentry-actix
+    name: Check compile errors
+    uses: ./.github/workflows/check.yml
 
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, 1.88.0]
-
-    name: Test using Rust ${{ matrix.rust }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install rust ${{ matrix.rust }} toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
-          rustup default ${{ matrix.rust }}
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run cargo test
-        run: cargo test --workspace --all-features --all-targets --locked
-
-      - name: Run cargo doc tests
-        run: cargo test --workspace --all-features --doc --locked
-
-      # Keep this separate so we continue asserting the default+test feature
-      # combination for sentry explicitly, even with broader all-features coverage.
-      - name: Test sentry default+test feature combination
-        run: cargo test -p sentry --features test --locked
+    name: Run tests
+    uses: ./.github/workflows/test.yml
 
   codecov:
     name: Code Coverage
@@ -132,21 +48,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   doc:
-    name: Build-test documentation
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - run: rustup component add rust-docs
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run cargo doc
-        run: cargo doc --workspace --all-features --document-private-items --no-deps --locked
+    name: Build documentation
+    uses: ./.github/workflows/doc.yml
 
   required:
     name: Check required jobs

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,25 @@
+name: Build documentation
+
+on:
+  workflow_call:
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  doc:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - run: rustup component add rust-docs
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo doc
+        run: cargo doc --workspace --all-features --document-private-items --no-deps --locked

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Run lint checks
+
+on:
+  workflow_call:
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  lint:
+    name: Run lint checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - run: rustup component add rustfmt clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run cargo clippy
+        run: cargo clippy --all-features --workspace --tests --examples --locked -- -D clippy::all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Run tests
+
+on:
+  workflow_call:
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable, 1.88.0]
+
+    name: Run tests using Rust ${{ matrix.rust }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install rust ${{ matrix.rust }} toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo test
+        run: cargo test --workspace --all-features --all-targets --locked
+
+      - name: Run cargo doc tests
+        run: cargo test --workspace --all-features --doc --locked
+
+      # Keep this separate so we continue asserting the default+test feature
+      # combination for sentry explicitly, even with broader all-features coverage.
+      - name: Test sentry default+test feature combination
+        run: cargo test -p sentry --features test --locked


### PR DESCRIPTION
Refactor the top-level CI workflow into a thin orchestrator that calls reusable workflows for lint, check, test, and doc lanes via job-level uses.

Keep lane behavior unchanged by moving the existing matrices, commands, flags, and environment settings into the called workflows. Keep codecov inline in ci.yml and preserve the required aggregator job identity and gating behavior so required checks remain stable during the refactor.

Closes #980
Closes [RUST-146](https://linear.app/getsentry/issue/RUST-146/split-ci-into-reusable-workflows)