### PR TITLE
feat(metrics): Associate trace data with metrics

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -25,6 +25,7 @@ client = ["rand"]
 test = ["client", "release-health"]
 release-health = []
 logs = []
+metrics = []
 
 [dependencies]
 log = { version = "0.4.8", optional = true, features = ["std"] }

--- a/sentry-core/src/batcher.rs
+++ b/sentry-core/src/batcher.rs
@@ -8,6 +8,8 @@ use crate::client::TransportArc;
 use crate::protocol::EnvelopeItem;
 use crate::Envelope;
 use sentry_types::protocol::v7::Log;
+#[cfg(feature = "metrics")]
+use sentry_types::protocol::v7::Metric;
 
 // Flush when there's 100 items in the buffer
 const MAX_ITEMS: usize = 100;
@@ -38,6 +40,11 @@ pub(crate) trait Batch: IntoBatchEnvelopeItem {
 
 impl Batch for Log {
     const TYPE_NAME: &str = "logs";
+}
+
+#[cfg(feature = "metrics")]
+impl Batch for Metric {
+    const TYPE_NAME: &str = "metrics";
 }
 
 /// Accumulates items in the queue and submits them through the transport when one of the flushing
@@ -154,7 +161,7 @@ impl<T: Batch> Drop for Batcher<T> {
     }
 }
 
