### PR TITLE
ref(client): Move `batcher` under `client` module

### DIFF
--- a/sentry-core/src/client/batcher.rs
+++ b/sentry-core/src/client/batcher.rs
@@ -1,10 +1,12 @@
+#![cfg(any(feature = "logs", feature = "metrics"))]
+
 //! Generic batching for Sentry envelope items.
 
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use crate::client::EnvelopeSender;
+use super::EnvelopeSender;
 use crate::protocol::EnvelopeItem;
 use crate::Envelope;
 use sentry_types::protocol::v7::Log;
@@ -21,7 +23,7 @@ struct BatchQueue<T> {
     items: Vec<T>,
 }
 
-pub(crate) trait IntoBatchEnvelopeItem: Sized {
+pub(super) trait IntoBatchEnvelopeItem: Sized {
     fn into_envelope_item(items: Vec<Self>) -> EnvelopeItem;
 }
 
@@ -34,7 +36,7 @@ where
     }
 }
 
-pub(crate) trait Batch: IntoBatchEnvelopeItem {
+pub(super) trait Batch: IntoBatchEnvelopeItem {
     const TYPE_NAME: &str;
 }
 
@@ -49,7 +51,7 @@ impl Batch for Metric {
 
 /// Accumulates items in the queue and submits them through the transport when one of the flushing
 /// conditions is met.
-pub(crate) struct Batcher<T: Batch> {
+pub(super) struct Batcher<T: Batch> {
     envelope_sender: EnvelopeSender,
     queue: Arc<Mutex<BatchQueue<T>>>,
     shutdown: Arc<(Mutex<bool>, Condvar)>,
@@ -61,7 +63,7 @@ where
     T: Batch + Send + 'static,
 {
     /// Creates a new Batcher that will submit envelopes to the transport.
-    pub(crate) fn new(envelope_sender: EnvelopeSender) -> Self {
+    pub(super) fn new(envelope_sender: EnvelopeSender) -> Self {
         let queue = Arc::new(Mutex::new(BatchQueue { items: Vec::new() }));
         #[allow(clippy::mutex_atomic)]
         let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
@@ -111,7 +113,7 @@ impl<T: Batch> Batcher<T> {
     /// Enqueues an item for delayed sending.
     ///
     /// This will automatically flush the queue if it reaches a size of `MAX_ITEMS`.
-    pub(crate) fn enqueue(&self, item: T) {
+    pub(super) fn enqueue(&self, item: T) {
         let mut queue = self.queue.lock().unwrap();
         queue.items.push(item);
         if queue.items.len() >= MAX_ITEMS {
@@ -120,7 +122,7 @@ impl<T: Batch> Batcher<T> {
     }
 
     /// Flushes the queue to the transport.
-    pub(crate) fn flush(&self) {
+    pub(super) fn flush(&self) {
         let queue = self.queue.lock().unwrap();
         Batcher::flush_queue_internal(queue, &self.envelope_sender);
     }

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -17,7 +17,7 @@ use rand::random;
 use sentry_types::random_uuid;
 
 #[cfg(any(feature = "logs", feature = "metrics"))]
-use crate::batcher::Batcher;
+use self::batcher::Batcher;
 use crate::constants::SDK_INFO;
 use crate::protocol::{ClientSdkInfo, Event};
 #[cfg(feature = "release-health")]
@@ -36,6 +36,7 @@ use sentry_types::protocol::v7::LogAttribute;
 #[cfg(feature = "metrics")]
 use sentry_types::protocol::v7::Metric;
 
+mod batcher;
 mod envelope_sender;
 
 pub(crate) use self::envelope_sender::EnvelopeSender;

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -139,8 +139,6 @@ mod logger; // structured logging macros exported with `#[macro_export]`
 pub mod metrics;
 
 // client feature
-#[cfg(all(feature = "client", any(feature = "logs", feature = "metrics")))]
-mod batcher;
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "client")]


### PR DESCRIPTION
Move `batcher` under `client`, as it is only used in the `client`.

Follow up to #1139, and stacked on that PR.

Closes [#1156](https://github.com/getsentry/sentry-rust/issues/1156)
Closes [RUST-231](https://linear.app/getsentry/issue/RUST-231)