### PR TITLE
feat: introduce `rustls-no-provider` feature flag

### DIFF
--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -58,6 +58,7 @@ ureq = ["dep:ureq", "httpdate"]
 # transport settings
 native-tls = ["dep:native-tls", "reqwest?/native-tls", "ureq?/native-tls"]
 rustls = ["dep:rustls", "reqwest?/rustls", "ureq?/rustls"]
+rustls-no-provider = ["dep:rustls", "reqwest?/rustls-no-provider", "ureq?/rustls"]
 embedded-svc-http = ["dep:embedded-svc", "dep:esp-idf-svc"]
 
 [dependencies]

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -1,7 +1,11 @@
 use std::time::Duration;
 
 use ureq::http::Response;
-#[cfg(any(feature = "rustls", feature = "native-tls"))]
+#[cfg(any(
+    feature = "rustls",
+    feature = "rustls-no-provider",
+    feature = "native-tls"
+))]
 use ureq::tls::{TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
 
@@ -43,7 +47,7 @@ impl UreqHttpTransport {
                         .build(),
                 );
             }
-            #[cfg(feature = "rustls")]
+            #[cfg(any(feature = "rustls", feature = "rustls-no-provider"))]
             {
                 builder = builder.tls_config(
                     TlsConfig::builder()


### PR DESCRIPTION
### Description

Activating the `rustls` feature of `reqwest` pulls in `aws-lc-rs` by default as the crypto provider. To allow people to make their own decision about which crypto provider to use with `rustls`, we should depend on the `rustls-no-provider` feature flag instead.

We add our own `rustls-no-provider` feature flag which allows users to opt out of `aws-lc-rs` being the default crypto provider of `reqwest` in a backwards-compatible way.

#### Issues
Resolves: #1102

#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- Add an entry to CHANGELOG.md, following the format of existing entries
- The PR title should use [Conventional Commits](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`, etc.)
- Useful links for external contributors: [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/sentry)
