### PR TITLE
fix!(sentry-core): Ungate `ClientOptions` fields behind feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- [`sentry_core::ClientOptions`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html) fields [`before_send_log`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.before_send_log), [`enable_logs`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.enable_logs), [`auto_session_tracking`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.auto_session_tracking), and [`session_mode`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.session_mode) are no longer gated behind the `logs` and `release-health` feature flags ([#1091](https://github.com/getsentry/sentry-rust/pull/1091)). Code that constructs `ClientOptions` with a full struct literal (without `..Default::default()`), or which exhaustively matches against it, must now include all four fields regardless of enabled features.
+
 ## 0.47.0
 
 ### Breaking Changes

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -5,9 +5,7 @@ use std::time::Duration;
 
 use crate::constants::USER_AGENT;
 use crate::performance::TracesSampler;
-#[cfg(feature = "logs")]
-use crate::protocol::Log;
-use crate::protocol::{Breadcrumb, Event};
+use crate::protocol::{Breadcrumb, Event, Log};
 use crate::types::Dsn;
 use crate::{Integration, IntoDsn, TransportFactory};
 
@@ -146,7 +144,9 @@ pub struct ClientOptions {
     /// Callback that is executed for each Breadcrumb being added.
     pub before_breadcrumb: Option<BeforeCallback<Breadcrumb>>,
     /// Callback that is executed for each Log being added.
-    #[cfg(feature = "logs")]
+    ///
+    /// This callback has no effect unless the `logs` feature is enabled at compile-time, as the
+    /// feature is a pre-requisite to capturing logs.
     pub before_send_log: Option<BeforeCallback<Log>>,
     // Transport options
     /// The transport to use.
@@ -170,7 +170,9 @@ pub struct ClientOptions {
     /// server integrations. Needs `send_default_pii` to be enabled to have any effect.
     pub max_request_body_size: MaxRequestBodySize,
     /// Determines whether captured structured logs should be sent to Sentry (defaults to false).
-    #[cfg(feature = "logs")]
+    ///
+    /// This setting has no effect unless the `logs` feature is enabled at compile-time, as the
+    /// feature is a pre-requisite to sending logs.
     pub enable_logs: bool,
     // Other options not documented in Unified API
     /// Disable SSL verification.
@@ -184,10 +186,14 @@ pub struct ClientOptions {
     /// When automatic session tracking is enabled, a new "user-mode" session
     /// is started at the time of `sentry::init`, and will persist for the
     /// application lifetime.
-    #[cfg(feature = "release-health")]
+    ///
+    /// This setting has no effect unless the `release-health` feature is enabled at compile-time,
+    /// as the feature is a pre-requisite to tracking sessions.
     pub auto_session_tracking: bool,
     /// Determine how Sessions are being tracked.
-    #[cfg(feature = "release-health")]
+    ///
+    /// This setting has no effect unless the `release-health` feature is enabled at compile-time,
+    /// as the feature is a pre-requisite to tracking sessions.
     pub session_mode: SessionMode,
     /// The user agent that should be reported.
     pub user_agent: Cow<'static, str>,
@@ -226,7 +232,6 @@ impl fmt::Debug for ClientOptions {
         #[derive(Debug)]
         struct BeforeBreadcrumb;
         let before_breadcrumb = self.before_breadcrumb.as_ref().map(|_| BeforeBreadcrumb);
-        #[cfg(feature = "logs")]
         let before_send_log = {
             #[derive(Debug)]
             struct BeforeSendLog;
@@ -266,19 +271,13 @@ impl fmt::Debug for ClientOptions {
             .field("http_proxy", &self.http_proxy)
             .field("https_proxy", &self.https_proxy)
             .field("shutdown_timeout", &self.shutdown_timeout)
-            .field("accept_invalid_certs", &self.accept_invalid_certs);
-
-        #[cfg(feature = "release-health")]
-        debug_struct
+            .field("accept_invalid_certs", &self.accept_invalid_certs)
             .field("auto_session_tracking", &self.auto_session_tracking)
-            .field("session_mode", &self.session_mode);
-
-        #[cfg(feature = "logs")]
-        debug_struct
+            .field("session_mode", &self.session_mode)
             .field("enable_logs", &self.enable_logs)
-            .field("before_send_log", &before_send_log);
-
-        debug_struct.field("user_agent", &self.user_agent).finish()
+            .field("before_send_log", &before_send_log)
+            .field("user_agent", &self.user_agent)
+            .finish()
     }
 }
 
@@ -307,15 +306,11 @@ impl Default for ClientOptions {
             https_proxy: None,
             shutdown_timeout: Duration::from_secs(2),
             accept_invalid_certs: false,
-            #[cfg(feature = "release-health")]
             auto_session_tracking: false,
-            #[cfg(feature = "release-health")]
             session_mode: SessionMode::Application,
             user_agent: Cow::Borrowed(USER_AGENT),
             max_request_body_size: MaxRequestBodySize::Medium,
-            #[cfg(feature = "logs")]
             enable_logs: true,
-            #[cfg(feature = "logs")]
             before_send_log: None,
         }
     }


### PR DESCRIPTION
`ClientOptions` is a non-`#[non_exhaustive]` public struct. Four of its fields were gated behind `#[cfg(feature = "logs")]` and `#[cfg(feature = "release-health")]`, which violated Cargo's feature additivity requirement: enabling either feature could break downstream code that constructs `ClientOptions` with a full struct literal.

Remove the `cfg` gates so all four fields (`before_send_log`, `enable_logs`, `auto_session_tracking`, `session_mode`) are always present. The fields have no effect when their respective features are disabled.

BREAKING CHANGE: Code that constructs `ClientOptions` with a full struct literal (without `..Default::default()`), or exhaustively matches against it, must now include all four fields regardless of which features are enabled.

Closes #1087
Closes [RUST-200](https://linear.app/getsentry/issue/RUST-200/sentry-core-ungate-clientoptions-fields-added-by-logs-and-release)
