### PR TITLE
fix: Enable `clippy::arithmetic_side_effects` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,8 @@ homepage = "https://sentry.io/welcome/"
 edition = "2021"
 rust-version = "1.88"
 
+[workspace.lints.clippy]
+arithmetic-side-effects.level = "warn"
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/sentry-contexts/src/utils.rs
+++ b/sentry-contexts/src/utils.rs
@@ -54,7 +54,7 @@ mod model_support {
 
     pub fn get_macos_version() -> Option<String> {
         let version = sysctlbyname_call("kern.osproductversion")?;
-        let dot_count = version.split('.').count() - 1;
+        let dot_count = version.split('.').count().saturating_sub(1);
         if dot_count < 2 {
             return Some(version + ".0");
         }

--- a/sentry-core/src/logger.rs
+++ b/sentry-core/src/logger.rs
@@ -25,13 +25,13 @@ macro_rules! logger_log {
             "sentry.message.template".to_owned(),
             $crate::protocol::LogAttribute($crate::protocol::Value::from($fmt))
         );
-        let mut i = 0;
+        let mut i = 0usize;
         $(
             attributes.insert(
                 format!("sentry.message.parameter.{}", i),
                 $crate::protocol::LogAttribute($crate::protocol::Value::from($arg))
             );
-            i += 1;
+            i = i.checked_add(1).expect("number of parametrs should not overflow usize");
         )*
         let _ = i; // avoid triggering the `unused_assignments` lint
 

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -2,6 +2,8 @@
 //!
 //! <https://develop.sentry.dev/sdk/sessions/>
 
+#![expect(clippy::arithmetic_side_effects)] // https://github.com/getsentry/sentry-rust/issues/1117
+
 #[cfg(feature = "release-health")]
 pub use session_impl::*;
 

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::arithmetic_side_effects)] // https://github.com/getsentry/sentry-rust/issues/1118
+
 use std::{borrow::Cow, io::Write, path::Path, time::SystemTime};
 
 use serde::{Deserialize, Serialize};

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::arithmetic_side_effects)] // https://github.com/getsentry/sentry-rust/issues/1115
+
 use httpdate::parse_http_date;
 use std::time::{Duration, SystemTime};
 


### PR DESCRIPTION
[This lint](https://rust-lang.github.io/rust-clippy/master/index.html?search=clippy%3A%3Aarithmetic_side_effects#arithmetic_side_effects) warns against using normal math operations, like `+`, `-`, etc. In Rust, these operators panic on overflow in debug builds and overflow in release builds. Enabling this lint forces us to handle potential overflow explicitly.

This change enables the lint and fixes the easy violations. Three follow up PRs will address the more complex cases.

Ref #1113
Ref [RUST-211](https://linear.app/getsentry/issue/RUST-211/enforce-checked-arithmetic-in-the-sdk)
