### PR TITLE
fix!(sentry-tracing): Make `EventMapping` non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [`sentry_core::ClientOptions`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html) fields [`before_send_log`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.before_send_log), [`enable_logs`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.enable_logs), [`auto_session_tracking`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.auto_session_tracking), and [`session_mode`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#structfield.session_mode) are no longer gated behind the `logs` and `release-health` feature flags ([#1091](https://github.com/getsentry/sentry-rust/pull/1091)). Code that constructs `ClientOptions` with a full struct literal (without `..Default::default()`), or which exhaustively matches against it, must now include all four fields regardless of enabled features.
 - [`sentry_core::Scope`](https://docs.rs/sentry-core/latest/sentry_core/struct.Scope.html) can no longer be publicly constructed or exhaustively matched against, even when the `client` feature is disabled ([#1094](https://github.com/getsentry/sentry-rust/pull/1094)). Previously, both of these were possible when `client` was disabled.
+- [`sentry_tracing::EventMapping](https://docs.rs/sentry-tracing/latest/sentry_tracing/enum.EventMapping.html) is now ``#[non_exhaustive]`` ([#1097](https://github.com/getsentry/sentry-rust/pull/1097)).
 
 ## 0.47.0
 

--- a/sentry-tracing/src/layer/mod.rs
+++ b/sentry-tracing/src/layer/mod.rs
@@ -37,6 +37,7 @@ bitflags! {
 
 /// The type of data Sentry should ingest for an [`Event`].
 #[derive(Debug)]
+#[non_exhaustive]
 #[allow(clippy::large_enum_variant)]
 pub enum EventMapping {
     /// Ignore the [`Event`]


### PR DESCRIPTION
Make `EventMapping` non-exhaustive. This prevents the log feature from introducing a breaking change by adding a variant to the enum, while also allowing us to add variants in the future without breaking the public API.

Closes #1090
Closes [RUST-203](https://linear.app/getsentry/issue/RUST-203/sentry-tracing-add-non-exhaustive-to-eventmapping)
