### PR TITLE
feat(metrics): Attach default SDK attributes to metrics

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -1,6 +1,6 @@
 use std::any::TypeId;
 use std::borrow::Cow;
-#[cfg(feature = "logs")]
+#[cfg(any(feature = "logs", feature = "metrics"))]
 use std::collections::BTreeMap;
 use std::fmt;
 use std::panic::RefUnwindSafe;
@@ -26,10 +26,12 @@ use crate::SessionMode;
 use crate::{ClientOptions, Envelope, Hub, Integration, Scope, Transport};
 #[cfg(feature = "logs")]
 use sentry_types::protocol::v7::Context;
+#[cfg(feature = "logs")]
+use sentry_types::protocol::v7::Log;
+#[cfg(any(feature = "logs", feature = "metrics"))]
+use sentry_types::protocol::v7::LogAttribute;
 #[cfg(feature = "metrics")]
 use sentry_types::protocol::v7::Metric;
-#[cfg(feature = "logs")]
-use sentry_types::protocol::v7::{Log, LogAttribute};
 
 impl<T: Into<ClientOptions>> From<T> for Client {
     fn from(o: T) -> Client {
@@ -67,6 +69,8 @@ pub struct Client {
     metrics_batcher: RwLock<Option<Batcher<Metric>>>,
     #[cfg(feature = "logs")]
     default_log_attributes: Option<BTreeMap<String, LogAttribute>>,
+    #[cfg(feature = "metrics")]
+    default_metric_attributes: BTreeMap<Cow<'static, str>, LogAttribute>,
     integrations: Vec<(TypeId, Arc<dyn Integration>)>,
     pub(crate) sdk_info: ClientSdkInfo,
 }
@@ -115,6 +119,8 @@ impl Clone for Client {
             metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: self.default_log_attributes.clone(),
+            #[cfg(feature = "metrics")]
+            default_metric_attributes: self.default_metric_attributes.clone(),
             integrations: self.integrations.clone(),
             sdk_info: self.sdk_info.clone(),
         }
@@ -210,12 +216,17 @@ impl Client {
             metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: None,
+            #[cfg(feature = "metrics")]
+            default_metric_attributes: Default::default(),
             integrations,
             sdk_info,
         };
 
         #[cfg(feature = "logs")]
         client.cache_default_log_attributes();
+
+        #[cfg(feature = "metrics")]
+        client.cache_default_metric_attributes();
 
         client
     }
@@ -269,6 +280,28 @@ impl Client {
         }
 
         self.default_log_attributes = Some(attributes);
+    }
+
+    #[cfg(feature = "metrics")]
+    fn cache_default_metric_attributes(&mut self) {
+        let always_present_attributes = [
+            ("sentry.sdk.name", &self.sdk_info.name),
+            ("sentry.sdk.version", &self.sdk_info.version),
+        ]
+        .into_iter()
+        .map(|(name, value)| (name.into(), value.as_str().into()));
+
+        let maybe_present_attributes = [
+            ("sentry.environment", &self.options.environment),
+            ("sentry.release", &self.options.release),
+            ("server.address", &self.options.server_name),
+        ]
+        .into_iter()
+        .filter_map(|(name, value)| value.clone().map(|value| (name.into(), value.into())));
+
+        self.default_metric_attributes = maybe_present_attributes
+            .chain(always_present_attributes)
+            .collect();
     }
 
     pub(crate) fn get_integration<I>(&self) -> Option<&I>
@@ -544,10 +577,15 @@ impl Client {
         }
     }
 
-    /// Prepares a metric to be sent, setting trace association data from the scope.
+    /// Prepares a metric to be sent, setting trace association data and default attributes.
     #[cfg(feature = "metrics")]
     fn prepare_metric<M: IntoProtocolMetric>(&self, metric: M, scope: &Scope) -> Option<Metric> {
-        let metric = scope.apply_to_metric(metric);
+        let mut metric = scope.apply_to_metric(metric);
+
+        for (key, val) in &self.default_metric_attributes {
+            metric.attributes.entry(key.clone()).or_insert(val.clone());
+        }
+
         Some(metric)
     }
 }

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -1,6 +1,6 @@
 use std::any::TypeId;
 use std::borrow::Cow;
-#[cfg(feature = "logs")]
+#[cfg(any(feature = "logs", feature = "metrics"))]
 use std::collections::BTreeMap;
 use std::fmt;
 use std::panic::RefUnwindSafe;
@@ -24,10 +24,12 @@ use crate::SessionMode;
 use crate::{ClientOptions, Envelope, Hub, Integration, Scope, Transport};
 #[cfg(feature = "logs")]
 use sentry_types::protocol::v7::Context;
+#[cfg(feature = "logs")]
+use sentry_types::protocol::v7::Log;
+#[cfg(any(feature = "logs", feature = "metrics"))]
+use sentry_types::protocol::v7::LogAttribute;
 #[cfg(feature = "metrics")]
 use sentry_types::protocol::v7::Metric;
