### PR TITLE
feat(metrics): Add before_send_metric callback

### DIFF
--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -577,13 +577,18 @@ impl Client {
         }
     }
 
-    /// Prepares a metric to be sent, setting trace association data and default attributes.
+    /// Prepares a metric to be sent, setting the `trace_id` and other default attributes, and
+    /// processing it through `before_send_metric`.
     #[cfg(feature = "metrics")]
     fn prepare_metric<M: IntoProtocolMetric>(&self, metric: M, scope: &Scope) -> Option<Metric> {
         let mut metric = scope.apply_to_metric(metric, self.options().send_default_pii);
 
         for (key, val) in &self.default_metric_attributes {
             metric.attributes.entry(key.clone()).or_insert(val.clone());
+        }
+
+        if let Some(ref func) = self.options.before_send_metric {
+            metric = func(metric)?;
         }
 
         Some(metric)

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -570,13 +570,18 @@ impl Client {
         }
     }
 
-    /// Prepares a metric to be sent, setting trace association data and default attributes.
+    /// Prepares a metric to be sent, setting the `trace_id` and other default attributes, and
+    /// processing it through `before_send_metric`.
     #[cfg(feature = "metrics")]
     fn prepare_metric(&self, mut metric: Metric, scope: &Scope) -> Option<Metric> {
         scope.apply_to_metric(&mut metric, self.options.send_default_pii);
 
         for (key, val) in &self.default_metric_attributes {
             metric.attributes.entry(key.clone()).or_insert(val.clone());
+        }
+
+        if let Some(ref func) = self.options.before_send_metric {
+            metric = func(metric)?;
         }
 
         Some(metric)

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::constants::USER_AGENT;
 use crate::performance::TracesSampler;
-use crate::protocol::{Breadcrumb, Event, Log};
+use crate::protocol::{Breadcrumb, Event, Log, Metric};
 use crate::types::Dsn;
 use crate::{Integration, IntoDsn, TransportFactory};
 
@@ -179,6 +179,11 @@ pub struct ClientOptions {
     /// This setting has no effect unless the `metrics` feature is enabled at compile-time,
     /// as the feature is a prerequisite for sending metrics.
     pub enable_metrics: bool,
+    /// Callback that is executed for each Metric before sending.
+    ///
+    /// This setting has no effect unless the `metrics` feature is enabled at compile-time,
+    /// as the feature is a prerequisite for sending metrics.
+    pub before_send_metric: Option<BeforeCallback<Metric>>,
     // Other options not documented in Unified API
     /// Disable SSL verification.
     ///
@@ -242,6 +247,11 @@ impl fmt::Debug for ClientOptions {
             struct BeforeSendLog;
             self.before_send_log.as_ref().map(|_| BeforeSendLog)
         };
+        let before_send_metric = {
+            #[derive(Debug)]
+            struct BeforeSendMetric;
+            self.before_send_metric.as_ref().map(|_| BeforeSendMetric)
+        };
         #[derive(Debug)]
         struct TransportFactory;
 
@@ -282,6 +292,7 @@ impl fmt::Debug for ClientOptions {
             .field("enable_logs", &self.enable_logs)
             .field("before_send_log", &before_send_log)
             .field("enable_metrics", &self.enable_metrics)
+            .field("before_send_metric", &before_send_metric)
             .field("user_agent", &self.user_agent)
             .finish()
     }
@@ -319,6 +330,7 @@ impl Default for ClientOptions {
             enable_logs: true,
             before_send_log: None,
             enable_metrics: false,
+            before_send_metric: None,
         }
     }
 }

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -7,6 +7,8 @@ use crate::constants::USER_AGENT;
 use crate::performance::TracesSampler;
 #[cfg(feature = "logs")]
 use crate::protocol::Log;
+#[cfg(feature = "metrics")]
+use crate::protocol::Metric;
 use crate::protocol::{Breadcrumb, Event};
 use crate::types::Dsn;
 use crate::{Integration, IntoDsn, TransportFactory};
