### PR TITLE
chore(meta): Centralize workspace lint config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
 edition = "2021"
 rust-version = "1.88"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for actix-web 4.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [features]
 default = ["release-health"]
 release-health = ["sentry-core/release-health"]

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for anyhow.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [features]
 default = ["backtrace"]
 backtrace = []

--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration and utilities for dealing with stacktraces.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 backtrace = "0.3.44"
 regex = { version = "1.5.5", default-features = false, features = [

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -13,6 +13,9 @@ build = "build.rs"
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 sentry-core = { version = "0.48.1", path = "../sentry-core" }
 libc = "0.2.66"

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -12,6 +12,9 @@ Core Sentry library used for instrumentation and integration development.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration that adds the list of loaded libraries to events.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 findshlibs = "=0.10.2"
 sentry-core = { version = "0.48.1", path = "../sentry-core" }

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for the log and env_logger crates.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [features]
 default = []
 logs = ["sentry-core/logs"]

--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for OpenTelemetry.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for capturing panics.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 sentry-core = { version = "0.48.1", path = "../sentry-core", features = ["client"] }
 sentry-backtrace = { version = "0.48.1", path = "../sentry-backtrace" }

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for the slog crate.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 sentry-core = { version = "0.48.1", path = "../sentry-core" }
 slog = { version = "2.5.2", features = ["nested-values"] }

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for tower-based crates.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -12,6 +12,9 @@ Sentry integration for the tracing and tracing-subscriber crates.
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["sentry", "protocol"]
 edition = { workspace = true }
 rust-version = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -107,8 +107,8 @@ tower = { version = "0.5.2", features = ["util"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt", "tracing-log"] }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true
 
 [build-dependencies]
 cfg_aliases = "0.2.1"


### PR DESCRIPTION
Centralize the lint config for all crates in the workspace `Cargo.toml`. Moved the only custom lint config (currently in the Sentry crate) to the workspace, so it now applies to all crates.

Done in prep for #1113 ([RUST-211](https://linear.app/getsentry/issue/RUST-211/enforce-checked-arithmetic-in-the-sdk)).