-#[cfg(feature = "logs")]
-use sentry_types::protocol::v7::{Log, LogAttribute};
 
 impl<T: Into<ClientOptions>> From<T> for Client {
     fn from(o: T) -> Client {
@@ -65,6 +67,8 @@ pub struct Client {
     metrics_batcher: RwLock<Option<Batcher<Metric>>>,
     #[cfg(feature = "logs")]
     default_log_attributes: Option<BTreeMap<String, LogAttribute>>,
+    #[cfg(feature = "metrics")]
+    default_metric_attributes: BTreeMap<Cow<'static, str>, LogAttribute>,
     integrations: Vec<(TypeId, Arc<dyn Integration>)>,
     pub(crate) sdk_info: ClientSdkInfo,
 }
@@ -113,6 +117,8 @@ impl Clone for Client {
             metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: self.default_log_attributes.clone(),
+            #[cfg(feature = "metrics")]
+            default_metric_attributes: self.default_metric_attributes.clone(),
             integrations: self.integrations.clone(),
             sdk_info: self.sdk_info.clone(),
         }
@@ -208,12 +214,17 @@ impl Client {
             metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: None,
+            #[cfg(feature = "metrics")]
+            default_metric_attributes: Default::default(),
             integrations,
             sdk_info,
         };
 
         #[cfg(feature = "logs")]
         client.cache_default_log_attributes();
+
+        #[cfg(feature = "metrics")]
+        client.cache_default_metric_attributes();
 
         client
     }
@@ -267,6 +278,28 @@ impl Client {
         }
 
         self.default_log_attributes = Some(attributes);
+    }
+
+    #[cfg(feature = "metrics")]
+    fn cache_default_metric_attributes(&mut self) {
+        let always_present_attributes = [
+            ("sentry.sdk.name", &self.sdk_info.name),
+            ("sentry.sdk.version", &self.sdk_info.version),
+        ]
+        .into_iter()
+        .map(|(name, value)| (name.into(), value.as_str().into()));
+
+        let maybe_present_attributes = [
+            ("sentry.environment", &self.options.environment),
+            ("sentry.release", &self.options.release),
+            ("server.address", &self.options.server_name),
+        ]
+        .into_iter()
+        .filter_map(|(name, value)| value.clone().map(|value| (name.into(), value.into())));
+
+        self.default_metric_attributes = maybe_present_attributes
+            .chain(always_present_attributes)
+            .collect();
     }
 
     pub(crate) fn get_integration<I>(&self) -> Option<&I>
@@ -537,10 +570,15 @@ impl Client {
         }
     }
 
-    /// Prepares a metric to be sent, setting trace association data from the scope.
+    /// Prepares a metric to be sent, setting trace association data and default attributes.
     #[cfg(feature = "metrics")]
     fn prepare_metric(&self, mut metric: Metric, scope: &Scope) -> Option<Metric> {
         scope.apply_to_metric(&mut metric);
+
+        for (key, val) in &self.default_metric_attributes {
+            metric.attributes.entry(key.clone()).or_insert(val.clone());
+        }
+
         Some(metric)
     }
 }

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -8,7 +8,7 @@ use sentry::protocol::{MetricType, Unit, Value};
 use sentry_core::protocol::{EnvelopeItem, ItemContainer};
 use sentry_core::{metrics, test};
 use sentry_core::{ClientOptions, TransactionContext};
-use sentry_types::protocol::v7::Metric;
+use sentry_types::protocol::v7::{Envelope, Metric};
 
 /// Test that metrics are sent when metrics are enabled.
 #[test]
