### PR TITLE
feat(sentry): Expose `metrics` feature in `sentry` crate

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -49,6 +49,7 @@ opentelemetry = ["sentry-opentelemetry"]
 test = ["sentry-core/test"]
 release-health = ["sentry-core/release-health", "sentry-actix?/release-health"]
 logs = ["sentry-core/logs", "sentry-tracing?/logs", "sentry-log?/logs"]
+metrics = ["sentry-core/metrics"]
 # transports
 transport = ["reqwest", "native-tls"]
 reqwest = ["dep:reqwest", "httpdate", "tokio"]


### PR DESCRIPTION
Closes #1077 
Closes [RUST-195](https://linear.app/getsentry/issue/RUST-195/expose-the-metrics-feature-in-sentry)