### PR TITLE
ref: narrow unused lint expectations in sentry-core hub

### DIFF
--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -8,6 +8,8 @@ use crate::protocol::{Event, Level};
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 
+/// Marks values as used in minimal builds where `with_client_impl!` turns many
+/// method bodies into no-ops and would otherwise leave their parameters unused.
 macro_rules! use_without_client {
     ($($value:expr),+ $(,)?) => {
         #[cfg(not(feature = "client"))]

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -1,10 +1,10 @@
-// NOTE: Most of the methods are noops without the `client` feature, and this will
-// silence all the "unused variable" warnings related to fn arguments.
-#![allow(unused)]
-
 use std::sync::{Arc, RwLock};
 
-use crate::protocol::{Event, Level, Log, LogAttribute, LogLevel, Map, SessionStatus};
+use crate::protocol::{Event, Level};
+#[cfg(feature = "logs")]
+use crate::protocol::Log;
+#[cfg(feature = "release-health")]
+use crate::protocol::SessionStatus;
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 
@@ -47,7 +47,13 @@ impl Hub {
     /// This is useful for integrations that want to do efficiently nothing if there is no
     /// client bound.  Additionally this internally ensures that the client can be safely
     /// synchronized.  This prevents accidental recursive calls into the client.
-    pub fn with_active<F, R>(f: F) -> R
+    pub fn with_active<F, R>(
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "this callback is unused without the `client` feature")
+        )]
+        f: F,
+    ) -> R
     where
         F: FnOnce(&Arc<Hub>) -> R,
         R: Default,
@@ -70,7 +76,14 @@ impl Hub {
     ///
     /// See the global [`capture_event`](fn.capture_event.html)
     /// for more documentation.
-    pub fn with_integration<I, F, R>(&self, f: F) -> R
+    pub fn with_integration<I, F, R>(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "this callback is unused without the `client` feature")
+        )]
+        f: F,
+    ) -> R
     where
         I: Integration,
         F: FnOnce(&I) -> R,