@@ -250,7 +250,6 @@ fn metric_attributes_are_captured() {
     assert_eq!(value, 1.0);
     assert!(span_id.is_none());
     assert!(unit.is_none());
-    assert_eq!(attributes.len(), 2, "expected two attributes");
     assert_eq!(
         attributes.get("http.route").map(|value| &value.0),
         Some(&Value::from("/health")),
@@ -296,7 +295,7 @@ fn metric_unit_is_captured() {
         trace_id: _,
         span_id,
         unit,
-        attributes,
+        attributes: _,
     } = metric;
 
     assert_eq!(r#type, MetricType::Gauge);
@@ -304,7 +303,6 @@ fn metric_unit_is_captured() {
     assert_eq!(value, 42.0);
     assert!(span_id.is_none());
     assert_eq!(unit, Some(Unit::Millisecond));
-    assert!(attributes.is_empty(), "expected no attributes");
 }
 
 /// Test that metrics in the same scope share the same trace_id when no span is active.
@@ -384,6 +382,112 @@ fn metrics_span_id_from_active_span() {
         Some(expected_span_id),
         "span_id should be set from the active span"
     );
+}
+
+/// Test that default SDK attributes are attached to metrics.
+#[test]
+fn default_attributes_attached() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        environment: Some("test-env".into()),
+        release: Some("1.0.0".into()),
+        server_name: Some("test-server".into()),
+        ..Default::default()
+    };
+
+    let envelopes =
+        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        ("sentry.environment", "test-env"),
+        ("sentry.release", "1.0.0"),
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+        ("server.address", "test-server"),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that optional default attributes are omitted when not configured.
+#[test]
+fn optional_default_attributes_omitted_when_not_configured() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes =
+        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        // Importantly, no other attributes should be set.
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that explicitly set metric attributes are not overwritten by defaults.
+#[test]
+fn default_attributes_do_not_overwrite_explicit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        environment: Some("default-env".into()),
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            metrics::counter("test", 1)
+                .attribute("sentry.environment", "custom-env")
+                .capture();
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        // Check the environment is the one set directly on the metric
+        ("sentry.environment", "custom-env"),
+        // The other default attributes also stay
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Helper to extract the single metric from a list of captured envelopes.
+///
+/// Asserts that the envelope contains only a single item, which contains only
+/// a single metrics item, and returns that metrics item, or an error if failed.
+fn extract_single_metric<I>(envelopes: I) -> Result<Metric>
+where
+    I: IntoIterator<Item = Envelope>,
+{
+    envelopes
+        .try_into_only_item()
+        .context("expected exactly one envelope")?
+        .into_items()
+        .try_into_only_item()
+        .context("expected exactly one item")?
+        .into_metrics()
+        .context("expected a metrics item")?
+        .try_into_only_item()
+        .context("expected exactly one metric")
 }
 
 /// Extension trait for iterators allowing conversion to only item.

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -5,8 +5,8 @@ use std::time::SystemTime;
 
 use anyhow::{Context, Result};
 
-use sentry::protocol::MetricType;
-use sentry_core::protocol::{EnvelopeItem, ItemContainer};
+use sentry::protocol::{LogAttribute, MetricType};
+use sentry_core::protocol::{Envelope, EnvelopeItem, ItemContainer, Value};
 use sentry_core::test;
 use sentry_core::{ClientOptions, Hub, TransactionContext};
 use sentry_types::protocol::v7::Metric;
@@ -283,6 +283,93 @@ fn metrics_span_id_from_active_span() {
     );
 }
 
+/// Test that default SDK attributes are attached to metrics.
+#[test]
+fn default_attributes_attached() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        environment: Some("test-env".into()),
+        release: Some("1.0.0".into()),
+        server_name: Some("test-server".into()),
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(|| capture_test_metric("test"), options);
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        ("sentry.environment", "test-env"),
+        ("sentry.release", "1.0.0"),
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+        ("server.address", "test-server"),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that optional default attributes are omitted when not configured.
+#[test]
+fn optional_default_attributes_omitted_when_not_configured() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(|| capture_test_metric("test"), options);
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        // Importantly, no other attributes should be set.
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that explicitly set metric attributes are not overwritten by defaults.
+#[test]
+fn default_attributes_do_not_overwrite_explicit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        environment: Some("default-env".into()),
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            let mut metric = test_metric("test");
+            metric.attributes.insert(
+                "sentry.environment".into(),
+                LogAttribute(Value::from("custom-env")),
+            );
+            Hub::current().capture_metric(metric);
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        // Check the environment is the one set directly on the metric
+        ("sentry.environment", "custom-env"),
+        // The other default attributes also stay
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
 /// Returns a [`Metric`] with [type `Counter`](MetricType),
 /// the provided name, and a value of `1.0`.
 fn test_metric<S>(name: S) -> Metric
@@ -307,6 +394,26 @@ where
     S: Into<String>,
 {
     Hub::current().capture_metric(test_metric(name))
+}
+
+/// Helper to extract the single metric from a list of captured envelopes.
+///
+/// Asserts that the envelope contains only a single item, which contains only
+/// a single metrics item, and returns that metrics item, or an error if failed.
+fn extract_single_metric<I>(envelopes: I) -> Result<Metric>
+where
+    I: IntoIterator<Item = Envelope>,
+{
+    envelopes
+        .try_into_only_item()
+        .context("expected exactly one envelope")?
+        .into_items()
+        .try_into_only_item()
+        .context("expected exactly one item")?
+        .into_metrics()
+        .context("expected a metrics item")?
+        .try_into_only_item()
+        .context("expected exactly one metric")
 }
 
 /// Extension trait for iterators allowing conversion to only item.


### PR DESCRIPTION
Set these metric attributes by default:
- `sentry.environment`
- `sentry.release`
- `sentry.sdk.name`
- `sentry.sdk.version`
- `server.address`

Preserve explicitly set metric attributes when applying those defaults.

Stacked on #1073

Co-authored-by: Joris Bayer <joris.bayer@sentry.io>
Closes #1059
Closes [RUST-187](https://linear.app/getsentry/issue/RUST-187/add-trace-metric-default-attribute-enrichment-in-sentry-core)