### PR TITLE
feat(metrics): Add metric user attributes from scope

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -580,7 +580,7 @@ impl Client {
     /// Prepares a metric to be sent, setting trace association data and default attributes.
     #[cfg(feature = "metrics")]
     fn prepare_metric<M: IntoProtocolMetric>(&self, metric: M, scope: &Scope) -> Option<Metric> {
-        let mut metric = scope.apply_to_metric(metric);
+        let mut metric = scope.apply_to_metric(metric, self.options().send_default_pii);
 
         for (key, val) in &self.default_metric_attributes {
             metric.attributes.entry(key.clone()).or_insert(val.clone());

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -573,7 +573,7 @@ impl Client {
     /// Prepares a metric to be sent, setting trace association data and default attributes.
     #[cfg(feature = "metrics")]
     fn prepare_metric(&self, mut metric: Metric, scope: &Scope) -> Option<Metric> {
-        scope.apply_to_metric(&mut metric);
+        scope.apply_to_metric(&mut metric, self.options.send_default_pii);
 
         for (key, val) in &self.default_metric_attributes {
             metric.attributes.entry(key.clone()).or_insert(val.clone());

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -9,13 +9,15 @@ use std::sync::{Arc, PoisonError, RwLock};
 #[cfg(feature = "metrics")]
 use crate::metrics::{IntoProtocolMetric, MetricTraceInfo};
 use crate::performance::TransactionOrSpan;
+#[cfg(feature = "logs")]
+use crate::protocol::Log;
+#[cfg(any(feature = "logs", feature = "metrics"))]
+use crate::protocol::LogAttribute;
 #[cfg(feature = "metrics")]
 use crate::protocol::Metric;
 use crate::protocol::{
     Attachment, Breadcrumb, Context, Event, Level, TraceContext, Transaction, User, Value,
 };
-#[cfg(feature = "logs")]
-use crate::protocol::{Log, LogAttribute};
 #[cfg(feature = "release-health")]
 use crate::session::Session;
 use crate::{Client, SentryTrace, TraceHeader, TraceHeadersIter};
@@ -410,9 +412,13 @@ impl Scope {
     /// This function takes a user-facing metric type (which implements [`IntoProtocolMetric`]).
     /// The function computes the trace_id and span_id, then converts the user-facing metric into
     /// the protocol's [`Metric`] type with the [`trace_id`](Metric::trace_id) and the
-    /// [`span_id`](Metric::span_id) set appropriately.
+    /// [`span_id`](Metric::span_id) set appropriately. Also sets user attributes when
+    /// send_default_pii is true.
     #[cfg(feature = "metrics")]
-    pub(crate) fn apply_to_metric<M: IntoProtocolMetric>(&self, metric: M) -> Metric {
+    pub(crate) fn apply_to_metric<M>(&self, metric: M, send_default_pii: bool) -> Metric
+    where
+        M: IntoProtocolMetric,
+    {
         let (trace_id, span_id) = match self.get_span() {
             Some(span) => {
                 let trace_context = span.get_trace_context();
@@ -427,7 +433,17 @@ impl Scope {
         };
 
         let trace = MetricTraceInfo { trace_id, span_id };
-        metric.into_protocol_metric(trace)
+        let mut metric = metric.into_protocol_metric(trace);
+        let should_add_user_attributes = send_default_pii && !metric.has_any_user_attributes();
+
+        if let Some(user) = should_add_user_attributes
+            .then_some(self.user.as_deref())
+            .flatten()
+        {
+            metric.apply_user_attributes(user);
+        }
+
+        metric
     }
 
     /// Set the given [`TransactionOrSpan`] as the active span for this scope.
@@ -473,5 +489,50 @@ impl Scope {
             );
             TraceHeadersIter::new(data.to_string())
         }
+    }
+}
+
+#[cfg(feature = "metrics")]
+trait MetricExt {
+    fn insert_attribute<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<Cow<'static, str>>,
+        V: Into<Value>;
+
+    fn attribute(&self, key: &str) -> Option<&LogAttribute>;
+
+    /// Applies user attributes from provided [`User`].
+    fn apply_user_attributes(&mut self, user: &User) {
+        [
+            ("user.id", user.id.as_deref()),
+            ("user.name", user.username.as_deref()),
+            ("user.email", user.email.as_deref()),
+        ]
+        .into_iter()
+        .flat_map(|(attribute, value)| value.map(|v| (attribute, v)))
+        .for_each(|(attribute, value)| self.insert_attribute(attribute, value));
+    }
+
+    /// Checks if any user attributes are on this metric
+    fn has_any_user_attributes(&self) -> bool {
+        ["user.id", "user.name", "user.email"]
+            .into_iter()
+            .any(|key| self.attribute(key).is_some())
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl MetricExt for Metric {
+    fn insert_attribute<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<Cow<'static, str>>,
+        V: Into<Value>,
+    {
+        self.attributes
+            .insert(key.into(), LogAttribute(value.into()));
+    }
+
+    fn attribute(&self, key: &str) -> Option<&LogAttribute> {
+        self.attributes.get(key)
     }
 }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -6,13 +6,15 @@ use std::sync::Mutex;
 use std::sync::{Arc, PoisonError, RwLock};
 
 use crate::performance::TransactionOrSpan;
+#[cfg(feature = "logs")]
+use crate::protocol::Log;
+#[cfg(any(feature = "logs", feature = "metrics"))]
+use crate::protocol::LogAttribute;
 #[cfg(feature = "metrics")]
 use crate::protocol::Metric;
 use crate::protocol::{
     Attachment, Breadcrumb, Context, Event, Level, TraceContext, Transaction, User, Value,
 };
-#[cfg(feature = "logs")]
-use crate::protocol::{Log, LogAttribute};
 #[cfg(feature = "release-health")]
 use crate::session::Session;
 use crate::{Client, SentryTrace, TraceHeader, TraceHeadersIter};
@@ -401,15 +403,25 @@ impl Scope {
         }
     }
 
-    /// Applies the contained scoped data to a trace metric, setting the `trace_id` and `span_id`.
+    /// Applies the contained scoped data to a trace metric, setting the `trace_id`, `span_id`,
+    /// and user attributes, when send_default_pii is true.
     #[cfg(feature = "metrics")]
-    pub(crate) fn apply_to_metric(&self, metric: &mut Metric) {
+    pub(crate) fn apply_to_metric(&self, metric: &mut Metric, send_default_pii: bool) {
         metric.trace_id = self
             .get_span()
             .map(|span| span.get_trace_context().trace_id)
             .unwrap_or(self.propagation_context.trace_id);
 
         metric.span_id = self.get_span().map(|span| span.span_id());
+
+        let should_add_user_attributes = send_default_pii && !metric.has_any_user_attributes();
+
+        if let Some(user) = should_add_user_attributes
+            .then_some(self.user.as_deref())
+            .flatten()
+        {
+            metric.apply_user_attributes(user);
+        }
     }
 
     /// Set the given [`TransactionOrSpan`] as the active span for this scope.
@@ -455,5 +467,50 @@ impl Scope {
             );
             TraceHeadersIter::new(data.to_string())
         }
+    }
+}
+
+#[cfg(feature = "metrics")]
+trait MetricExt {
+    fn insert_attribute<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<Cow<'static, str>>,
+        V: Into<Value>;
+
+    fn attribute(&self, key: &str) -> Option<&LogAttribute>;
+
+    /// Applies user attributes from provided [`User`].
+    fn apply_user_attributes(&mut self, user: &User) {
+        [
+            ("user.id", user.id.as_deref()),
+            ("user.name", user.username.as_deref()),
+            ("user.email", user.email.as_deref()),
+        ]
+        .into_iter()
+        .flat_map(|(attribute, value)| value.map(|v| (attribute, v)))
+        .for_each(|(attribute, value)| self.insert_attribute(attribute, value));
+    }
+
+    /// Checks if any user attributes are on this metric
+    fn has_any_user_attributes(&self) -> bool {
+        ["user.id", "user.name", "user.email"]
+            .into_iter()
+            .any(|key| self.attribute(key).is_some())
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl MetricExt for Metric {
+    fn insert_attribute<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<Cow<'static, str>>,
+        V: Into<Value>,
+    {
+        self.attributes
+            .insert(key.into(), LogAttribute(value.into()));
+    }
+
+    fn attribute(&self, key: &str) -> Option<&LogAttribute> {
+        self.attributes.get(key)
     }
 }

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -8,7 +8,7 @@ use sentry::protocol::{MetricType, Unit, Value};
 use sentry_core::protocol::{EnvelopeItem, ItemContainer};
 use sentry_core::{metrics, test};
 use sentry_core::{ClientOptions, TransactionContext};
-use sentry_types::protocol::v7::{Envelope, Metric};
+use sentry_types::protocol::v7::{Envelope, Metric, User};
 
 /// Test that metrics are sent when metrics are enabled.
 #[test]
@@ -462,6 +462,125 @@ fn default_attributes_do_not_overwrite_explicit() {
         // The other default attributes also stay
         ("sentry.sdk.name", "sentry.rust"),
         ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that user attributes are NOT attached when `send_default_pii` is false.
+#[test]
+fn user_attributes_absent_without_send_default_pii() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        send_default_pii: false,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            sentry_core::configure_scope(|scope| {
+                scope.set_user(Some(User {
+                    id: Some("uid-123".into()),
+                    username: Some("testuser".into()),
+                    email: Some("test@example.com".into()),
+                    ..Default::default()
+                }));
+            });
+            metrics::counter("test", 1).capture();
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        // Note the lack of user attributes, despite setting them on the scope.
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that scope user attributes are attached to metrics when
+/// `send_default_pii` is true.
+#[test]
+fn metric_user_attributes_from_scope_are_applied_with_send_default_pii() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        send_default_pii: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            sentry_core::configure_scope(|scope| {
+                scope.set_user(Some(User {
+                    id: Some("uid-123".into()),
+                    username: Some("testuser".into()),
+                    email: Some("test@example.com".into()),
+                    ..Default::default()
+                }));
+            });
+            metrics::counter("test", 1).capture()
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+        ("user.id", "uid-123"),
+        ("user.name", "testuser"),
+        ("user.email", "test@example.com"),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that if a metric already has any user attribute set, scope user
+/// attributes are not merged in.
+#[test]
+fn metric_user_attributes_do_not_overwrite_explicit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        send_default_pii: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            sentry_core::configure_scope(|scope| {
+                scope.set_user(Some(User {
+                    id: Some("scope-uid".into()),
+                    username: Some("scope-user".into()),
+                    email: Some("scope@example.com".into()),
+                    ..Default::default()
+                }));
+            });
+            metrics::counter("test", 1)
+                .attribute("user.id", "explicit-uid")
+                .attribute("user.name", "explicit-user")
+                .capture();
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+        ("user.id", "explicit-uid"),
+        ("user.name", "explicit-user"),
     ]
     .into_iter()
     .map(|(attribute, value)| (attribute.into(), value.into()))

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -5,7 +5,7 @@ use std::time::SystemTime;
 
 use anyhow::{Context, Result};
 
-use sentry::protocol::{LogAttribute, MetricType};
+use sentry::protocol::{LogAttribute, MetricType, User};
 use sentry_core::protocol::{Envelope, EnvelopeItem, ItemContainer, Value};
 use sentry_core::test;
 use sentry_core::{ClientOptions, Hub, TransactionContext};
@@ -362,6 +362,130 @@ fn default_attributes_do_not_overwrite_explicit() {
         // The other default attributes also stay
         ("sentry.sdk.name", "sentry.rust"),
         ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that user attributes are NOT attached when `send_default_pii` is false.
+#[test]
+fn user_attributes_absent_without_send_default_pii() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        send_default_pii: false,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            sentry_core::configure_scope(|scope| {
+                scope.set_user(Some(User {
+                    id: Some("uid-123".into()),
+                    username: Some("testuser".into()),
+                    email: Some("test@example.com".into()),
+                    ..Default::default()
+                }));
+            });
+            capture_test_metric("test");
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        // Note the lack of user attributes, despite setting them on the scope.
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that scope user attributes are attached to metrics when
+/// `send_default_pii` is true.
+#[test]
+fn metric_user_attributes_from_scope_are_applied_with_send_default_pii() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        send_default_pii: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            sentry_core::configure_scope(|scope| {
+                scope.set_user(Some(User {
+                    id: Some("uid-123".into()),
+                    username: Some("testuser".into()),
+                    email: Some("test@example.com".into()),
+                    ..Default::default()
+                }));
+            });
+            capture_test_metric("test");
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+        ("user.id", "uid-123"),
+        ("user.name", "testuser"),
+        ("user.email", "test@example.com"),
+    ]
+    .into_iter()
+    .map(|(attribute, value)| (attribute.into(), value.into()))
+    .collect();
+
+    assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that if a metric already has any user attribute set, scope user
+/// attributes are not merged in.
+#[test]
+fn metric_user_attributes_do_not_overwrite_explicit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        send_default_pii: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            sentry_core::configure_scope(|scope| {
+                scope.set_user(Some(User {
+                    id: Some("scope-uid".into()),
+                    username: Some("scope-user".into()),
+                    email: Some("scope@example.com".into()),
+                    ..Default::default()
+                }));
+            });
+            let mut metric = test_metric("test");
+            metric
+                .attributes
+                .insert("user.id".into(), LogAttribute(Value::from("explicit-uid")));
+            metric.attributes.insert(
+                "user.name".into(),
+                LogAttribute(Value::from("explicit-user")),
+            );
+            Hub::current().capture_metric(metric);
+        },
+        options,
+    );
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    let expected_attributes = [
+        ("sentry.sdk.name", "sentry.rust"),
+        ("sentry.sdk.version", env!("CARGO_PKG_VERSION")),
+        ("user.id", "explicit-uid"),
+        ("user.name", "explicit-user"),
     ]
     .into_iter()
     .map(|(attribute, value)| (attribute.into(), value.into()))


### PR DESCRIPTION
Add the metric user attribute portion of the earlier enrichment work.

Pass send_default_pii into metric scope application and attach user.id, user.name, and user.email from the scope when that option is enabled. Preserve explicitly set `user.*` metric attributes instead of overwriting them.

Stacked on #1062

Co-authored-by: Joris Bayer <joris.bayer@sentry.io>
Closes #1060
Closes [RUST-188](https://linear.app/getsentry/issue/RUST-188/add-trace-metric-user-attribute-enrichment-gated-by-send-default-pii)