@@ -97,7 +110,14 @@ impl Hub {
     ///
     /// See the global [`capture_event`](fn.capture_event.html)
     /// for more documentation.
-    pub fn capture_event(&self, event: Event<'static>) -> Uuid {
+    pub fn capture_event(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "the event is unused without the `client` feature")
+        )]
+        event: Event<'static>,
+    ) -> Uuid {
         with_client_impl! {{
             let top = self.inner.with(|stack| stack.top().clone());
             let Some(ref client) = top.client else { return Default::default() };
@@ -111,7 +131,19 @@ impl Hub {
     ///
     /// See the global [`capture_message`](fn.capture_message.html)
     /// for more documentation.
-    pub fn capture_message(&self, msg: &str, level: Level) -> Uuid {
+    pub fn capture_message(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "the message is unused without the `client` feature")
+        )]
+        msg: &str,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "the level is unused without the `client` feature")
+        )]
+        level: Level,
+    ) -> Uuid {
         with_client_impl! {{
             let event = Event {
                 message: Some(msg.to_string()),
@@ -134,7 +166,7 @@ impl Hub {
                 if let Some(session) = crate::session::Session::from_stack(top) {
                     // When creating a *new* session, we make sure it is unique,
                     // as to no inherit *backwards* to any parents.
-                    let mut scope = Arc::make_mut(&mut top.scope);
+                    let scope = Arc::make_mut(&mut top.scope);
                     scope.session = Arc::new(std::sync::Mutex::new(Some(session)));
                 }
             })
@@ -154,7 +186,14 @@ impl Hub {
     /// See the global [`end_session_with_status`](crate::end_session_with_status)
     /// for more documentation.
     #[cfg(feature = "release-health")]
-    pub fn end_session_with_status(&self, status: SessionStatus) {
+    pub fn end_session_with_status(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "the status is unused without the `client` feature")
+        )]
+        status: SessionStatus,
+    ) {
         with_client_impl! {{
             self.inner.with_mut(|stack| {
                 let top = stack.top_mut();
@@ -182,7 +221,18 @@ impl Hub {
     ///
     /// See the global [`with_scope`](fn.with_scope.html)
     /// for more documentation.
-    pub fn with_scope<C, F, R>(&self, scope_config: C, callback: F) -> R
+    pub fn with_scope<C, F, R>(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(
+                unused,
+                reason = "the scope config callback is unused without the `client` feature"
+            )
+        )]
+        scope_config: C,
+        callback: F,
+    ) -> R
     where
         C: FnOnce(&mut Scope),
         F: FnOnce() -> R,
@@ -195,7 +245,6 @@ impl Hub {
         }
         #[cfg(not(feature = "client"))]
         {
-            let _scope_config = scope_config;
             callback()
         }
     }
@@ -204,7 +253,14 @@ impl Hub {
     ///
     /// See the global [`configure_scope`](fn.configure_scope.html)
     /// for more documentation.
-    pub fn configure_scope<F, R>(&self, f: F) -> R
+    pub fn configure_scope<F, R>(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "this callback is unused without the `client` feature")
+        )]
+        f: F,
+    ) -> R
     where
         R: Default,
         F: FnOnce(&mut Scope) -> R,
@@ -221,7 +277,14 @@ impl Hub {
     ///
     /// See the global [`add_breadcrumb`](fn.add_breadcrumb.html)
     /// for more documentation.
-    pub fn add_breadcrumb<B: IntoBreadcrumbs>(&self, breadcrumb: B) {
+    pub fn add_breadcrumb<B: IntoBreadcrumbs>(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "the breadcrumb is unused without the `client` feature")
+        )]
+        breadcrumb: B,
+    ) {
         with_client_impl! {{
             self.inner.with_mut(|stack| {
                 let top = stack.top_mut();
@@ -248,7 +311,14 @@ impl Hub {
 
     /// Captures a structured log.
     #[cfg(feature = "logs")]
-    pub fn capture_log(&self, log: Log) {
+    pub fn capture_log(
+        &self,
+        #[cfg_attr(
+            not(feature = "client"),
+            expect(unused, reason = "the log is unused without the `client` feature")
+        )]
+        log: Log,
+    ) {
         with_client_impl! {{
             let top = self.inner.with(|stack| stack.top().clone());
             let Some(ref client) = top.client else { return };

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -8,6 +8,13 @@ use crate::protocol::{Event, Level};
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 
+macro_rules! use_without_client {
+    ($($value:expr),+ $(,)?) => {
+        #[cfg(not(feature = "client"))]
+        let _ = ($( &$value ),+,);
+    };
+}
+
 /// The central object that can manage scopes and clients.
 ///
 /// This can be used to capture events and manage the scope.  This object is [`Send`] and
@@ -47,20 +54,12 @@ impl Hub {
     /// This is useful for integrations that want to do efficiently nothing if there is no
     /// client bound.  Additionally this internally ensures that the client can be safely
     /// synchronized.  This prevents accidental recursive calls into the client.
-    pub fn with_active<F, R>(
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(
-                unused,
-                reason = "this callback is unused without the `client` feature"
-            )
-        )]
-        f: F,
-    ) -> R
+    pub fn with_active<F, R>(f: F) -> R
     where
         F: FnOnce(&Arc<Hub>) -> R,
         R: Default,
     {
+        use_without_client!(f);
         with_client_impl! {{
             Hub::with(|hub| {
                 if hub.is_active_and_usage_safe() {
@@ -79,22 +78,13 @@ impl Hub {
     ///
     /// See the global [`capture_event`](fn.capture_event.html)
     /// for more documentation.
-    pub fn with_integration<I, F, R>(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(
-                unused,
-                reason = "this callback is unused without the `client` feature"
-            )
-        )]
-        f: F,
-    ) -> R
+    pub fn with_integration<I, F, R>(&self, f: F) -> R
     where
         I: Integration,
         F: FnOnce(&I) -> R,
         R: Default,
     {
+        use_without_client!(f);
         with_client_impl! {{
             if let Some(client) = self.client() {
                 if let Some(integration) = client.get_integration::<I>() {
@@ -116,14 +106,8 @@ impl Hub {
     ///
     /// See the global [`capture_event`](fn.capture_event.html)
     /// for more documentation.
-    pub fn capture_event(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(unused, reason = "the event is unused without the `client` feature")
-        )]
-        event: Event<'static>,
-    ) -> Uuid {
+    pub fn capture_event(&self, event: Event<'static>) -> Uuid {
+        use_without_client!(event);
         with_client_impl! {{
             let top = self.inner.with(|stack| stack.top().clone());
             let Some(ref client) = top.client else { return Default::default() };
@@ -137,19 +121,8 @@ impl Hub {
     ///
     /// See the global [`capture_message`](fn.capture_message.html)
     /// for more documentation.
-    pub fn capture_message(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(unused, reason = "the message is unused without the `client` feature")
-        )]
-        msg: &str,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(unused, reason = "the level is unused without the `client` feature")
-        )]
-        level: Level,
-    ) -> Uuid {
+    pub fn capture_message(&self, msg: &str, level: Level) -> Uuid {
+        use_without_client!(msg, level);
         with_client_impl! {{
             let event = Event {
                 message: Some(msg.to_string()),
@@ -192,14 +165,8 @@ impl Hub {
     /// See the global [`end_session_with_status`](crate::end_session_with_status)
     /// for more documentation.
     #[cfg(feature = "release-health")]
-    pub fn end_session_with_status(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(unused, reason = "the status is unused without the `client` feature")
-        )]
-        status: SessionStatus,
-    ) {
+    pub fn end_session_with_status(&self, status: SessionStatus) {
+        use_without_client!(status);
         with_client_impl! {{
             self.inner.with_mut(|stack| {
                 let top = stack.top_mut();
@@ -227,22 +194,12 @@ impl Hub {
     ///
     /// See the global [`with_scope`](fn.with_scope.html)
     /// for more documentation.
-    pub fn with_scope<C, F, R>(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(
-                unused,
-                reason = "the scope config callback is unused without the `client` feature"
-            )
-        )]
-        scope_config: C,
-        callback: F,
-    ) -> R
+    pub fn with_scope<C, F, R>(&self, scope_config: C, callback: F) -> R
     where
         C: FnOnce(&mut Scope),
         F: FnOnce() -> R,
     {
+        use_without_client!(scope_config);
         #[cfg(feature = "client")]
         {
             let _guard = self.push_scope();
@@ -259,21 +216,12 @@ impl Hub {
     ///
     /// See the global [`configure_scope`](fn.configure_scope.html)
     /// for more documentation.
-    pub fn configure_scope<F, R>(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(
-                unused,
-                reason = "this callback is unused without the `client` feature"
-            )
-        )]
-        f: F,
-    ) -> R
+    pub fn configure_scope<F, R>(&self, f: F) -> R
     where
         R: Default,
         F: FnOnce(&mut Scope) -> R,
     {
+        use_without_client!(f);
         with_client_impl! {{
             let mut new_scope = self.with_current_scope(|scope| scope.clone());
             let rv = f(&mut new_scope);
@@ -286,17 +234,8 @@ impl Hub {
     ///
     /// See the global [`add_breadcrumb`](fn.add_breadcrumb.html)
     /// for more documentation.
-    pub fn add_breadcrumb<B: IntoBreadcrumbs>(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(
-                unused,
-                reason = "the breadcrumb is unused without the `client` feature"
-            )
-        )]
-        breadcrumb: B,
-    ) {
+    pub fn add_breadcrumb<B: IntoBreadcrumbs>(&self, breadcrumb: B) {
+        use_without_client!(breadcrumb);
         with_client_impl! {{
             self.inner.with_mut(|stack| {
                 let top = stack.top_mut();
@@ -323,14 +262,8 @@ impl Hub {
 
     /// Captures a structured log.
     #[cfg(feature = "logs")]
-    pub fn capture_log(
-        &self,
-        #[cfg_attr(
-            not(feature = "client"),
-            expect(unused, reason = "the log is unused without the `client` feature")
-        )]
-        log: Log,
-    ) {
+    pub fn capture_log(&self, log: Log) {
+        use_without_client!(log);
         with_client_impl! {{
             let top = self.inner.with(|stack| stack.top().clone());
             let Some(ref client) = top.client else { return };

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -1,10 +1,10 @@
 use std::sync::{Arc, RwLock};
 
-use crate::protocol::{Event, Level};
 #[cfg(feature = "logs")]
 use crate::protocol::Log;
 #[cfg(feature = "release-health")]
 use crate::protocol::SessionStatus;
+use crate::protocol::{Event, Level};
 use crate::types::Uuid;
 use crate::{Integration, IntoBreadcrumbs, Scope, ScopeGuard};
 
@@ -50,7 +50,10 @@ impl Hub {
     pub fn with_active<F, R>(
         #[cfg_attr(
             not(feature = "client"),
-            expect(unused, reason = "this callback is unused without the `client` feature")
+            expect(
+                unused,
+                reason = "this callback is unused without the `client` feature"
+            )
         )]
         f: F,
     ) -> R
@@ -80,7 +83,10 @@ impl Hub {
         &self,
         #[cfg_attr(
             not(feature = "client"),
-            expect(unused, reason = "this callback is unused without the `client` feature")
+            expect(
+                unused,
+                reason = "this callback is unused without the `client` feature"
+            )
         )]
         f: F,
     ) -> R
@@ -257,7 +263,10 @@ impl Hub {
         &self,
         #[cfg_attr(
             not(feature = "client"),
-            expect(unused, reason = "this callback is unused without the `client` feature")
+            expect(
+                unused,
+                reason = "this callback is unused without the `client` feature"
+            )
         )]
         f: F,
     ) -> R
@@ -281,7 +290,10 @@ impl Hub {
         &self,
         #[cfg_attr(
             not(feature = "client"),
-            expect(unused, reason = "the breadcrumb is unused without the `client` feature")
+            expect(
+                unused,
+                reason = "the breadcrumb is unused without the `client` feature"
+            )
         )]
         breadcrumb: B,
     ) {


### PR DESCRIPTION
Remove the blanket `#![allow(unused)]` in `sentry-core/src/hub.rs`. This will allow the linter to find problems like the following (from #1073) and many more, rather than needing to rely on the clanker for such things.

<img width="805" height="575" alt="image" src="https://github.com/user-attachments/assets/19c8d4e7-94a9-416a-842e-55bec93377d7" />

Instead, we now have a macro that adds a `let _ = ...arguments...` when the `client` feature is enabled. This solves the stated purpose of having the `allow(unused)` in the first place, but where more narrowly.

The clanker also cleaned up some truly unused things that were suppressed before.

<details>

<summary>🤖What the clanker wrote</summary>

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Removes the blanket `#![allow(unused)]` from `sentry-core/src/hub.rs`.

Instead of repeating a long `#[cfg_attr(not(feature = "client"), expect(unused, ...))]` annotation across many parameters, this change uses a small documented local `use_without_client!` helper macro that only touches those values in `not(feature = "client")` builds. That keeps the handling narrow to the specific methods and arguments that need it, while avoiding duplicated attributes in the signatures.

Also cleans up truly unused imports, removes an unnecessary `mut` in the release-health session setup path, and keeps the file rustfmt-clean for CI.

Validated with:
- `cargo +1.88.0 fmt --all --check`
- `cargo +1.88.0 clippy -p sentry-core --no-default-features -- -D warnings`
- `cargo +1.88.0 clippy -p sentry-core --no-default-features --features client -- -D warnings`
- `cargo +1.88.0 clippy -p sentry-core --all-features -- -D warnings`
- `cargo +1.88.0 clippy -p sentry-core --no-default-features --features release-health -- -D warnings`
- `cargo +1.88.0 clippy -p sentry-core --no-default-features --features logs -- -D warnings`

Note: a full local workspace `cargo clippy --all-features --workspace --tests --examples --locked` is blocked in this environment by missing system OpenSSL development libraries, which is unrelated to this `hub.rs` change.

#### Issues
- N/A

#### Reminders
- GH Issue ID / Linear ID: N/A
- CHANGELOG.md: not updated (internal lint cleanup)
- PR title uses conventional commit style
- Useful links for external contributors: [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/sentry)
<!-- CURSOR_AGENT_PR_BODY_END -->

</details>

<div><a href="https://cursor.com/agents/bc-0342af16-4799-43c3-8028-50dc657541e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0342af16-4799-43c3-8028-50dc657541e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