-#[cfg(all(test, feature = "test"))]
+#[cfg(all(test, feature = "test", feature = "logs"))]
 mod tests {
     use crate::logger_info;
     use crate::test;

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -12,7 +12,7 @@ use crate::protocol::SessionUpdate;
 use rand::random;
 use sentry_types::random_uuid;
 
-#[cfg(feature = "logs")]
+#[cfg(any(feature = "logs", feature = "metrics"))]
 use crate::batcher::Batcher;
 use crate::constants::SDK_INFO;
 use crate::protocol::{ClientSdkInfo, Event};
@@ -24,6 +24,8 @@ use crate::SessionMode;
 use crate::{ClientOptions, Envelope, Hub, Integration, Scope, Transport};
 #[cfg(feature = "logs")]
 use sentry_types::protocol::v7::Context;
+#[cfg(feature = "metrics")]
+use sentry_types::protocol::v7::Metric;
 #[cfg(feature = "logs")]
 use sentry_types::protocol::v7::{Log, LogAttribute};
 
@@ -59,6 +61,8 @@ pub struct Client {
     session_flusher: RwLock<Option<SessionFlusher>>,
     #[cfg(feature = "logs")]
     logs_batcher: RwLock<Option<Batcher<Log>>>,
+    #[cfg(feature = "metrics")]
+    metrics_batcher: RwLock<Option<Batcher<Metric>>>,
     #[cfg(feature = "logs")]
     default_log_attributes: Option<BTreeMap<String, LogAttribute>>,
     integrations: Vec<(TypeId, Arc<dyn Integration>)>,
@@ -91,6 +95,13 @@ impl Clone for Client {
             None
         });
 
+        #[cfg(feature = "metrics")]
+        let metrics_batcher = RwLock::new(
+            self.options
+                .enable_metrics
+                .then(|| Batcher::new(transport.clone())),
+        );
+
         Client {
             options: self.options.clone(),
             transport,
@@ -98,6 +109,8 @@ impl Clone for Client {
             session_flusher,
             #[cfg(feature = "logs")]
             logs_batcher,
+            #[cfg(feature = "metrics")]
+            metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: self.default_log_attributes.clone(),
             integrations: self.integrations.clone(),
@@ -176,6 +189,13 @@ impl Client {
             None
         });
 
+        #[cfg(feature = "metrics")]
+        let metrics_batcher = RwLock::new(
+            options
+                .enable_metrics
+                .then(|| Batcher::new(transport.clone())),
+        );
+
         #[allow(unused_mut)]
         let mut client = Client {
             options,
@@ -184,6 +204,8 @@ impl Client {
             session_flusher,
             #[cfg(feature = "logs")]
             logs_batcher,
+            #[cfg(feature = "metrics")]
+            metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: None,
             integrations,
@@ -420,6 +442,10 @@ impl Client {
         if let Some(ref batcher) = *self.logs_batcher.read().unwrap() {
             batcher.flush();
         }
+        #[cfg(feature = "metrics")]
+        if let Some(ref batcher) = *self.metrics_batcher.read().unwrap() {
+            batcher.flush();
+        }
         if let Some(ref transport) = *self.transport.read().unwrap() {
             transport.flush(timeout.unwrap_or(self.options.shutdown_timeout))
         } else {
@@ -439,6 +465,8 @@ impl Client {
         drop(self.session_flusher.write().unwrap().take());
         #[cfg(feature = "logs")]
         drop(self.logs_batcher.write().unwrap().take());
+        #[cfg(feature = "metrics")]
+        drop(self.metrics_batcher.write().unwrap().take());
         let transport_opt = self.transport.write().unwrap().take();
         if let Some(transport) = transport_opt {
             sentry_debug!("client close; request transport to shut down");
@@ -492,6 +520,19 @@ impl Client {
         }
 
         Some(log)
+    }
+
+    /// Captures a metric and sends it to Sentry.
+    #[cfg(feature = "metrics")]
+    pub fn capture_metric(&self, metric: Metric, _: &Scope) {
+        if let Some(batcher) = self
+            .metrics_batcher
+            .read()
+            .expect("metrics batcher lock could not be acquired")
+            .as_ref()
+        {
+            batcher.enqueue(metric);
+        }
     }
 }
 

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -524,15 +524,24 @@ impl Client {
 
     /// Captures a metric and sends it to Sentry.
     #[cfg(feature = "metrics")]
-    pub fn capture_metric(&self, metric: Metric, _: &Scope) {
-        if let Some(batcher) = self
-            .metrics_batcher
-            .read()
-            .expect("metrics batcher lock could not be acquired")
-            .as_ref()
-        {
-            batcher.enqueue(metric);
+    pub fn capture_metric(&self, metric: Metric, scope: &Scope) {
+        if let Some(metric) = self.prepare_metric(metric, scope) {
+            if let Some(batcher) = self
+                .metrics_batcher
+                .read()
+                .expect("metrics batcher lock could not be acquired")
+                .as_ref()
+            {
+                batcher.enqueue(metric);
+            }
         }
+    }
+
+    /// Prepares a metric to be sent, setting trace association data from the scope.
+    #[cfg(feature = "metrics")]
+    fn prepare_metric(&self, mut metric: Metric, scope: &Scope) -> Option<Metric> {
+        scope.apply_to_metric(&mut metric);
+        Some(metric)
     }
 }
 

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -172,6 +172,9 @@ pub struct ClientOptions {
     /// Determines whether captured structured logs should be sent to Sentry (defaults to false).
     #[cfg(feature = "logs")]
     pub enable_logs: bool,
+    /// Determines whether captured metrics should be sent to Sentry (defaults to false).
+    #[cfg(feature = "metrics")]
+    pub enable_metrics: bool,
     // Other options not documented in Unified API
     /// Disable SSL verification.
     ///
@@ -278,6 +281,9 @@ impl fmt::Debug for ClientOptions {
             .field("enable_logs", &self.enable_logs)
             .field("before_send_log", &before_send_log);
 
+        #[cfg(feature = "metrics")]
+        debug_struct.field("enable_metrics", &self.enable_metrics);
+
         debug_struct.field("user_agent", &self.user_agent).finish()
     }
 }
@@ -317,6 +323,8 @@ impl Default for ClientOptions {
             enable_logs: true,
             #[cfg(feature = "logs")]
             before_send_log: None,
+            #[cfg(feature = "metrics")]
+            enable_metrics: false,
         }
     }
 }

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -4,6 +4,8 @@
 
 use std::sync::{Arc, RwLock};
 
+#[cfg(feature = "metrics")]
+use crate::protocol::Metric;
 use crate::protocol::{Event, Level, Log, LogAttribute, LogLevel, Map, SessionStatus};
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
@@ -253,6 +255,16 @@ impl Hub {
             let top = self.inner.with(|stack| stack.top().clone());
             let Some(ref client) = top.client else { return };
             client.capture_log(log, &top.scope);
+        }}
+    }
+
+    /// Captures a metric.
+    #[cfg(feature = "metrics")]
+    pub fn capture_metric(&self, metric: Metric) {
+        with_client_impl! {{
+            let top = self.inner.with(|stack| stack.top().clone());
+            let Some(ref client) = top.client else { return };
+            client.capture_metric(metric, &top.scope);
         }}
     }
 }

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -136,7 +136,7 @@ pub use crate::transport::{Transport, TransportFactory};
 mod logger; // structured logging macros exported with `#[macro_export]`
 
 // client feature
-#[cfg(all(feature = "client", feature = "logs"))]
+#[cfg(all(feature = "client", any(feature = "logs", feature = "metrics")))]
 mod batcher;
 #[cfg(feature = "client")]
 mod client;

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -586,6 +586,15 @@ impl TransactionOrSpan {
             TransactionOrSpan::Span(span) => span.finish(),
         }
     }
+
+    /// Get the span ID of this [`TransactionOrSpan`].
+    #[cfg(all(feature = "metrics", feature = "client"))]
+    pub(crate) fn span_id(&self) -> SpanId {
+        match self {
+            TransactionOrSpan::Transaction(transaction) => transaction.get_trace_context().span_id,
+            TransactionOrSpan::Span(span) => span.get_span_id(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -6,6 +6,8 @@ use std::sync::Mutex;
 use std::sync::{Arc, PoisonError, RwLock};
 
 use crate::performance::TransactionOrSpan;
+#[cfg(feature = "metrics")]
+use crate::protocol::Metric;
 use crate::protocol::{
     Attachment, Breadcrumb, Context, Event, Level, TraceContext, Transaction, User, Value,
 };
@@ -397,6 +399,17 @@ impl Scope {
                 }
             }
         }
+    }
+
+    /// Applies the contained scoped data to a trace metric, setting the `trace_id` and `span_id`.
+    #[cfg(feature = "metrics")]
+    pub(crate) fn apply_to_metric(&self, metric: &mut Metric) {
+        metric.trace_id = self
+            .get_span()
+            .map(|span| span.get_trace_context().trace_id)
+            .unwrap_or(self.propagation_context.trace_id);
+
+        metric.span_id = self.get_span().map(|span| span.span_id());
     }
 
     /// Set the given [`TransactionOrSpan`] as the active span for this scope.

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use sentry::protocol::MetricType;
 use sentry_core::protocol::{EnvelopeItem, ItemContainer};
 use sentry_core::test;
-use sentry_core::{ClientOptions, Hub};
+use sentry_core::{ClientOptions, Hub, TransactionContext};
 use sentry_types::protocol::v7::Metric;
 
 /// Test that metrics are sent when metrics are enabled.
@@ -202,6 +202,85 @@ fn test_metrics_batching_over_limit() {
         } if name == "metric.100"),
         "unexpected metric captured"
     )
