### PR TITLE
feat(metrics): Basic metrics capturing functionality in sentry-core

### DIFF
--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -25,6 +25,7 @@ client = ["rand"]
 test = ["client", "release-health"]
 release-health = []
 logs = []
+metrics = []
 
 [dependencies]
 log = { version = "0.4.8", optional = true, features = ["std"] }

--- a/sentry-core/src/batcher.rs
+++ b/sentry-core/src/batcher.rs
@@ -8,6 +8,8 @@ use crate::client::TransportArc;
 use crate::protocol::EnvelopeItem;
 use crate::Envelope;
 use sentry_types::protocol::v7::Log;
+#[cfg(feature = "metrics")]
+use sentry_types::protocol::v7::Metric;
 
 // Flush when there's 100 items in the buffer
 const MAX_ITEMS: usize = 100;
@@ -38,6 +40,11 @@ pub(crate) trait Batch: IntoBatchEnvelopeItem {
 
 impl Batch for Log {
     const TYPE_NAME: &str = "logs";
+}
+
+#[cfg(feature = "metrics")]
+impl Batch for Metric {
+    const TYPE_NAME: &str = "metrics";
 }
 
 /// Accumulates items in the queue and submits them through the transport when one of the flushing
@@ -154,7 +161,7 @@ impl<T: Batch> Drop for Batcher<T> {
     }
 }
 
