### PR TITLE
fix!(sentry-core): Make no-op `Scope` non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 - [`sentry_core::ClientOptions`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html) fields [`before_send_log`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.before_send_log), [`enable_logs`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.enable_logs), [`auto_session_tracking`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.auto_session_tracking), and [`session_mode`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.session_mode) are no longer gated behind the `logs` and `release-health` feature flags ([#1091](https://github.com/getsentry/sentry-rust/pull/1091)). Code that constructs `ClientOptions` with a full struct literal (without `..Default::default()`), or which exhaustively matches against it, must now include all four fields regardless of enabled features.
+- [`sentry_core::Scope`](https://docs.rs/sentry-core/latest/sentry_core/struct.Scope.html) can no longer be publicly constructed or exhaustively matched against, even when the `client` feature is disabled ([#1094](https://github.com/getsentry/sentry-rust/pull/1094)). Previously, both of these were possible when `client` was disabled.
 
 ## 0.47.0
 

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -22,6 +22,7 @@ impl fmt::Debug for ScopeGuard {
 /// In minimal API mode all modification functions are available as normally
 /// just that generally calling them is impossible.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Scope;
 
 impl Scope {


### PR DESCRIPTION
BREAKING CHANGE: `sentry_core::Scope` is no longer constructible or exhaustively matchable, even when the `client` feature is disabled.

Fixes #1092
Fixes [RUST-204](https://linear.app/getsentry/issue/RUST-204/make-scope-non-exhaustive-in-non-client)