+}
+
+/// Test that metrics in the same scope share the same trace_id when no span is active.
+///
+/// This tests that trace ID is set from the propagation context when there is no active span.
+#[test]
+fn metrics_share_trace_id_without_active_span() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            capture_test_metric("test-1");
+            capture_test_metric("test-2");
+        },
+        options,
+    );
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected one item");
+    let metrics = item.into_metrics().expect("expected metrics item");
+
+    let [metric1, metric2] = metrics.as_slice() else {
+        panic!("expected exactly two metrics");
+    };
+
+    assert_eq!(
+        metric1.trace_id, metric2.trace_id,
+        "metrics in the same scope should share the same trace_id"
+    );
+
+    assert!(metric1.span_id.is_none());
+    assert!(metric2.span_id.is_none());
+}
+
+/// Test that span_id is set from the active span when one is present.
+#[test]
+fn metrics_span_id_from_active_span() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let mut expected_span_id = None;
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            let transaction_ctx = TransactionContext::new("test transaction", "test");
+            expected_span_id = Some(transaction_ctx.span_id());
+            let transaction = sentry_core::start_transaction(transaction_ctx);
+            sentry_core::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            capture_test_metric("test");
+            transaction.finish();
+        },
+        options,
+    );
+
+    let expected_span_id = expected_span_id.expect("expected_span_id did not get set");
+
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected one item");
+    let mut metrics = item.into_metrics().expect("expected metrics item");
+    let metric = metrics.pop().expect("expected one metric");
+
+    assert_eq!(
+        metric.span_id,
+        Some(expected_span_id),
+        "span_id should be set from the active span"
+    );
 }
 
 /// Returns a [`Metric`] with [type `Counter`](MetricType),

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -1,0 +1,272 @@
+#![cfg(all(feature = "test", feature = "metrics"))]
+
+use std::collections::HashSet;
+use std::time::SystemTime;
+
+use anyhow::{Context, Result};
+
+use sentry::protocol::MetricType;
+use sentry_core::protocol::{EnvelopeItem, ItemContainer};
+use sentry_core::test;
+use sentry_core::{ClientOptions, Hub};
+use sentry_types::protocol::v7::Metric;
+
+/// Test that metrics are sent when metrics are enabled.
+#[test]
+fn sent_when_enabled() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let mut envelopes =
+        test::with_captured_envelopes_options(|| capture_test_metric("test"), options);
+
+    assert_eq!(envelopes.len(), 1, "expected exactly one envelope");
+
+    let envelope = envelopes.pop().unwrap();
+
+    let mut items = envelope.into_items();
+    let Some(item) = items.next() else {
+        panic!("Expected at least one item");
+    };
+
+    assert!(items.next().is_none(), "Expected only one item");
+
+    let EnvelopeItem::ItemContainer(ItemContainer::Metrics(mut metrics)) = item else {
+        panic!("Envelope item has unexpected structure");
+    };
+
+    assert_eq!(metrics.len(), 1, "Expected exactly one metric");
+
+    let metric = metrics.pop().unwrap();
+    assert!(matches!(metric, Metric {
+        r#type: MetricType::Counter,
+        name,
+        value: 1.0,
+        ..
+    } if name == "test"));
+}
+
+/// Test that metrics are disabled (not sent) when disabled in the
+/// [`ClientOptions`].
+#[test]
+fn metrics_disabled_by_default() {
+    // Metrics are disabled by default.
+    let options: ClientOptions = Default::default();
+
+    let envelopes = test::with_captured_envelopes_options(|| capture_test_metric("test"), options);
+    assert!(
+        envelopes.is_empty(),
+        "no envelopes should be captured when metrics disabled"
+    )
+}
+
+/// Test that no metrics are captured by a no-op call with
+/// metrics enabled
+#[test]
+fn noop_sends_nothing() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(|| (), options);
+
+    assert!(envelopes.is_empty(), "no-op should not capture metrics");
+}
+
+/// Test that 100 metrics are sent in a single envelope.
+#[test]
+fn test_metrics_batching_at_limit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            (0..100)
+                .map(|i| format!("metric.{i}"))
+                .for_each(capture_test_metric);
+        },
+        options,
+    );
+
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected exactly one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item");
+    let metrics = item
+        .into_metrics()
+        .expect("the envelope item is not a metrics item");
+
+    assert_eq!(metrics.len(), 100, "expected 100 metrics");
+
+    let metric_names: HashSet<_> = metrics
+        .into_iter()
+        .inspect(|metric| assert_eq!(metric.value, 1.0, "metric had unexpected value"))
+        .inspect(|metric| {
+            assert_eq!(
+                metric.r#type,
+                MetricType::Counter,
+                "metric had unexpected type"
+            )
+        })
+        .map(|metric| metric.name)
+        .collect();
+
+    (0..100)
+        .map(|i| format!("metric.{i}"))
+        .for_each(|metric_name| {
+            assert!(
+                metric_names.contains(metric_name.as_str()),
+                "expected metric {metric_name} was not captured"
+            )
+        });
+}
+
+/// Test that 101 envelopes are sent in two separate envelopes
+#[test]
+fn test_metrics_batching_over_limit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let mut envelopes = test::with_captured_envelopes_options(
+        || {
+            (0..101)
+                .map(|i| format!("metric.{i}"))
+                .for_each(capture_test_metric);
+        },
+        options,
+    )
+    .into_iter();
+    let envelope1 = envelopes.next().expect("expected a first envelope");
+    let envelope2 = envelopes.next().expect("expected a second envelope");
+    assert!(envelopes.next().is_none(), "expected exactly two envelopes");
+
+    let item1 = envelope1
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item in the first envelope");
+    let metrics1 = item1
+        .into_metrics()
+        .expect("the first envelope item is not a metrics item");
+
+    assert_eq!(metrics1.len(), 100, "expected 100 metrics");
+
+    let first_metric_names: HashSet<_> = metrics1
+        .into_iter()
+        .inspect(|metric| assert_eq!(metric.value, 1.0, "metric had unexpected value"))
+        .inspect(|metric| {
+            assert_eq!(
+                metric.r#type,
+                MetricType::Counter,
+                "metric had unexpected type"
+            )
+        })
+        .map(|metric| metric.name)
+        .collect();
+
+    (0..100)
+        .map(|i| format!("metric.{i}"))
+        .for_each(|metric_name| {
+            assert!(
+                first_metric_names.contains(metric_name.as_str()),
+                "expected metric {metric_name} was not captured in the first envelope"
+            )
+        });
+
+    let item2 = envelope2
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item in the second envelope");
+    let metrics2 = item2
+        .into_metrics()
+        .expect("the second envelope item is not a metrics item");
+    let metric2 = metrics2
+        .try_into_only_item()
+        .expect("expected exactly one metric in the second envelope");
+
+    assert!(
+        matches!(metric2, Metric {
+            r#type: MetricType::Counter,
+            name,
+            value: 1.0,
+            ..
+        } if name == "metric.100"),
+        "unexpected metric captured"
+    )
+}
+
+/// Returns a [`Metric`] with [type `Counter`](MetricType),
+/// the provided name, and a value of `1.0`.
+fn test_metric<S>(name: S) -> Metric
+where
+    S: Into<String>,
+{
+    Metric {
+        r#type: MetricType::Counter,
+        name: name.into().into(),
+        value: 1.0,
+        timestamp: SystemTime::now(),
+        trace_id: Default::default(),
+        span_id: Default::default(),
+        unit: Default::default(),
+        attributes: Default::default(),
+    }
+}
+
+/// Helper function to capture a metric, returned by `test_metric` on the current Hub.
+fn capture_test_metric<S>(name: S)
+where
+    S: Into<String>,
+{
+    Hub::current().capture_metric(test_metric(name))
+}
+
+/// Extension trait for iterators allowing conversion to only item.
+trait TryIntoOnlyElementExt<I> {
+    type Item;
+
+    /// Convert the iterator to the only item, erroring if the
+    /// iterator does not contain exactly one item.
+    fn try_into_only_item(self) -> Result<Self::Item>;
+}
+
+impl<I> TryIntoOnlyElementExt<I> for I
+where
+    I: IntoIterator,
+{
+    type Item = I::Item;
+
+    fn try_into_only_item(self) -> Result<Self::Item> {
+        let mut iter = self.into_iter();
+        let rv = iter.next().context("iterator was empty")?;
+
+        match iter.next() {
+            Some(_) => anyhow::bail!("iterator had more than one item"),
+            None => Ok(rv),
+        }
+    }
+}
+
+trait IntoMetricsExt {
+    /// Attempt to convert the provided value to a trace metric,
+    /// returning None if the conversion is not possible.
+    fn into_metrics(self) -> Option<Vec<Metric>>;
+}
+
+impl IntoMetricsExt for EnvelopeItem {
+    fn into_metrics(self) -> Option<Vec<Metric>> {
+        match self {
+            EnvelopeItem::ItemContainer(ItemContainer::Metrics(metrics)) => Some(metrics),
+            _ => None,
+        }
+    }
+}

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -10,8 +10,8 @@ use crate::Dsn;
 use super::v7 as protocol;
 
 use protocol::{
-    Attachment, AttachmentType, ClientSdkInfo, DynamicSamplingContext, Event, Log, MonitorCheckIn,
-    SessionAggregates, SessionUpdate, Transaction,
+    Attachment, AttachmentType, ClientSdkInfo, DynamicSamplingContext, Event, Log, Metric,
+    MonitorCheckIn, SessionAggregates, SessionUpdate, Transaction,
 };
 
 /// Raised if a envelope cannot be parsed from a given input.