-#[cfg(all(test, feature = "test"))]
+#[cfg(all(test, feature = "test", feature = "logs"))]
 mod tests {
     use crate::logger_info;
     use crate::test;

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -7,12 +7,14 @@ use std::panic::RefUnwindSafe;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
+#[cfg(feature = "metrics")]
+use crate::metrics::IntoProtocolMetric;
 #[cfg(feature = "release-health")]
 use crate::protocol::SessionUpdate;
 use rand::random;
 use sentry_types::random_uuid;
 
-#[cfg(feature = "logs")]
+#[cfg(any(feature = "logs", feature = "metrics"))]
 use crate::batcher::Batcher;
 use crate::constants::SDK_INFO;
 use crate::protocol::{ClientSdkInfo, Event};
@@ -24,6 +26,8 @@ use crate::SessionMode;
 use crate::{ClientOptions, Envelope, Hub, Integration, Scope, Transport};
 #[cfg(feature = "logs")]
 use sentry_types::protocol::v7::Context;
+#[cfg(feature = "metrics")]
+use sentry_types::protocol::v7::Metric;
 #[cfg(feature = "logs")]
 use sentry_types::protocol::v7::{Log, LogAttribute};
 
@@ -59,6 +63,8 @@ pub struct Client {
     session_flusher: RwLock<Option<SessionFlusher>>,
     #[cfg(feature = "logs")]
     logs_batcher: RwLock<Option<Batcher<Log>>>,
+    #[cfg(feature = "metrics")]
+    metrics_batcher: RwLock<Option<Batcher<Metric>>>,
     #[cfg(feature = "logs")]
     default_log_attributes: Option<BTreeMap<String, LogAttribute>>,
     integrations: Vec<(TypeId, Arc<dyn Integration>)>,
@@ -91,6 +97,13 @@ impl Clone for Client {
             None
         });
 
+        #[cfg(feature = "metrics")]
+        let metrics_batcher = RwLock::new(
+            self.options
+                .enable_metrics
+                .then(|| Batcher::new(transport.clone())),
+        );
+
         Client {
             options: self.options.clone(),
             transport,
@@ -98,6 +111,8 @@ impl Clone for Client {
             session_flusher,
             #[cfg(feature = "logs")]
             logs_batcher,
+            #[cfg(feature = "metrics")]
+            metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: self.default_log_attributes.clone(),
             integrations: self.integrations.clone(),
@@ -176,6 +191,13 @@ impl Client {
             None
         });
 
+        #[cfg(feature = "metrics")]
+        let metrics_batcher = RwLock::new(
+            options
+                .enable_metrics
+                .then(|| Batcher::new(transport.clone())),
+        );
+
         #[allow(unused_mut)]
         let mut client = Client {
             options,
@@ -184,6 +206,8 @@ impl Client {
             session_flusher,
             #[cfg(feature = "logs")]
             logs_batcher,
+            #[cfg(feature = "metrics")]
+            metrics_batcher,
             #[cfg(feature = "logs")]
             default_log_attributes: None,
             integrations,
@@ -420,6 +444,10 @@ impl Client {
         if let Some(ref batcher) = *self.logs_batcher.read().unwrap() {
             batcher.flush();
         }
+        #[cfg(feature = "metrics")]
+        if let Some(ref batcher) = *self.metrics_batcher.read().unwrap() {
+            batcher.flush();
+        }
         if let Some(ref transport) = *self.transport.read().unwrap() {
             transport.flush(timeout.unwrap_or(self.options.shutdown_timeout))
         } else {
@@ -439,6 +467,8 @@ impl Client {
         drop(self.session_flusher.write().unwrap().take());
         #[cfg(feature = "logs")]
         drop(self.logs_batcher.write().unwrap().take());
+        #[cfg(feature = "metrics")]
+        drop(self.metrics_batcher.write().unwrap().take());
         let transport_opt = self.transport.write().unwrap().take();
         if let Some(transport) = transport_opt {
             sentry_debug!("client close; request transport to shut down");
@@ -492,6 +522,33 @@ impl Client {
         }
 
         Some(log)
+    }
+
+    /// Captures a metric and sends it to Sentry.
+    #[cfg(feature = "metrics")]
+    pub fn capture_metric<M: IntoProtocolMetric>(&self, metric: M, scope: &Scope) {
+        if !self.options.enable_metrics {
+            // Skip preparing the metric if we don't send it anyways.
+            return;
+        }
+
+        if let Some(metric) = self.prepare_metric(metric, scope) {
+            if let Some(batcher) = self
+                .metrics_batcher
+                .read()
+                .expect("metrics batcher lock could not be acquired")
+                .as_ref()
+            {
+                batcher.enqueue(metric);
+            }
+        }
+    }
+
+    /// Prepares a metric to be sent, setting trace association data from the scope.
+    #[cfg(feature = "metrics")]
+    fn prepare_metric<M: IntoProtocolMetric>(&self, metric: M, scope: &Scope) -> Option<Metric> {
+        let metric = scope.apply_to_metric(metric);
+        Some(metric)
     }
 }
 

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -174,6 +174,11 @@ pub struct ClientOptions {
     /// This setting has no effect unless the `logs` feature is enabled at compile-time, as the
     /// feature is a pre-requisite to sending logs.
     pub enable_logs: bool,
+    /// Determines whether captured metrics should be sent to Sentry (defaults to false).
+    ///
+    /// This setting has no effect unless the `metrics` feature is enabled at compile-time,
+    /// as the feature is a prerequisite for sending metrics.
+    pub enable_metrics: bool,
     // Other options not documented in Unified API
     /// Disable SSL verification.
     ///
@@ -276,6 +281,7 @@ impl fmt::Debug for ClientOptions {
             .field("session_mode", &self.session_mode)
             .field("enable_logs", &self.enable_logs)
             .field("before_send_log", &before_send_log)
+            .field("enable_metrics", &self.enable_metrics)
             .field("user_agent", &self.user_agent)
             .finish()
     }
@@ -312,6 +318,7 @@ impl Default for ClientOptions {
             max_request_body_size: MaxRequestBodySize::Medium,
             enable_logs: true,
             before_send_log: None,
+            enable_metrics: false,
         }
     }
 }

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -1,5 +1,7 @@
 use std::sync::{Arc, RwLock};
 
+#[cfg(feature = "metrics")]
+use crate::metrics::IntoProtocolMetric;
 #[cfg(feature = "logs")]
 use crate::protocol::Log;
 #[cfg(feature = "release-health")]
@@ -270,6 +272,19 @@ impl Hub {
             let top = self.inner.with(|stack| stack.top().clone());
             let Some(ref client) = top.client else { return };
             client.capture_log(log, &top.scope);
+        }}
+    }
+
+    /// Captures a metric on this hub, sending it to Sentry.
+    ///
+    /// If this hub has no client, the metric is dropped.
+    #[cfg(feature = "metrics")]
+    pub fn capture_metric<M: IntoProtocolMetric>(&self, metric: M) {
+        use_without_client!(metric);
+        with_client_impl! {{
+            let top = self.inner.with(|stack| stack.top().clone());
+            let Some(ref client) = top.client else { return };
+            client.capture_metric(metric, &top.scope);
         }}
     }
 }

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -135,8 +135,12 @@ pub use crate::transport::{Transport, TransportFactory};
 #[cfg(feature = "logs")]
 mod logger; // structured logging macros exported with `#[macro_export]`
 
+/// Module for creating metrics.
+#[cfg(feature = "metrics")]
+pub mod metrics;
+
 // client feature
-#[cfg(all(feature = "client", feature = "logs"))]
+#[cfg(all(feature = "client", any(feature = "logs", feature = "metrics")))]
 mod batcher;
 #[cfg(feature = "client")]
 mod client;

--- a/sentry-core/src/metrics.rs
+++ b/sentry-core/src/metrics.rs
@@ -1,0 +1,282 @@
+//! APIs for creating and capturing metrics.
+
+use std::collections::BTreeMap;
+use std::{borrow::Cow, time::SystemTime};
+
+use sentry_types::protocol::v7::{
+    LogAttribute, Metric as ProtocolMetric, MetricType, SpanId, TraceId, Unit,
+};
+
+#[cfg(any(doc, feature = "client"))]
+use crate::Hub;
+
+/// Creates a counter metric, with the given name and value.
+///
+/// You may set attributes via [`CounterMetric::attribute`].
+///
+/// Note that unlike [`gauge`] and [`distribution`] metrics, counters are always unitless.
+pub fn counter<N, V>(name: N, value: V) -> CounterMetric
+where
+    N: Into<Cow<'static, str>>,
+    V: Into<f64>,
+{
+    MetricInner::new(name, value).into()
+}
+
+/// Creates a gauge metric, with the given name and value.
+///
+/// It is recommended to set the unit on the metric via [`GaugeMetric::unit`]. You may also set
+/// attributes with [`GaugeMetric::attribute`].
+pub fn gauge<N, V>(name: N, value: V) -> GaugeMetric
+where
+    N: Into<Cow<'static, str>>,
+    V: Into<f64>,
+{
+    MetricInner::new(name, value).into()
+}
+
+/// Creates a distribution metric, with the given name and value.
+///
+/// It is recommended to set the unit on the metric via [`DistributionMetric::unit`]. You may also set
+/// attributes with [`DistributionMetric::attribute`].
+pub fn distribution<N, V>(name: N, value: V) -> DistributionMetric
+where
+    N: Into<Cow<'static, str>>,
+    V: Into<f64>,
+{
+    MetricInner::new(name, value).into()
+}
+
+/// A counter metric, created with [`counter`].
+#[must_use = "metrics must be captured via `.capture()` to be sent to Sentry"]
+pub struct CounterMetric {
+    inner: MetricInner,
+}
+
+/// A gauge metric, created with [`gauge`].
+#[must_use = "metrics must be captured via `.capture()` to be sent to Sentry"]
+pub struct GaugeMetric {
+    inner: UnitMetricInner,
+}
+
+/// A distribution metric, created with [`distribution`].
+#[must_use = "metrics must be captured via `.capture()` to be sent to Sentry"]
+pub struct DistributionMetric {
+    inner: UnitMetricInner,
+}
+
+/// Marker trait for types which can be converted to a [protocol metric](ProtocolMetric),
+/// allowing [`Hub::capture_metric`] to capture and send them to Sentry.
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait IntoProtocolMetric: sealed::IntoProtocolMetricImpl {}
+
+/// Implement metric methods common to all metric types.
+///
+/// This includes the `attribute` and the `capture` functions.
+macro_rules! implement_metric_common_methods {
+    ($struct:ident, $metric_type:expr) => {
+        impl $struct {
+            /// Adds an attribute to the metric.
+            pub fn attribute<K, V>(self, key: K, value: V) -> Self
+            where
+                K: Into<Cow<'static, str>>,
+                V: Into<LogAttribute>,
+            {
+                let inner = self.inner.attribute(key, value);
+                Self { inner }
+            }
+
+            /// Captures the metric on the current [`Hub`], sending it to Sentry.
+            ///
+            /// If the current hub has no client, the metric is dropped. To capture on a different
+            /// hub, use [`Hub::capture_metric`].
+            #[inline]
+            pub fn capture(self) {
+                with_client_impl! {{
+                    Hub::current().capture_metric(self)
+                }}
+            }
+        }
+
+        impl IntoProtocolMetric for $struct {}
+
+        impl sealed::IntoProtocolMetricImpl for $struct {
+            #[expect(private_interfaces)] // Not actually a public API
+            fn into_protocol_metric(self, trace: MetricTraceInfo) -> ProtocolMetric {
+                self.inner.into_protocol_metric($metric_type, trace)
+            }
+        }
+    };
+}
+
+/// Implements the `unit` method for a given metric type.
+macro_rules! implement_unit {
+    ($struct:ident) => {
+        impl $struct {
+            /// Sets the unit on the metric.
+            pub fn unit<U>(self, unit: U) -> Self
+            where
+                U: Into<Unit>,
+            {
+                let inner = self.inner.unit(unit);
+                Self { inner }
+            }
+        }
+    };
+}
+
+implement_metric_common_methods!(CounterMetric, MetricType::Counter);
+implement_metric_common_methods!(GaugeMetric, MetricType::Gauge);
+implement_metric_common_methods!(DistributionMetric, MetricType::Distribution);
+
+implement_unit!(GaugeMetric);
+implement_unit!(DistributionMetric);
+
+/// Information that links a metric to a trace.
+pub(crate) struct MetricTraceInfo {
+    pub(crate) trace_id: TraceId,
+    pub(crate) span_id: Option<SpanId>,
+}
+
+/// Common data that all metrics share.
+///
+/// Includes the metric type, name, value, and attributes.
+struct MetricInner {
+    name: Cow<'static, str>,
+    value: f64,
+    attributes: BTreeMap<Cow<'static, str>, LogAttribute>,
+}
+
+/// Common data that metrics, which support units, share.
+///
+/// Includes everything from [`MetricInner`] plus an optional [`Unit`].
+struct UnitMetricInner {
+    metric_inner: MetricInner,
+    unit: Option<Unit>,
+}
+
+impl MetricInner {
+    fn new<N, V>(name: N, value: V) -> Self
+    where
+        N: Into<Cow<'static, str>>,
+        V: Into<f64>,
+    {
+        let name = name.into();
+        let value = value.into();
+
+        Self {
+            name,
+            value,
+            attributes: Default::default(),
+        }
+    }
+
+    fn attribute<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<Cow<'static, str>>,
+        V: Into<LogAttribute>,
+    {
+        self.attributes.insert(key.into(), value.into());
+        self
+    }
+
+    fn into_protocol_metric(self, r#type: MetricType, trace: MetricTraceInfo) -> ProtocolMetric {
+        let Self {
+            name,
+            value,
+            attributes,
+        } = self;
+        let MetricTraceInfo { trace_id, span_id } = trace;
+
+        ProtocolMetric {
+            r#type,
+            trace_id,
+            name,
+            value,
+            attributes,
+            span_id,
+            timestamp: SystemTime::now(),
+            unit: None,
+        }
+    }
+}
+
+impl UnitMetricInner {
+    fn attribute<K, V>(self, key: K, value: V) -> Self
+    where
+        K: Into<Cow<'static, str>>,
+        V: Into<LogAttribute>,
+    {
+        Self {
+            metric_inner: self.metric_inner.attribute(key, value),
+            ..self
+        }
+    }
+
+    fn unit<U>(self, unit: U) -> Self
+    where
+        U: Into<Unit>,
+    {
+        let unit = Some(unit.into());
+        Self { unit, ..self }
+    }
+
+    fn into_protocol_metric(self, r#type: MetricType, trace: MetricTraceInfo) -> ProtocolMetric {
+        ProtocolMetric {
+            unit: self.unit,
+            ..self.metric_inner.into_protocol_metric(r#type, trace)
+        }
+    }
+}
+
+impl From<MetricInner> for CounterMetric {
+    #[inline]
+    fn from(inner: MetricInner) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<MetricInner> for GaugeMetric {
+    #[inline]
+    fn from(inner: MetricInner) -> Self {
+        let inner = inner.into();
+        Self { inner }
+    }
+}
+
+impl From<MetricInner> for DistributionMetric {
+    #[inline]
+    fn from(inner: MetricInner) -> Self {
+        let inner = inner.into();
+        Self { inner }
+    }
+}
+
+impl From<MetricInner> for UnitMetricInner {
+    #[inline]
+    fn from(metric_inner: MetricInner) -> Self {
+        Self {
+            metric_inner,
+            unit: None,
+        }
+    }
+}
+
+/// Private module for used to prevent [`IntoProtocolMetric`] from being implemented outside this
+/// crate, and for keeping its implementation details private.
+mod sealed {
+    use sentry_types::protocol::v7::Metric as ProtocolMetric;
+
+    use crate::metrics::MetricTraceInfo;
+
+    #[cfg(doc)]
+    use super::IntoProtocolMetric;
+
+    /// Actual implementation of [`IntoProtocolMetric`]
+    pub trait IntoProtocolMetricImpl {
+        /// Converts this item into a [`ProtocolMetric`], with the given [`MetricTraceInfo`].
+        #[expect(private_interfaces)] // This trait is not actually publicly accessible.
+        fn into_protocol_metric(self, trace: MetricTraceInfo) -> ProtocolMetric;
+    }
+}

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -6,7 +6,11 @@ use std::panic::RefUnwindSafe;
 use std::sync::Mutex;
 use std::sync::{Arc, PoisonError, RwLock};
 
+#[cfg(feature = "metrics")]
+use crate::metrics::{IntoProtocolMetric, MetricTraceInfo};
 use crate::performance::TransactionOrSpan;
+#[cfg(feature = "metrics")]
+use crate::protocol::Metric;
 use crate::protocol::{
     Attachment, Breadcrumb, Context, Event, Level, TraceContext, Transaction, User, Value,
 };
@@ -399,6 +403,31 @@ impl Scope {
                 }
             }
         }
+    }
+
+    /// Applies the contained scoped data to a metric, setting the `trace_id` and `span_id`.
+    ///
+    /// This function takes a user-facing metric type (which implements [`IntoProtocolMetric`]).
+    /// The function computes the trace_id and span_id, then converts the user-facing metric into
+    /// the protocol's [`Metric`] type with the [`trace_id`](Metric::trace_id) and the
+    /// [`span_id`](Metric::span_id) set appropriately.
+    #[cfg(feature = "metrics")]
+    pub(crate) fn apply_to_metric<M: IntoProtocolMetric>(&self, metric: M) -> Metric {
+        let (trace_id, span_id) = match self.get_span() {
+            Some(span) => {
+                let trace_context = span.get_trace_context();
+                let span_id = match span {
+                    TransactionOrSpan::Span(span) => span.get_span_id(),
+                    TransactionOrSpan::Transaction(_) => trace_context.span_id,
+                };
+
+                (trace_context.trace_id, Some(span_id))
+            }
+            None => (self.propagation_context.trace_id, None),
+        };
+
+        let trace = MetricTraceInfo { trace_id, span_id };
+        metric.into_protocol_metric(trace)
     }
 
     /// Set the given [`TransactionOrSpan`] as the active span for this scope.

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -1,0 +1,428 @@
+#![cfg(all(feature = "test", feature = "metrics"))]
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result};
+
+use sentry::protocol::{MetricType, Unit, Value};
+use sentry_core::protocol::{EnvelopeItem, ItemContainer};
+use sentry_core::{metrics, test};
+use sentry_core::{ClientOptions, TransactionContext};
+use sentry_types::protocol::v7::Metric;
+
+/// Test that metrics are sent when metrics are enabled.
+#[test]
+fn sent_when_enabled() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let mut envelopes =
+        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
+
+    assert_eq!(envelopes.len(), 1, "expected exactly one envelope");
+
+    let envelope = envelopes.pop().unwrap();
+
+    let mut items = envelope.into_items();
+    let Some(item) = items.next() else {
+        panic!("Expected at least one item");
+    };
+
+    assert!(items.next().is_none(), "Expected only one item");
+
+    let EnvelopeItem::ItemContainer(ItemContainer::Metrics(mut metrics)) = item else {
+        panic!("Envelope item has unexpected structure");
+    };
+
+    assert_eq!(metrics.len(), 1, "Expected exactly one metric");
+
+    let metric = metrics.pop().unwrap();
+    assert!(matches!(metric, Metric {
+        r#type: MetricType::Counter,
+        name,
+        value: 1.0,
+        ..
+    } if name == "test"));
+}
+
+/// Test that metrics are disabled (not sent) when disabled in the
+/// [`ClientOptions`].
+#[test]
+fn metrics_disabled_by_default() {
+    // Metrics are disabled by default.
+    let options: ClientOptions = Default::default();
+
+    let envelopes =
+        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
+    assert!(
+        envelopes.is_empty(),
+        "no envelopes should be captured when metrics disabled"
+    )
+}
+
+/// Test that no metrics are captured by a no-op call with
+/// metrics enabled
+#[test]
+fn noop_sends_nothing() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(|| (), options);
+
+    assert!(envelopes.is_empty(), "no-op should not capture metrics");
+}
+
+/// Test that 100 metrics are sent in a single envelope.
+#[test]
+fn test_metrics_batching_at_limit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            (0..100)
+                .map(|i| format!("metric.{i}"))
+                .for_each(|name| metrics::counter(name, 1).capture());
+        },
+        options,
+    );
+
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected exactly one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item");
+    let metrics = item
+        .into_metrics()
+        .expect("the envelope item is not a metrics item");
+
+    assert_eq!(metrics.len(), 100, "expected 100 metrics");
+
+    let metric_names: HashSet<_> = metrics
+        .into_iter()
+        .inspect(|metric| assert_eq!(metric.value, 1.0, "metric had unexpected value"))
+        .inspect(|metric| {
+            assert_eq!(
+                metric.r#type,
+                MetricType::Counter,
+                "metric had unexpected type"
+            )
+        })
+        .map(|metric| metric.name)
+        .collect();
+
+    (0..100)
+        .map(|i| format!("metric.{i}"))
+        .for_each(|metric_name| {
+            assert!(
+                metric_names.contains(metric_name.as_str()),
+                "expected metric {metric_name} was not captured"
+            )
+        });
+}
+
+/// Test that 101 envelopes are sent in two separate envelopes
+#[test]
+fn test_metrics_batching_over_limit() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let mut envelopes = test::with_captured_envelopes_options(
+        || {
+            (0..101)
+                .map(|i| format!("metric.{i}"))
+                .for_each(|name| metrics::counter(name, 1).capture());
+        },
+        options,
+    )
+    .into_iter();
+    let envelope1 = envelopes.next().expect("expected a first envelope");
+    let envelope2 = envelopes.next().expect("expected a second envelope");
+    assert!(envelopes.next().is_none(), "expected exactly two envelopes");
+
+    let item1 = envelope1
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item in the first envelope");
+    let metrics1 = item1
+        .into_metrics()
+        .expect("the first envelope item is not a metrics item");
+
+    assert_eq!(metrics1.len(), 100, "expected 100 metrics");
+
+    let first_metric_names: HashSet<_> = metrics1
+        .into_iter()
+        .inspect(|metric| assert_eq!(metric.value, 1.0, "metric had unexpected value"))
+        .inspect(|metric| {
+            assert_eq!(
+                metric.r#type,
+                MetricType::Counter,
+                "metric had unexpected type"
+            )
+        })
+        .map(|metric| metric.name)
+        .collect();
+
+    (0..100)
+        .map(|i| format!("metric.{i}"))
+        .for_each(|metric_name| {
+            assert!(
+                first_metric_names.contains(metric_name.as_str()),
+                "expected metric {metric_name} was not captured in the first envelope"
+            )
+        });
+
+    let item2 = envelope2
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item in the second envelope");
+    let metrics2 = item2
+        .into_metrics()
+        .expect("the second envelope item is not a metrics item");
+    let metric2 = metrics2
+        .try_into_only_item()
+        .expect("expected exactly one metric in the second envelope");
+
+    assert!(
+        matches!(metric2, Metric {
+            r#type: MetricType::Counter,
+            name,
+            value: 1.0,
+            ..
+        } if name == "metric.100"),
+        "unexpected metric captured"
+    )
+}
+
+#[test]
+fn metric_attributes_are_captured() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            metrics::counter("test", 1)
+                .attribute("http.route", "/health")
+                .attribute("http.response.status_code", 200)
+                .capture();
+        },
+        options,
+    );
+
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected exactly one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item");
+    let metric = item
+        .into_metrics()
+        .expect("expected metrics item")
+        .try_into_only_item()
+        .expect("expected exactly one metric in the envelope");
+
+    let Metric {
+        r#type,
+        name,
+        value,
+        timestamp: _,
+        trace_id: _,
+        span_id,
+        unit,
+        attributes,
+    } = metric;
+
+    assert_eq!(r#type, MetricType::Counter);
+    assert_eq!(name, "test");
+    assert_eq!(value, 1.0);
+    assert!(span_id.is_none());
+    assert!(unit.is_none());
+    assert_eq!(attributes.len(), 2, "expected two attributes");
+    assert_eq!(
+        attributes.get("http.route").map(|value| &value.0),
+        Some(&Value::from("/health")),
+    );
+    assert_eq!(
+        attributes
+            .get("http.response.status_code")
+            .map(|value| &value.0),
+        Some(&Value::from(200)),
+    );
+}
+
+#[test]
+fn metric_unit_is_captured() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || metrics::gauge("test", 42).unit(Unit::Millisecond).capture(),
+        options,
+    );
+
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected exactly one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected exactly one item");
+    let metric = item
+        .into_metrics()
+        .expect("expected metrics item")
+        .try_into_only_item()
+        .expect("expected exactly one metric in the envelope");
+
+    let Metric {
+        r#type,
+        name,
+        value,
+        timestamp: _,
+        trace_id: _,
+        span_id,
+        unit,
+        attributes,
+    } = metric;
+
+    assert_eq!(r#type, MetricType::Gauge);
+    assert_eq!(name, "test");
+    assert_eq!(value, 42.0);
+    assert!(span_id.is_none());
+    assert_eq!(unit, Some(Unit::Millisecond));
+    assert!(attributes.is_empty(), "expected no attributes");
+}
+
+/// Test that metrics in the same scope share the same trace_id when no span is active.
+///
+/// This tests that trace ID is set from the propagation context when there is no active span.
+#[test]
+fn metrics_share_trace_id_without_active_span() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            metrics::counter("test-2", 1).capture();
+            metrics::counter("test-2", 1).capture();
+        },
+        options,
+    );
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected one item");
+    let metrics = item.into_metrics().expect("expected metrics item");
+
+    let [metric1, metric2] = metrics.as_slice() else {
+        panic!("expected exactly two metrics");
+    };
+
+    assert_eq!(
+        metric1.trace_id, metric2.trace_id,
+        "metrics in the same scope should share the same trace_id"
+    );
+
+    assert!(metric1.span_id.is_none());
+    assert!(metric2.span_id.is_none());
+}
+
+/// Test that span_id is set from the active span when one is present.
+#[test]
+fn metrics_span_id_from_active_span() {
+    let options = ClientOptions {
+        enable_metrics: true,
+        ..Default::default()
+    };
+
+    let mut expected_span_id = None;
+    let envelopes = test::with_captured_envelopes_options(
+        || {
+            let transaction_ctx = TransactionContext::new("test transaction", "test");
+            expected_span_id = Some(transaction_ctx.span_id());
+            let transaction = sentry_core::start_transaction(transaction_ctx);
+            sentry_core::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
+            metrics::counter("test", 1).capture();
+            transaction.finish();
+        },
+        options,
+    );
+
+    let expected_span_id = expected_span_id.expect("expected_span_id did not get set");
+
+    let envelope = envelopes
+        .try_into_only_item()
+        .expect("expected one envelope");
+    let item = envelope
+        .into_items()
+        .try_into_only_item()
+        .expect("expected one item");
+    let mut metrics = item.into_metrics().expect("expected metrics item");
+    let metric = metrics.pop().expect("expected one metric");
+
+    assert_eq!(
+        metric.span_id,
+        Some(expected_span_id),
+        "span_id should be set from the active span"
+    );
+}
+
+/// Extension trait for iterators allowing conversion to only item.
+trait TryIntoOnlyElementExt<I> {
+    type Item;
+
+    /// Convert the iterator to the only item, erroring if the
+    /// iterator does not contain exactly one item.
+    fn try_into_only_item(self) -> Result<Self::Item>;
+}
+
+impl<I> TryIntoOnlyElementExt<I> for I
+where
+    I: IntoIterator,
+{
+    type Item = I::Item;
+
+    fn try_into_only_item(self) -> Result<Self::Item> {
+        let mut iter = self.into_iter();
+        let rv = iter.next().context("iterator was empty")?;
+
+        match iter.next() {
+            Some(_) => anyhow::bail!("iterator had more than one item"),
+            None => Ok(rv),
+        }
+    }
+}
+
+trait IntoMetricsExt {
+    /// Attempt to convert the provided value to a trace metric,
+    /// returning None if the conversion is not possible.
+    fn into_metrics(self) -> Option<Vec<Metric>>;
+}
+
+impl IntoMetricsExt for EnvelopeItem {
+    fn into_metrics(self) -> Option<Vec<Metric>> {
+        match self {
+            EnvelopeItem::ItemContainer(ItemContainer::Metrics(metrics)) => Some(metrics),
+            _ => None,
+        }
+    }
+}

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -2382,6 +2382,8 @@ pub enum MetricType {
 }
 
 /// A single [metric](https://develop.sentry.dev/sdk/telemetry/metrics/).
+///
+/// Construct this type directly with a struct literal.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Metric {
     /// The metric type.


### PR DESCRIPTION
Basic metrics capture functionality. Follow-up PR will implement the rest.

This PR implements public APIs for capturing metrics, plus batching when sending them. 

Stacked on #1022

Co-authored-by: Joris Bayer <joris.bayer@sentry.io>

Closes #1073
Closes [RUST-193](https://linear.app/getsentry/issue/RUST-193/add-public-metric-creation-functions)
Closes #1023
Closes [RUST-168](https://linear.app/getsentry/issue/RUST-168/implement-trace-metric-capture-and-batching-in-sentry-core)
Closes #1058
Closes [RUST-186](https://linear.app/getsentry/issue/RUST-186/add-trace-metric-tracing-association-in-sentry-core)