### PR TITLE
chore(client-reports): Add Client Report aggregator

### DIFF
--- a/sentry-core/src/client/client_reports/inner.rs
+++ b/sentry-core/src/client/client_reports/inner.rs
@@ -1,0 +1,84 @@
+//! Contains the [`ClientReportAggregatorInner`] type.
+//!
+//! Separate module as all this stuff requires atomics.
+
+#![cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use sentry_types::protocol::v7::{ClientReport, ClientReportItem, DataCategory, DiscardReason};
+use sentry_types::IndexedEnum as _;
+
+const ARRAY_SIZE: usize = DiscardReason::VARIANT_COUNT * DataCategory::VARIANT_COUNT;
+
+#[derive(Debug, Default)]
+pub(super) struct ClientReportAggregatorInner {
+    inner: [AtomicU64; ARRAY_SIZE],
+    has_reports: AtomicBool,
+}
+
+impl ClientReportAggregatorInner {
+    pub(super) fn record_loss(&self, category: DataCategory, reason: DiscardReason, quantity: u64) {
+        if quantity > 0 {
+            self.inner[index(category, reason)].fetch_add(quantity, Ordering::Relaxed);
+            self.has_reports.store(true, Ordering::Release);
+        }
+    }
+
+    /// Aggregate the counts into a [`ClientReport`], resetting them to zero.
+    ///
+    /// Only nonzero counts are included in the report.
+    ///
+    /// We only return a report if there is at least one dropped item to report. Otherwise, we
+    /// return [`None`] to indicate that there is nothing to be sent.
+    pub(super) fn take_pending_report(&self) -> Option<ClientReport> {
+        let reports = self.take_pending_report_vec();
+
+        match reports.as_slice() {
+            [] => None,
+            [_, ..] => Some(ClientReport::new(reports)),
+        }
+    }
+
+    /// Aggregate the counts into a vector, resetting all counts in the aggregator to zero.
+    ///
+    /// Only nonzero quantities are included.
+    fn take_pending_report_vec(&self) -> Vec<ClientReportItem> {
+        if !self.has_reports.swap(false, Ordering::Acquire) {
+            return vec![];
+        }
+
+        iter_reason_categories()
+            .zip(self.inner.iter())
+            .map(|(cr, quantity)| (cr, quantity.swap(0, Ordering::Relaxed)))
+            .filter(|&(_, quantity)| quantity > 0)
+            .map(|(CategoryReason { category, reason }, quantity)| {
+                ClientReportItem::new(category, reason, quantity)
+            })
+            .collect()
+    }
+}
+
+/// A category-reason pair in a Client Report.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CategoryReason {
+    category: DataCategory,
+    reason: DiscardReason,
+}
+
+/// Computes the index in the [`ClientReportAggregatorInner`]'s array for a category-reason pair.
+fn index(category: DataCategory, reason: DiscardReason) -> usize {
+    category
+        .as_index()
+        .checked_mul(DiscardReason::VARIANT_COUNT)
+        .and_then(|product| product.checked_add(reason.as_index()))
+        .expect("should not overflow usize")
+}
+
+/// Iterates the category-reason pairs. The zero-indexed n-th item returned from this category
+/// is the category-reason that the n-th item in the array corresponds to.
+fn iter_reason_categories() -> impl Iterator<Item = CategoryReason> {
+    DataCategory::iter_variants().flat_map(|category| {
+        DiscardReason::iter_variants().map(move |reason| CategoryReason { category, reason })
+    })
+}

--- a/sentry-core/src/client/client_reports/inner.rs
+++ b/sentry-core/src/client/client_reports/inner.rs
@@ -6,10 +6,10 @@
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use sentry_types::protocol::v7::{ClientReport, ClientReportItem, DataCategory, DiscardReason};
+use sentry_types::protocol::v7::client_report::{Category, Item, Reason, Report};
 use sentry_types::IndexedEnum as _;
 