@@ -127,6 +127,10 @@ enum EnvelopeItemType {
     /// A container of Log items.
     #[serde(rename = "log")]
     LogsContainer,
+    /// A container of Metric items.
+    /// Serialized to a `trace_metric` envelope item.
+    #[serde(rename = "trace_metric")]
+    MetricsContainer,
 }
 
 /// An Envelope Item Header.
@@ -192,6 +196,8 @@ pub enum EnvelopeItem {
 pub enum ItemContainer {
     /// A list of logs.
     Logs(Vec<Log>),
+    /// A list of metrics.
+    Metrics(Vec<Metric>),
 }
 
 #[allow(clippy::len_without_is_empty, reason = "is_empty is not needed")]
@@ -200,6 +206,7 @@ impl ItemContainer {
     pub fn len(&self) -> usize {
         match self {
             Self::Logs(logs) => logs.len(),
+            Self::Metrics(metrics) => metrics.len(),
         }
     }
 
@@ -207,6 +214,7 @@ impl ItemContainer {
     pub fn ty(&self) -> &'static str {
         match self {
             Self::Logs(_) => "log",
+            Self::Metrics(_) => "trace_metric",
         }
     }
 
@@ -214,6 +222,7 @@ impl ItemContainer {
     pub fn content_type(&self) -> &'static str {
         match self {
             Self::Logs(_) => "application/vnd.sentry.items.log+json",
+            Self::Metrics(_) => "application/vnd.sentry.items.trace-metric+json",
         }
     }
 }
@@ -233,6 +242,12 @@ impl From<Vec<Log>> for ItemContainer {
 #[derive(Deserialize, Serialize)]
 struct ItemsSerdeWrapper<'a, T: Clone> {
     items: Cow<'a, [T]>,
+}
+
+impl From<Vec<Metric>> for ItemContainer {
+    fn from(metrics: Vec<Metric>) -> Self {
+        Self::Metrics(metrics)
+    }
 }
 
 impl From<Event<'static>> for EnvelopeItem {
@@ -280,6 +295,12 @@ impl From<ItemContainer> for EnvelopeItem {
 impl From<Vec<Log>> for EnvelopeItem {
     fn from(logs: Vec<Log>) -> Self {
         EnvelopeItem::ItemContainer(logs.into())
+    }
+}
+
+impl From<Vec<Metric>> for EnvelopeItem {
+    fn from(metrics: Vec<Metric>) -> Self {
+        EnvelopeItem::ItemContainer(metrics.into())
     }
 }
 
@@ -506,6 +527,12 @@ impl Envelope {
                         let wrapper = ItemsSerdeWrapper { items: logs.into() };
                         serde_json::to_writer(&mut item_buf, &wrapper)?
                     }
+                    ItemContainer::Metrics(metrics) => {
+                        let wrapper = ItemsSerdeWrapper {
+                            items: metrics.into(),
+                        };
+                        serde_json::to_writer(&mut item_buf, &wrapper)?
+                    }
                 },
                 EnvelopeItem::Raw => {
                     continue;
@@ -677,6 +704,10 @@ impl Envelope {
                 serde_json::from_slice::<ItemsSerdeWrapper<_>>(payload)
                     .map(|x| EnvelopeItem::ItemContainer(ItemContainer::Logs(x.items.into())))
             }
+            EnvelopeItemType::MetricsContainer => {
+                serde_json::from_slice::<ItemsSerdeWrapper<_>>(payload)
+                    .map(|x| EnvelopeItem::ItemContainer(ItemContainer::Metrics(x.items.into())))
+            }
         }
         .map_err(EnvelopeError::InvalidItemPayload)?;
 
@@ -708,6 +739,7 @@ mod test {
     use std::time::{Duration, SystemTime};
 
     use protocol::Map;
+    use serde_json::Value;
     use time::format_description::well_known::Rfc3339;
     use time::OffsetDateTime;
 
@@ -1121,6 +1153,49 @@ some content
         assert_eq!(expected, serialized.as_bytes());
     }
 
+    #[test]
+    fn test_metric_container_header() {
+        let metrics: EnvelopeItem = vec![Metric {
+            r#type: protocol::MetricType::Counter,
+            name: "api.requests".into(),
+            value: 1.0,
+            timestamp: timestamp("2026-03-02T13:36:02.000Z"),
+            trace_id: "335e53d614474acc9f89e632b776cc28".parse().unwrap(),
+            span_id: None,
+            unit: None,
+            attributes: Map::new(),
+        }]
+        .into();
+
+        let mut envelope = Envelope::new();
+        envelope.add_item(metrics);
+
+        let expected = [
+            serde_json::json!({}),
+            serde_json::json!({
+                "type": "trace_metric",
+                "item_count": 1,
+                "content_type": "application/vnd.sentry.items.trace-metric+json"
+            }),
+            serde_json::json!({
+                "items": [{
+                    "type": "counter",
+                    "name": "api.requests",
+                    "value": 1.0,
+                    "timestamp": 1772458562,
+                    "trace_id": "335e53d614474acc9f89e632b776cc28"
+                }]
+            }),
+        ];
+
+        let serialized = to_str(envelope);
+        let actual = serialized
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("envelope has invalid JSON"));
+
+        assert!(actual.eq(expected.into_iter()));
+    }
+
     // Test all possible item types in a single envelope
     #[test]
     fn test_deserialize_serialized() {
@@ -1197,12 +1272,27 @@ some content
         ]
         .into();
 
