### PR TITLE
ref(sentry-core): Privatize `EventProcessor` type alias

### DIFF
--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -21,7 +21,7 @@ pub struct Stack {
     layers: Vec<StackLayer>,
 }
 
-pub type EventProcessor = Arc<dyn Fn(Event<'static>) -> Option<Event<'static>> + Send + Sync>;
+type EventProcessor = Arc<dyn Fn(Event<'static>) -> Option<Event<'static>> + Send + Sync>;
 
 /// Holds contextual data for the current scope.
 ///


### PR DESCRIPTION
This type is not actually publicly exposed, nor is it used outside the `scope::real` module, so it is safe to make it module-private.