-const ARRAY_SIZE: usize = DiscardReason::VARIANT_COUNT * DataCategory::VARIANT_COUNT;
+const ARRAY_SIZE: usize = Reason::VARIANT_COUNT * Category::VARIANT_COUNT;
 
 #[derive(Debug, Default)]
 pub(super) struct ClientReportAggregatorInner {
@@ -18,32 +18,32 @@ pub(super) struct ClientReportAggregatorInner {
 }
 
 impl ClientReportAggregatorInner {
-    pub(super) fn record_loss(&self, category: DataCategory, reason: DiscardReason, quantity: u64) {
+    pub(super) fn record_loss(&self, category: Category, reason: Reason, quantity: u64) {
         if quantity > 0 {
             self.inner[index(category, reason)].fetch_add(quantity, Ordering::Relaxed);
             self.has_reports.store(true, Ordering::Release);
         }
     }
 
-    /// Aggregate the counts into a [`ClientReport`], resetting them to zero.
+    /// Aggregate the counts into a Client [`Report`], resetting them to zero.
     ///
     /// Only nonzero counts are included in the report.
     ///
     /// We only return a report if there is at least one dropped item to report. Otherwise, we
     /// return [`None`] to indicate that there is nothing to be sent.
-    pub(super) fn take_pending_report(&self) -> Option<ClientReport> {
+    pub(super) fn take_pending_report(&self) -> Option<Report> {
         let reports = self.take_pending_report_vec();
 
         match reports.as_slice() {
             [] => None,
-            [_, ..] => Some(ClientReport::new(reports)),
+            [_, ..] => Some(Report::new(reports)),
         }
     }
 
     /// Aggregate the counts into a vector, resetting all counts in the aggregator to zero.
     ///
     /// Only nonzero quantities are included.
-    fn take_pending_report_vec(&self) -> Vec<ClientReportItem> {
+    fn take_pending_report_vec(&self) -> Vec<Item> {
         if !self.has_reports.swap(false, Ordering::Acquire) {
             return vec![];
         }
@@ -53,7 +53,7 @@ impl ClientReportAggregatorInner {
             .map(|(cr, quantity)| (cr, quantity.swap(0, Ordering::Relaxed)))
             .filter(|&(_, quantity)| quantity > 0)
             .map(|(CategoryReason { category, reason }, quantity)| {
-                ClientReportItem::new(category, reason, quantity)
+                Item::new(category, reason, quantity)
             })
             .collect()
     }
@@ -62,15 +62,15 @@ impl ClientReportAggregatorInner {
 /// A category-reason pair in a Client Report.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CategoryReason {
-    category: DataCategory,
-    reason: DiscardReason,
+    category: Category,
+    reason: Reason,
 }
 
 /// Computes the index in the [`ClientReportAggregatorInner`]'s array for a category-reason pair.
-fn index(category: DataCategory, reason: DiscardReason) -> usize {
+fn index(category: Category, reason: Reason) -> usize {
     category
         .as_index()
-        .checked_mul(DiscardReason::VARIANT_COUNT)
+        .checked_mul(Reason::VARIANT_COUNT)
         .and_then(|product| product.checked_add(reason.as_index()))
         .expect("should not overflow usize")
 }
@@ -78,7 +78,7 @@ fn index(category: DataCategory, reason: DiscardReason) -> usize {
 /// Iterates the category-reason pairs. The zero-indexed n-th item returned from this category
 /// is the category-reason that the n-th item in the array corresponds to.
 fn iter_reason_categories() -> impl Iterator<Item = CategoryReason> {
-    DataCategory::iter_variants().flat_map(|category| {
-        DiscardReason::iter_variants().map(move |reason| CategoryReason { category, reason })
+    Category::iter_variants().flat_map(|category| {
+        Reason::iter_variants().map(move |reason| CategoryReason { category, reason })
     })
 }

--- a/sentry-core/src/client/client_reports/inner.rs
+++ b/sentry-core/src/client/client_reports/inner.rs
@@ -7,9 +7,9 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use sentry_types::protocol::v7::client_report::{Category, Item, Reason, Report};
-use sentry_types::IndexedEnum as _;
+use sentry_types::IndexedEnum;
 
-const ARRAY_SIZE: usize = Reason::VARIANT_COUNT * Category::VARIANT_COUNT;
+const ARRAY_SIZE: usize = Reason::VARIANTS.len() * Category::VARIANTS.len();
 
 #[derive(Debug, Default)]
 pub(super) struct ClientReportAggregatorInner {
@@ -70,7 +70,7 @@ struct CategoryReason {
 fn index(category: Category, reason: Reason) -> usize {
     category
         .as_index()
-        .checked_mul(Reason::VARIANT_COUNT)
+        .checked_mul(Reason::VARIANTS.len())
         .and_then(|product| product.checked_add(reason.as_index()))
         .expect("should not overflow usize")
 }
@@ -78,7 +78,9 @@ fn index(category: Category, reason: Reason) -> usize {
 /// Iterates the category-reason pairs. The zero-indexed n-th item returned from this category
 /// is the category-reason that the n-th item in the array corresponds to.
 fn iter_reason_categories() -> impl Iterator<Item = CategoryReason> {
-    Category::iter_variants().flat_map(|category| {
-        Reason::iter_variants().map(move |reason| CategoryReason { category, reason })
+    Category::VARIANTS.iter().flat_map(|&category| {
+        Reason::VARIANTS
+            .iter()
+            .map(move |&reason| CategoryReason { category, reason })
     })
 }

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "client")]
+
+//! A module containing code for aggregating client reports.
+//!
+//! This module is a no-op on platforms lacking support for the atomics needed to collect client
+//! reports.
+
+#[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
+use std::sync::Arc;
+
+#[cfg(doc)]
+use sentry_types::protocol::v7::EnvelopeItem;
+use sentry_types::protocol::v7::{ClientReport, DataCategory, DiscardReason};
+
+use self::inner::ClientReportAggregatorInner;
+
+mod inner;
+
+/// Aggregates counts for lost data that should be reported in client reports.
+///
+/// The aggregator records losses by [`DataCategory`] and [`DiscardReason`]. Recording a loss only
+/// increments counters; no envelope is created at record time. Callers that are about to send an
+/// envelope can call [`Self::take_pending_report`] to drain the current counters into a
+/// [`ClientReport`] item and attach the report to the outgoing envelope.
+///
+/// Draining resets the counters that are included in the returned report. If no losses were
+/// recorded since the previous drain, [`Self::take_pending_report`] returns [`None`].
+///
+/// This type is backed by an [`Arc`]. Cloning the aggregator has the same semantics as cloning an
+/// [`Arc`]: clones share the same counters, and a drain from any clone resets the shared counters
+/// for all clones.
+///
+/// This type is a no-op on platforms lacking support for the atomics needed to collect client
+/// reports.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ClientReportAggregator {
+    #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
+    inner: Arc<ClientReportAggregatorInner>,
+}
+
+impl ClientReportAggregator {
+    /// Create a new client report, with all zero counts.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records `quantity` lost items for `category` and `reason`.
+    ///
+    /// This method updates aggregate counters only. The loss is not sent until a later call to
+    /// [`Self::take_pending_report`] drains the counters and returns a [`ClientReport`] for an
+    /// outgoing envelope. A `quantity` of zero is ignored.
+    #[expect(dead_code, reason = "we will add calls in a follow-up PR")]
+    pub(crate) fn record_loss(&self, category: DataCategory, reason: DiscardReason, quantity: u64) {
+        #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
+        self.inner.record_loss(category, reason, quantity);
+
+        #[cfg(not(all(target_has_atomic = "64", target_has_atomic = "8")))]
+        let _ = (category, reason, quantity);
+    }
+
+    /// Drains recorded losses into a [`ClientReport`].
+    ///
+    /// The returned report contains only nonzero counters. Counters included in the report are reset
+    /// before this method returns. If there are no recorded losses to report, this method returns
+    /// [`None`].
+    pub(crate) fn take_pending_report(&self) -> Option<ClientReport> {
+        #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
+        {
+            self.inner.take_pending_report()
+        }
+
+        #[cfg(not(all(target_has_atomic = "64", target_has_atomic = "8")))]
+        {
+            None
+        }
+    }
+}

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -8,7 +8,7 @@
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use std::sync::Arc;
 
-use sentry_types::protocol::v7::client_report::{Category, ItemLoss, Reason};
+use sentry_types::protocol::v7::client_report::{Category, ItemLoss, LossSource, Reason};
 use sentry_types::protocol::v7::{ClientReport, EnvelopeItem};
 
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
@@ -44,13 +44,12 @@ impl ClientReportAggregator {
         Self::default()
     }
 
-    /// Record a lost envelope item.
+    /// Record lost Sentry data.
     ///
-    /// This records losses for all the data we would lose when dropping the envelope item, for the
-    /// given reason.
+    /// Records the given Sentry telemetry item as discarded for the provided `reason`.
     #[expect(dead_code, reason = "we will add calls in a follow-up PR")]
-    pub(crate) fn record_lost_envelope_item(&self, envelope_item: &EnvelopeItem, reason: Reason) {
-        envelope_item.losses_on_drop().for_each(|loss| {
+    pub(crate) fn record_lost_data<L: LossSource>(&self, data: &L, reason: Reason) {
+        data.losses().for_each(|loss| {
             let ItemLoss {
                 category, quantity, ..
             } = loss;

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -13,6 +13,7 @@ use sentry_types::protocol::v7::client_report::{Category, ItemLoss, Reason};
 use sentry_types::protocol::v7::EnvelopeItem;
 use sentry_types::protocol::v7::{ClientReport, Envelope};
 
+#[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use self::inner::ClientReportAggregatorInner;
 
 mod inner;

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use sentry_types::protocol::v7::client_report::{Category, ItemLoss, LossSource, Reason};
-use sentry_types::protocol::v7::{ClientReport, EnvelopeItem};
+use sentry_types::protocol::v7::ClientReport;
 
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use self::inner::ClientReportAggregatorInner;

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -8,9 +8,10 @@
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use std::sync::Arc;
 
+use sentry_types::protocol::v7::client_report::{Category, Reason};
+use sentry_types::protocol::v7::ClientReport;
 #[cfg(doc)]
 use sentry_types::protocol::v7::EnvelopeItem;
-use sentry_types::protocol::v7::{ClientReport, DataCategory, DiscardReason};
 
 use self::inner::ClientReportAggregatorInner;
 
@@ -18,7 +19,7 @@ mod inner;
 
 /// Aggregates counts for lost data that should be reported in client reports.
 ///
-/// The aggregator records losses by [`DataCategory`] and [`DiscardReason`]. Recording a loss only
+/// The aggregator records losses by [`Category`] and [`Reason`]. Recording a loss only
 /// increments counters; no envelope is created at record time. Callers that are about to send an
 /// envelope can call [`Self::take_pending_report`] to drain the current counters into a
 /// [`ClientReport`] item and attach the report to the outgoing envelope.
@@ -50,7 +51,7 @@ impl ClientReportAggregator {
     /// [`Self::take_pending_report`] drains the counters and returns a [`ClientReport`] for an
     /// outgoing envelope. A `quantity` of zero is ignored.
     #[expect(dead_code, reason = "we will add calls in a follow-up PR")]
-    pub(crate) fn record_loss(&self, category: DataCategory, reason: DiscardReason, quantity: u64) {
+    pub(crate) fn record_loss(&self, category: Category, reason: Reason, quantity: u64) {
         #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
         self.inner.record_loss(category, reason, quantity);
 

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -9,9 +9,7 @@
 use std::sync::Arc;
 
 use sentry_types::protocol::v7::client_report::{Category, ItemLoss, Reason};
-#[cfg(doc)]
-use sentry_types::protocol::v7::EnvelopeItem;
-use sentry_types::protocol::v7::{ClientReport, Envelope};
+use sentry_types::protocol::v7::{ClientReport, EnvelopeItem};
 
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use self::inner::ClientReportAggregatorInner;
@@ -46,13 +44,13 @@ impl ClientReportAggregator {
         Self::default()
     }
 
-    /// Record a lost envelope.
+    /// Record a lost envelope item.
     ///
-    /// This records losses for all the data we would lose when dropping the envelope, for the
+    /// This records losses for all the data we would lose when dropping the envelope item, for the
     /// given reason.
     #[expect(dead_code, reason = "we will add calls in a follow-up PR")]
-    pub(crate) fn record_lost_envelope(&self, envelope: &Envelope, reason: Reason) {
-        envelope.losses_on_drop().for_each(|loss| {
+    pub(crate) fn record_lost_envelope_item(&self, envelope_item: &EnvelopeItem, reason: Reason) {
+        envelope_item.losses_on_drop().for_each(|loss| {
             let ItemLoss {
                 category, quantity, ..
             } = loss;

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -8,10 +8,10 @@
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use std::sync::Arc;
 
-use sentry_types::protocol::v7::client_report::{Category, Reason};
-use sentry_types::protocol::v7::ClientReport;
+use sentry_types::protocol::v7::client_report::{Category, ItemLoss, Reason};
 #[cfg(doc)]
 use sentry_types::protocol::v7::EnvelopeItem;
+use sentry_types::protocol::v7::{ClientReport, Envelope};
 
 use self::inner::ClientReportAggregatorInner;
 
@@ -45,12 +45,25 @@ impl ClientReportAggregator {
         Self::default()
     }
 
+    /// Record a lost envelope.
+    ///
+    /// This records losses for all the data we would lose when dropping the envelope, for the
+    /// given reason.
+    #[expect(dead_code, reason = "we will add calls in a follow-up PR")]
+    pub(crate) fn record_lost_envelope(&self, envelope: &Envelope, reason: Reason) {
+        envelope.losses_on_drop().for_each(|loss| {
+            let ItemLoss {
+                category, quantity, ..
+            } = loss;
+            self.record_loss(category, reason, quantity)
+        });
+    }
+
     /// Records `quantity` lost items for `category` and `reason`.
     ///
     /// This method updates aggregate counters only. The loss is not sent until a later call to
     /// [`Self::take_pending_report`] drains the counters and returns a [`ClientReport`] for an
     /// outgoing envelope. A `quantity` of zero is ignored.
-    #[expect(dead_code, reason = "we will add calls in a follow-up PR")]
     pub(crate) fn record_loss(&self, category: Category, reason: Reason, quantity: u64) {
         #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
         self.inner.record_loss(category, reason, quantity);

--- a/sentry-core/src/client/envelope_sender.rs
+++ b/sentry-core/src/client/envelope_sender.rs
@@ -7,10 +7,17 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use sentry_types::protocol::v7::EnvelopeItem;
+
 use self::slot::TransportSlot;
+use super::client_reports::ClientReportAggregator;
 use crate::{Envelope, Transport};
 
-/// Sends envelopes through the client's transport.
+/// Sends envelopes through the client's transport and tracks lost data.
+///
+/// This type wraps a [`Transport`] and a [`ClientReportAggregator`]. The transport is used for
+/// sending data to Sentry, while the aggregator tracks information about lost Sentry data. We
+/// attach any pending client reports to all outgoing envelopes sent with this type.
 ///
 /// Cloning this sender has `Arc`-like semantics: clones share the same transport
 /// slot and send to the same underlying transport until it is shut down.
@@ -20,10 +27,13 @@ use crate::{Envelope, Transport};
 #[derive(Clone, Default)]
 pub(crate) struct EnvelopeSender {
     transport_slot: TransportSlot<dyn Transport>,
+    client_report_aggregator: ClientReportAggregator,
 }
 
 impl EnvelopeSender {
     /// Sends an envelope if the transport is still available.
+    ///
+    /// If there are any pending client reports, we attach and send them, too.
     pub(crate) fn send_envelope(&self, envelope: Envelope) {
         // This forwards to `send_envelope_with`; any envelope pre-processing should be
         // centralized in the `send_envelope_with` function!
@@ -35,11 +45,21 @@ impl EnvelopeSender {
     /// The builder is only executed if this sender is still active. This allows skipping over
     /// logic that constructs the envelope when it cannot be sent. The builder can also return
     /// [`None`], in which case, we don't send anything.
+    ///
+    /// If there are any pending client reports, and we are sending an envelope, we attach and
+    /// send them, too.
     pub(super) fn send_envelope_with<F>(&self, builder: F)
     where
         F: FnOnce() -> Option<Envelope>,
     {
-        self.transport_slot.send_envelope_with(builder)
+        self.transport_slot.send_envelope_with(|| {
+            builder().map(
+                |envelope| match self.client_report_aggregator.take_pending_report() {
+                    Some(client_report) => with_item(envelope, client_report),
+                    None => envelope,
+                },
+            )
+        })
     }
 
     /// Creates a sender using the transport returned by the provided builder callback.
@@ -47,8 +67,13 @@ impl EnvelopeSender {
     where
         F: FnOnce() -> Arc<dyn Transport>,
     {
+        let client_report_aggregator = ClientReportAggregator::new();
         let transport_slot = TransportSlot::new(transport_builder());
-        Self { transport_slot }
+
+        Self {
+            transport_slot,
+            client_report_aggregator,
+        }
     }
 
     /// Flushes the transport if it is still available.
@@ -63,7 +88,10 @@ impl EnvelopeSender {
 
     pub(super) fn clone_with_new_transport_slot(&self) -> Self {
         let transport_slot = self.transport_slot.clone_into_new_slot();
-        Self { transport_slot }
+        Self {
+            transport_slot,
+            ..self.clone()
+        }
     }
 
     /// Returns whether this sender currently has an available transport.
@@ -184,4 +212,13 @@ mod slot {
             }
         }
     }
+}
+
+/// A little helper to return a new [`Envelope`] with the given `item` added.
+fn with_item<I>(mut envelope: Envelope, item: I) -> Envelope
+where
+    I: Into<EnvelopeItem>,
+{
+    envelope.add_item(item);
+    envelope
 }

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -38,6 +38,7 @@ use sentry_types::protocol::v7::LogAttribute;
 use sentry_types::protocol::v7::Metric;
 
 mod batcher;
+mod client_reports;
 mod envelope_sender;
 
 pub(crate) use self::envelope_sender::EnvelopeSender;


### PR DESCRIPTION
Create a client report aggregator in `sentry-core`.

The aggregator lives on the `EnvelopeSender` next to the `Transport`. The `EnvelopeSender` itself is owned by a `Client`.

The aggregator is entirely lock-free. Instead of the map shape suggested by the [SDK-wide client reports spec](https://develop.sentry.dev/sdk/telemetry/client-reports/#aggregation), the aggregator stores a counter for every discard reason/data category combination. There are currently [15 discard reasons](https://develop.sentry.dev/sdk/telemetry/client-reports/#discard-reasons-1) and [15 data categories](https://develop.sentry.dev/sdk/foundations/transport/rate-limiting/#definitions) allowed by the spec, some of which may be inapplicable to the Rust SDK. If we implement all of these in the SDK, the aggregator will consume approximately 1.8 KiB of fixed memory per instance (15 * 15 64-bit atomic counters).

The alternative would be a HashMap keyed by `(category, reason)`. A HashMap would consume less memory while the aggregator is empty, but recording losses would require synchronization and could allocate memory. The fixed counter array is a reasonable tradeoff for now, and we can revisit the representation if this becomes a practical concern.

Resolves [#1002](https://github.com/getsentry/sentry-rust/issues/1002)
Resolves [RUST-154](https://linear.app/getsentry/issue/RUST-154/add-shared-client-report-aggregator-and-send-client-reports-option)