### PR TITLE
Allow overriding the sampling rate for high priority events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 04.8.3
+
+- Added `override_sampling_rate` to `ClientOptions` to allow user defined function to override sampling rate when capturing an event. ([#1128](https://github.com/getsentry/sentry-rust/pull/1128)).
+
 ## 0.48.2
 
 ### New Features

--- a/sentry-core/src/client.rs
+++ b/sentry-core/src/client.rs
@@ -373,11 +373,15 @@ impl Client {
             scope.update_session_from_event(&event);
         }
 
-        if !self.sample_should_send(self.options.sample_rate) {
-            None
-        } else {
-            Some(event)
-        }
+        // Check if we have an override sampling rate function.
+        let sampling_rate = self
+            .options()
+            .override_sampling_rate
+            .as_ref()
+            .and_then(|f| f(&event))
+            .unwrap_or_else(|| self.options().sample_rate);
+
+        (self.sample_should_send(sampling_rate)).then_some(event)
     }
 
     /// Returns the options of this client.

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -12,6 +12,9 @@ use crate::{Integration, IntoDsn, TransportFactory};
 /// Type alias for before event/breadcrumb handlers.
 pub type BeforeCallback<T> = Arc<dyn Fn(T) -> Option<T> + Send + Sync>;
 
+/// Type alias for override sample rate callback.
+pub type OverrideSamplingRateCallback = Arc<dyn Fn(&Event<'static>) -> Option<f32> + Send + Sync>;
+
 /// The Session Mode of the SDK.
 ///
 /// Depending on the use-case, the SDK can be set to two different session modes:
@@ -143,6 +146,8 @@ pub struct ClientOptions {
     pub before_send: Option<BeforeCallback<Event<'static>>>,
     /// Callback that is executed for each Breadcrumb being added.
     pub before_breadcrumb: Option<BeforeCallback<Breadcrumb>>,
+    /// Callback allowing for setting sampling rate based on user defined function.
+    pub override_sampling_rate: Option<OverrideSamplingRateCallback>,
     /// Callback that is executed for each Log being added.
     ///
     /// This callback has no effect unless the `logs` feature is enabled at compile-time, as the
@@ -350,6 +355,7 @@ impl Default for ClientOptions {
             before_send_log: None,
             enable_metrics: true,
             before_send_metric: None,
+            override_sampling_rate: None,
         }
     }
 }


### PR DESCRIPTION
### Description
<!-- What changed and why? -->
Add ability for users to define a function that checks if an event should ignore the sampling rate when sending.

#### Issues
<!--
* resolves: #1127 
-->

#### Reminders
- Add GH Issue ID _&_ Linear ID (if applicable)
- Add an entry to CHANGELOG.md, following the format of existing entries
- The PR title should use [Conventional Commits](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`, etc.)
- Useful links for external contributors: [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/sentry)