+        let mut metric_attributes = Map::new();
+        metric_attributes.insert("route".into(), "/users".into());
+        let metrics: EnvelopeItem = vec![Metric {
+            r#type: protocol::MetricType::Distribution,
+            name: "response.time".into(),
+            value: 123.4,
+            timestamp: timestamp("2022-07-26T14:51:14.296Z"),
+            trace_id: "335e53d614474acc9f89e632b776cc28".parse().unwrap(),
+            span_id: Some("d42cee9fc3e74f5c".parse().unwrap()),
+            unit: Some("millisecond".into()),
+            attributes: metric_attributes,
+        }]
+        .into();
+
         let mut envelope: Envelope = Envelope::new();
         envelope.add_item(event);
         envelope.add_item(transaction);
         envelope.add_item(session);
         envelope.add_item(attachment);
         envelope.add_item(logs);
+        envelope.add_item(metrics);
 
         let serialized = to_str(envelope);
         let deserialized = Envelope::from_slice(serialized.as_bytes()).unwrap();

--- a/sentry-types/src/protocol/mod.rs
+++ b/sentry-types/src/protocol/mod.rs
@@ -17,3 +17,4 @@ mod attachment;
 mod envelope;
 mod monitor;
 mod session;
+mod unit;

--- a/sentry-types/src/protocol/unit.rs
+++ b/sentry-types/src/protocol/unit.rs
@@ -1,0 +1,125 @@
+//! Contains a [`Unit`] type, which encodes all
+//! [units we support](https://develop.sentry.dev/sdk/foundations/state-management/scopes/attributes/#units).
+//! Implementations to convert from common string types are provided.
+
+use std::borrow::Cow;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// A unit for a metric.
+///
+/// Recognized units are explicitly enumerated, while other units can be set using the
+/// [`Unit::Other`] variant.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all(serialize = "lowercase"))]
+#[expect(missing_docs)] // Most of the variants are self-explanatory
+#[non_exhaustive]
+pub enum Unit {
+    Nanosecond,
+    Microsecond,
+    Millisecond,
+    Second,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Bit,
+    Byte,
+    Kilobyte,
+    Kibibyte,
+    Megabyte,
+    Mebibyte,
+    Gigabyte,
+    Gibibyte,
+    Terabyte,
+    Tebibyte,
+    Petabyte,
+    Pebibyte,
+    Exabyte,
+    Exbibyte,
+    Ratio,
+    Percent,
+    /// Any other unit may not be recognized by the Sentry UI.
+    /// We advise against constructing this variant directly; instead, rely on the
+    /// `From<impl Into<Cow<'static, str>>>` implementation in case your unit is added as a known
+    /// unit in the future.
+    #[serde(untagged)]
+    Other(Cow<'static, str>),
+}
+
+impl From<Cow<'static, str>> for Unit {
+    /// Convert a [`Cow<'static, str>`] to a [`Unit`]. Known units (including standard symbols,
+    /// such as "MB" for "megabyte" or "ms" for "millisecond") are converted to the appropriate
+    /// enum variant, with other unknown units being mapped to [`Unit::Other`].
+    fn from(value: Cow<'static, str>) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&'static str> for Unit {
+    /// Convert a [`&'static str`](str) to a [`Unit`]. Known units (including standard symbols,
+    /// such as "MB" for "megabyte" or "ms" for "millisecond") are converted to the appropriate
+    /// enum variant, with other unknown units being mapped to [`Unit::Other`].
+    fn from(value: &'static str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for Unit {
+    /// Convert a [`String`] to a [`Unit`]. Known units (including standard symbols,
+    /// such as "MB" for "megabyte" or "ms" for "millisecond") are converted to the appropriate
+    /// enum variant, with other unknown units being mapped to [`Unit::Other`].
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for Unit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Unit::new(String::deserialize(deserializer)?))
+    }
+}
+
+impl Unit {
+    fn new<U>(value: U) -> Self
+    where
+        U: Into<Cow<'static, str>>,
+    {
+        let value = value.into();
+
+        match value.as_ref() {
+            "nanosecond" | "Nanosecond" | "nanoseconds" | "Nanoseconds" | "ns" => Self::Nanosecond,
+            "microsecond" | "Microsecond" | "microseconds" | "Microseconds" | "μs" => {
+                Self::Microsecond
+            }
+            "millisecond" | "Millisecond" | "milliseconds" | "Milliseconds" | "ms" => {
+                Self::Millisecond
+            }
+            "second" | "Second" | "seconds" | "Seconds" | "s" => Self::Second,
+            "minute" | "Minute" | "minutes" | "Minutes" | "min" => Self::Minute,
+            "hour" | "Hour" | "hours" | "Hours" | "h" => Self::Hour,
+            "day" | "Day" | "days" | "Days" | "d" => Self::Day,
+            "week" | "Week" | "weeks" | "Weeks" => Self::Week,
+            "bit" | "Bit" | "bits" | "Bits" | "b" => Self::Bit,
+            "byte" | "Byte" | "bytes" | "Bytes" | "B" => Self::Byte,
+            "kilobyte" | "Kilobyte" | "kilobytes" | "Kilobytes" | "kB" => Self::Kilobyte,
+            "kibibyte" | "Kibibyte" | "kibibytes" | "Kibibytes" | "KiB" => Self::Kibibyte,
+            "megabyte" | "Megabyte" | "megabytes" | "Megabytes" | "MB" => Self::Megabyte,
+            "mebibyte" | "Mebibyte" | "mebibytes" | "Mebibytes" | "MiB" => Self::Mebibyte,
+            "gigabyte" | "Gigabyte" | "gigabytes" | "Gigabytes" | "GB" => Self::Gigabyte,
+            "gibibyte" | "Gibibyte" | "gibibytes" | "Gibibytes" | "GiB" => Self::Gibibyte,
+            "terabyte" | "Terabyte" | "terabytes" | "Terabytes" | "TB" => Self::Terabyte,
+            "tebibyte" | "Tebibyte" | "tebibytes" | "Tebibytes" | "TiB" => Self::Tebibyte,
+            "petabyte" | "Petabyte" | "petabytes" | "Petabytes" | "PB" => Self::Petabyte,
+            "pebibyte" | "Pebibyte" | "pebibytes" | "Pebibytes" | "PiB" => Self::Pebibyte,
+            "exabyte" | "Exabyte" | "exabytes" | "Exabytes" | "EB" => Self::Exabyte,
+            "exbibyte" | "Exbibyte" | "exbibytes" | "Exbibytes" | "EiB" => Self::Exbibyte,
+            "ratio" | "Ratio" => Self::Ratio,
+            "percent" | "Percent" | "%" => Self::Percent,
+            _ => Self::Other(value),
+        }
+    }
+}

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -2382,6 +2382,8 @@ pub enum MetricType {
 }
 
 /// A single [metric](https://develop.sentry.dev/sdk/telemetry/metrics/).
+///
+/// Construct this type directly with a struct literal.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Metric {
     /// The metric type.

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -2369,6 +2369,43 @@ impl<'de> Deserialize<'de> for LogAttribute {
     }
 }
 
