### PR TITLE
meta(craft): Add `apiDocsUrl`

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -8,3 +8,4 @@ targets:
   - name: registry
     sdks:
       cargo:sentry:
+        apiDocsUrl: https://docs.rs/sentry


### PR DESCRIPTION
The API documentation URL on [our docs page's right hand sidebar](https://docs.sentry.io/platforms/rust/) is missing for the Rust SDK, because the `apiDocsUrl` field is not populated in the release registry. Since we pull the API docs link from the release registry, adding it to our Craft config should cause the link to surface after the next Rust SDK release.