@@ -175,6 +177,9 @@ pub struct ClientOptions {
     /// Determines whether captured metrics should be sent to Sentry (defaults to false).
     #[cfg(feature = "metrics")]
     pub enable_metrics: bool,
+    /// Callback that is executed for each Metric before sending.
+    #[cfg(feature = "metrics")]
+    pub before_send_metric: Option<BeforeCallback<Metric>>,
     // Other options not documented in Unified API
     /// Disable SSL verification.
     ///
@@ -235,6 +240,12 @@ impl fmt::Debug for ClientOptions {
             struct BeforeSendLog;
             self.before_send_log.as_ref().map(|_| BeforeSendLog)
         };
+        #[cfg(feature = "metrics")]
+        let before_send_metric = {
+            #[derive(Debug)]
+            struct BeforeSendMetric;
+            self.before_send_metric.as_ref().map(|_| BeforeSendMetric)
+        };
         #[derive(Debug)]
         struct TransportFactory;
 
@@ -282,7 +293,9 @@ impl fmt::Debug for ClientOptions {
             .field("before_send_log", &before_send_log);
 
         #[cfg(feature = "metrics")]
-        debug_struct.field("enable_metrics", &self.enable_metrics);
+        debug_struct
+            .field("enable_metrics", &self.enable_metrics)
+            .field("before_send_metric", &before_send_metric);
 
         debug_struct.field("user_agent", &self.user_agent).finish()
     }
@@ -325,6 +338,8 @@ impl Default for ClientOptions {
             before_send_log: None,
             #[cfg(feature = "metrics")]
             enable_metrics: false,
+            #[cfg(feature = "metrics")]
+            before_send_metric: None,
         }
     }
 }

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "test", feature = "metrics"))]
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
@@ -8,7 +9,7 @@ use sentry::protocol::{MetricType, Unit, Value};
 use sentry_core::protocol::{EnvelopeItem, ItemContainer};
 use sentry_core::{metrics, test};
 use sentry_core::{ClientOptions, TransactionContext};
-use sentry_types::protocol::v7::{Envelope, Metric, User};
+use sentry_types::protocol::v7::{Envelope, LogAttribute, Metric, User};
 
 /// Test that metrics are sent when metrics are enabled.
 #[test]
@@ -589,6 +590,49 @@ fn metric_user_attributes_do_not_overwrite_explicit() {
     assert_eq!(metric.attributes, expected_attributes);
 }
 
+/// Test that `before_send_metric` can filter out metrics.
+#[test]
+fn before_send_metric_can_drop() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        before_send_metric: Some(Arc::new(|_| None)),
+        ..Default::default()
+    };
+
+    let envelopes =
+        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
+    assert!(
+        envelopes.is_empty(),
+        "metric should be dropped by before_send_metric"
+    );
+}
+
+/// Test that `before_send_metric` can modify metrics.
+#[test]
+fn before_send_metric_can_modify() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        before_send_metric: Some(Arc::new(|mut metric| {
+            metric
+                .attributes
+                .insert("added_by_callback".into(), LogAttribute(Value::from("yes")));
+            Some(metric)
+        })),
+        ..Default::default()
+    };
+
+    let envelopes =
+        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    assert_eq!(
+        metric.attributes.get("added_by_callback"),
+        Some(&LogAttribute(Value::from("yes"))),
+    );
+}
+
+/// Returns a [`Metric`] with [type `Counter`](MetricType),
+/// the provided name, and a value of `1.0`.
 /// Helper to extract the single metric from a list of captured envelopes.
 ///
 /// Asserts that the envelope contains only a single item, which contains only

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "test", feature = "metrics"))]
 
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::{Context, Result};
@@ -492,6 +493,45 @@ fn metric_user_attributes_do_not_overwrite_explicit() {
     .collect();
 
     assert_eq!(metric.attributes, expected_attributes);
+}
+
+/// Test that `before_send_metric` can filter out metrics.
+#[test]
+fn before_send_metric_can_drop() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        before_send_metric: Some(Arc::new(|_| None)),
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(|| capture_test_metric("test"), options);
+    assert!(
+        envelopes.is_empty(),
+        "metric should be dropped by before_send_metric"
+    );
+}
+
+/// Test that `before_send_metric` can modify metrics.
+#[test]
+fn before_send_metric_can_modify() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        before_send_metric: Some(Arc::new(|mut metric| {
+            metric
+                .attributes
+                .insert("added_by_callback".into(), LogAttribute(Value::from("yes")));
+            Some(metric)
+        })),
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(|| capture_test_metric("test"), options);
+    let metric = extract_single_metric(envelopes).expect("expected a single-metric envelope");
+
+    assert_eq!(
+        metric.attributes.get("added_by_callback"),
+        Some(&LogAttribute(Value::from("yes"))),
+    );
 }
 
 /// Returns a [`Metric`] with [type `Counter`](MetricType),


### PR DESCRIPTION
Run metrics through `ClientOptions::before_send_metric` after scope/default attribute enrichment and before enqueue so applications can filter or mutate metrics before batching.

Stacked on #1063. 

Co-authored-by: Joris Bayer <joris.bayer@sentry.io>

 Closes #1025
Closes [RUST-170](https://linear.app/getsentry/issue/RUST-170/add-before-send-metric-callback-processing-in-sentry-core)