+/// The type of a [metric](https://develop.sentry.dev/sdk/telemetry/metrics/).
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum MetricType {
+    /// A counter metric that only increments.
+    Counter,
+    /// A gauge metric that can go up and down.
+    Gauge,
+    /// A distribution metric for statistical spread measurements.
+    Distribution,
+}
+
+/// A single [metric](https://develop.sentry.dev/sdk/telemetry/metrics/).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Metric {
+    /// The metric type.
+    pub r#type: MetricType,
+    /// The metric name. Uses dot separators for hierarchy.
+    pub name: Cow<'static, str>,
+    /// The numeric value.
+    pub value: f64,
+    /// The timestamp when recorded.
+    #[serde(with = "ts_seconds_float")]
+    pub timestamp: SystemTime,
+    /// The trace ID this metric is associated with.
+    pub trace_id: TraceId,
+    /// The span ID of the active span, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<SpanId>,
+    /// The measurement unit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit: Option<Unit>,
+    /// Additional key-value attributes.
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub attributes: Map<Cow<'static, str>, LogAttribute>,
+}
+
 /// An ID that identifies an organization in the Sentry backend.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub struct OrganizationId(u64);

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -28,6 +28,7 @@ pub use super::attachment::*;
 pub use super::envelope::*;
 pub use super::monitor::*;
 pub use super::session::*;
+pub use super::unit::Unit;
 
 /// An arbitrary (JSON) value.
 pub mod value {


### PR DESCRIPTION
Set trace and span id on metrics.

Stacked on #1026

Co-authored-by: Joris Bayer <joris.bayer@sentry.io>
Closes #1058
Closes [RUST-186](https://linear.app/getsentry/issue/RUST-186/add-trace-metric-tracing-association-in-sentry-core)