### PR TITLE
chore(ci): Update validate-pr to advisory mode

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -2,7 +2,7 @@ name: Validate PR
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened]
 
 jobs:
   validate-pr:
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: getsentry/github-workflows/validate-pr@71588ddf95134f804e82c5970a8098588e2eaecd
+      - uses: getsentry/github-workflows/validate-pr@43bf14b190c12080cfbedf2d2c82337bc559a0e1
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps the pinned SHA of `getsentry/github-workflows/validate-pr` to the new advisory-mode revision (`43bf14b`).

- The action no longer closes non-compliant community PRs or applies labels — it now posts a single friendly comment instead.
- Small PRs (<100 lines changed, excluding lock files) are skipped entirely.
- Also drops the `reopened` trigger; it was only useful when the workflow closed PRs.