### PR TITLE
feat(client-reports): Add transport loss recorder

### DIFF
--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -89,7 +89,7 @@ impl ClientReportAggregator {
         }
     }
 
-    /// Creates a [`ClientReportRecorder`] which records into this aggregator.
+    /// Creates a [`Recorder`] which records into this aggregator.
     pub(super) fn recorder(&self) -> Recorder {
         Recorder::new(self)
     }

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -8,6 +8,7 @@
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use std::sync::Arc;
 
+#[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use sentry_types::protocol::v7::client_report::{Category, ItemLoss, LossSource, Reason};
 use sentry_types::protocol::v7::ClientReport;
 
@@ -50,6 +51,7 @@ impl ClientReportAggregator {
     /// Record lost Sentry data.
     ///
     /// Records the given Sentry telemetry item as discarded for the provided `reason`.
+    #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
     pub(crate) fn record_lost_data<L: LossSource>(&self, data: &L, reason: Reason) {
         data.losses().for_each(|loss| {
             let ItemLoss {
@@ -64,12 +66,9 @@ impl ClientReportAggregator {
     /// This method updates aggregate counters only. The loss is not sent until a later call to
     /// [`Self::take_pending_report`] drains the counters and returns a [`ClientReport`] for an
     /// outgoing envelope. A `quantity` of zero is ignored.
+    #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
     pub(crate) fn record_loss(&self, category: Category, reason: Reason, quantity: u64) {
-        #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
         self.inner.record_loss(category, reason, quantity);
-
-        #[cfg(not(all(target_has_atomic = "64", target_has_atomic = "8")))]
-        let _ = (category, reason, quantity);
     }
 
     /// Drains recorded losses into a [`ClientReport`].

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -50,7 +50,6 @@ impl ClientReportAggregator {
     /// Record lost Sentry data.
     ///
     /// Records the given Sentry telemetry item as discarded for the provided `reason`.
-    #[expect(dead_code, reason = "we will add calls in a follow-up PR")]
     pub(crate) fn record_lost_data<L: LossSource>(&self, data: &L, reason: Reason) {
         data.losses().for_each(|loss| {
             let ItemLoss {

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -17,7 +17,7 @@ use self::inner::ClientReportAggregatorInner;
 mod inner;
 mod recorder;
 
-pub use self::recorder::ClientReportRecorder;
+pub use self::recorder::{Recorder, TransportLossReason};
 
 /// Aggregates counts for lost data that should be reported in client reports.
 ///
@@ -90,7 +90,7 @@ impl ClientReportAggregator {
     }
 
     /// Creates a [`ClientReportRecorder`] which records into this aggregator.
-    pub(super) fn recorder(&self) -> ClientReportRecorder {
-        ClientReportRecorder::new(self)
+    pub(super) fn recorder(&self) -> Recorder {
+        Recorder::new(self)
     }
 }

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -15,6 +15,9 @@ use sentry_types::protocol::v7::ClientReport;
 use self::inner::ClientReportAggregatorInner;
 
 mod inner;
+mod recorder;
+
+pub use self::recorder::ClientReportRecorder;
 
 /// Aggregates counts for lost data that should be reported in client reports.
 ///
@@ -85,5 +88,10 @@ impl ClientReportAggregator {
         {
             None
         }
+    }
+
+    /// Creates a [`ClientReportRecorder`] which records into this aggregator.
+    pub(super) fn recorder(&self) -> ClientReportRecorder {
+        ClientReportRecorder::new(self)
     }
 }

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -3,12 +3,15 @@
 //! This type is `pub` to allow transports, which are defined outside the `sentry-core` crate, to
 //! record lost events, without giving full access to the underlying [`ClientReportAggregator`].
 
+#[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
 use std::sync::{Arc, Weak};
 
 use sentry_types::protocol::v7::client_report::Reason;
 use sentry_types::protocol::v7::Envelope;
 
-use super::{ClientReportAggregator, ClientReportAggregatorInner};
+use super::ClientReportAggregator;
+#[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
+use super::ClientReportAggregatorInner;
 
 /// A handle for a transport to record lost Sentry data.
 ///

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -10,7 +10,7 @@ use sentry_types::protocol::v7::Envelope;
 
 use super::{ClientReportAggregator, ClientReportAggregatorInner};
 
-/// A handle for recording lost Sentry data.
+/// A handle for a transport to record lost Sentry data.
 ///
 /// Lost items recorded here will be aggregated into a [client report] and eventually sent to
 /// Sentry. We attempt to send client reports with a future envelope, so recording lost events
@@ -24,7 +24,7 @@ use super::{ClientReportAggregator, ClientReportAggregatorInner};
 ///
 /// [client report]: https://develop.sentry.dev/sdk/telemetry/client-reports/
 #[derive(Debug, Clone)]
-pub struct ClientReportRecorder {
+pub struct Recorder {
     /// The inner aggregator.
     ///
     /// As the recorder only records losses, but cannot retrieve them, it does not make sense for
@@ -38,12 +38,19 @@ pub struct ClientReportRecorder {
     inner: Weak<ClientReportAggregatorInner>,
 }
 
-impl ClientReportRecorder {
+/// Reasons for which a transport might drop data.
+///
+/// This is a subset of [`Reason`], as defined in [`sentry_types`] because only some of those
+/// reasons may be applicable to transports.
+#[non_exhaustive]
+pub enum TransportLossReason {}
+
+impl Recorder {
     /// Record an envelope lost for a given reason.
-    pub fn record_lost_envelope(&self, envelope: &Envelope, reason: Reason) {
+    pub fn record_lost_envelope(&self, envelope: &Envelope, reason: TransportLossReason) {
         #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
         if let Some(aggregator) = self.aggregator() {
-            aggregator.record_lost_envelope(envelope, reason);
+            aggregator.record_lost_envelope(envelope, reason.into_reason());
         }
         #[cfg(not(all(target_has_atomic = "8", target_has_atomic = "64")))]
         let _ = (envelope, reason);
@@ -90,5 +97,12 @@ impl ClientReportRecorder {
         self.inner
             .upgrade()
             .map(|inner| ClientReportAggregator { inner })
+    }
+}
+
+impl TransportLossReason {
+    /// Convert to the corresponding [`Reason`].
+    fn into_reason(self) -> Reason {
+        match self {}
     }
 }

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Weak};
 
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
 use sentry_types::protocol::v7::client_report::Reason;
-use sentry_types::protocol::v7::Envelope;
+use sentry_types::protocol::v7::EnvelopeItem;
 
 use super::ClientReportAggregator;
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
@@ -50,11 +50,15 @@ pub struct Recorder {
 pub enum TransportLossReason {}
 
 impl Recorder {
-    /// Record an envelope lost for a given reason.
-    pub fn record_lost_envelope(&self, envelope: &Envelope, reason: TransportLossReason) {
+    /// Record an envelope item lost for a given reason.
+    pub fn record_lost_envelope_item(
+        &self,
+        envelope_item: &EnvelopeItem,
+        reason: TransportLossReason,
+    ) {
         #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
         if let Some(aggregator) = self.aggregator() {
-            aggregator.record_lost_envelope(envelope, reason.into_reason());
+            aggregator.record_lost_envelope_item(envelope_item, reason.into_reason());
         }
         #[cfg(not(all(target_has_atomic = "8", target_has_atomic = "64")))]
         let _ = (envelope, reason);

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -5,7 +5,8 @@
 
 use std::sync::{Arc, Weak};
 
-use sentry_types::protocol::v7::client_report::{Category, Reason};
+use sentry_types::protocol::v7::client_report::Reason;
+use sentry_types::protocol::v7::Envelope;
 
 use super::{ClientReportAggregator, ClientReportAggregatorInner};
 
@@ -38,14 +39,14 @@ pub struct ClientReportRecorder {
 }
 
 impl ClientReportRecorder {
-    /// Record `quantity` lost items, of the given `category`, discarded for the given `reason`.
-    pub fn record_loss(&self, category: Category, reason: Reason, quantity: u64) {
+    /// Record an envelope lost for a given reason.
+    pub fn record_lost_envelope(&self, envelope: &Envelope, reason: Reason) {
         #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
         if let Some(aggregator) = self.aggregator() {
-            aggregator.record_loss(category, reason, quantity);
+            aggregator.record_lost_envelope(envelope, reason);
         }
         #[cfg(not(all(target_has_atomic = "8", target_has_atomic = "64")))]
-        let _ = (category, reason, quantity);
+        let _ = (envelope, reason);
     }
 
     /// Creates a new no-op [`ClientReportRecorder`].

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -6,9 +6,9 @@
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
 use std::sync::{Arc, Weak};
 
+use sentry_types::protocol::v7::client_report::LossSource;
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
 use sentry_types::protocol::v7::client_report::Reason;
-use sentry_types::protocol::v7::EnvelopeItem;
 
 use super::ClientReportAggregator;
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
@@ -52,17 +52,13 @@ pub enum TransportLossReason {}
 
 impl Recorder {
     /// Record an envelope item lost for a given reason.
-    pub fn record_lost_envelope_item(
-        &self,
-        envelope_item: &EnvelopeItem,
-        reason: TransportLossReason,
-    ) {
+    pub fn record_lost_data<L: LossSource>(&self, data: &L, reason: TransportLossReason) {
         #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
         if let Some(aggregator) = self.aggregator() {
-            aggregator.record_lost_envelope_item(envelope_item, reason.into_reason());
+            aggregator.record_lost_data(data, reason.into_reason());
         }
         #[cfg(not(all(target_has_atomic = "8", target_has_atomic = "64")))]
-        let _ = (envelope_item, reason);
+        let _ = (data, reason);
     }
 
     /// Creates a new no-op [`Recorder`].

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -63,7 +63,6 @@ impl ClientReportRecorder {
 
     /// Create a new [`ClientReportRecorder`] which records into the given
     /// [`ClientReportAggregator`].
-    #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
     pub(super) fn new(aggregator: &ClientReportAggregator) -> Self {
         #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
         {

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -6,6 +6,7 @@
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
 use std::sync::{Arc, Weak};
 
+#[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
 use sentry_types::protocol::v7::client_report::Reason;
 use sentry_types::protocol::v7::Envelope;
 
@@ -105,6 +106,7 @@ impl Recorder {
 
 impl TransportLossReason {
     /// Convert to the corresponding [`Reason`].
+    #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
     fn into_reason(self) -> Reason {
         match self {}
     }

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -1,4 +1,4 @@
-//! Contains the [`ClientReportRecorder`] type, which allows recording data losses.
+//! Contains the [`Recorder`] type, which allows recording data losses.
 //!
 //! This type is `pub` to allow transports, which are defined outside the `sentry-core` crate, to
 //! record lost events, without giving full access to the underlying [`ClientReportAggregator`].
@@ -56,12 +56,12 @@ impl Recorder {
         let _ = (envelope, reason);
     }
 
-    /// Creates a new no-op [`ClientReportRecorder`].
+    /// Creates a new no-op [`Recorder`].
     ///
     /// This is used in backwards-compatibility code to handle the case where we might not have an
     /// aggregator.
     ///
-    /// To get a useful [`ClientReportRecorder`], use [`ClientReportAggregator::recorder`].
+    /// To get a useful [`Recorder`], use [`ClientReportAggregator::recorder`].
     pub(crate) fn new_no_op() -> Self {
         Self {
             #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
@@ -69,7 +69,7 @@ impl Recorder {
         }
     }
 
-    /// Create a new [`ClientReportRecorder`] which records into the given
+    /// Create a new [`Recorder`] which records into the given
     /// [`ClientReportAggregator`].
     pub(super) fn new(aggregator: &ClientReportAggregator) -> Self {
         #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -1,0 +1,94 @@
+//! Contains the [`ClientReportRecorder`] type, which allows recording data losses.
+//!
+//! This type is `pub` to allow transports, which are defined outside the `sentry-core` crate, to
+//! record lost events, without giving full access to the underlying [`ClientReportAggregator`].
+
+use std::sync::{Arc, Weak};
+
+use sentry_types::protocol::v7::client_report::{Category, Reason};
+
+use super::{ClientReportAggregator, ClientReportAggregatorInner};
+
+/// A handle for recording lost Sentry data.
+///
+/// Lost items recorded here will be aggregated into a [client report] and eventually sent to
+/// Sentry. We attempt to send client reports with a future envelope, so recording lost events
+/// should not lead to increased requests to Sentry.
+///
+/// Cloning has [`Arc`]-like semantics in the sense that clones record into the same client report
+/// aggregator.
+///
+/// As client reports require atomics for aggregation, this struct's methods are no-ops on
+/// platforms which lack support for 8-bit and/or 64-bit atomic operations.
+///
+/// [client report]: https://develop.sentry.dev/sdk/telemetry/client-reports/
+#[derive(Debug, Clone)]
+pub struct ClientReportRecorder {
+    /// The inner aggregator.
+    ///
+    /// As the recorder only records losses, but cannot retrieve them, it does not make sense for
+    /// the recorder to keep the underlying aggregator alive.
+    ///
+    /// We therefore store `inner` as a [`Weak`] so that we do not keep the aggregator alive.
+    ///
+    /// In practice, we would expect the recorder not to outlive the underlying aggregator, but in
+    /// case it happens, it makes sense to make the `Weak` relationship explicit.
+    #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
+    inner: Weak<ClientReportAggregatorInner>,
+}
+
+impl ClientReportRecorder {
+    /// Record `quantity` lost items, of the given `category`, discarded for the given `reason`.
+    pub fn record_loss(&self, category: Category, reason: Reason, quantity: u64) {
+        #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
+        if let Some(aggregator) = self.aggregator() {
+            aggregator.record_loss(category, reason, quantity);
+        }
+        #[cfg(not(all(target_has_atomic = "8", target_has_atomic = "64")))]
+        let _ = (category, reason, quantity);
+    }
+
+    /// Creates a new no-op [`ClientReportRecorder`].
+    ///
+    /// This is used in backwards-compatibility code to handle the case where we might not have an
+    /// aggregator.
+    ///
+    /// To get a useful [`ClientReportRecorder`], use [`ClientReportAggregator::recorder`].
+    pub(crate) fn new_no_op() -> Self {
+        Self {
+            #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
+            inner: Weak::new(),
+        }
+    }
+
+    /// Create a new [`ClientReportRecorder`] which records into the given
+    /// [`ClientReportAggregator`].
+    #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
+    pub(super) fn new(aggregator: &ClientReportAggregator) -> Self {
+        #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
+        {
+            let ClientReportAggregator {
+                inner: aggregator_inner,
+            } = aggregator;
+
+            let inner = Arc::downgrade(aggregator_inner);
+            Self { inner }
+        }
+        #[cfg(not(all(target_has_atomic = "8", target_has_atomic = "64")))]
+        {
+            let _ = aggregator;
+            Self {}
+        }
+    }
+
+    /// Helper to obtain the [`ClientReportAggregator`] we record into, if still alive.
+    ///
+    /// This works by upgrading the [`Weak`] pointer to the [`ClientReportAggregatorInner`] stored
+    /// in `self.inner`, then wrapping it in a [`ClientReportAggregator`].
+    #[cfg(all(target_has_atomic = "8", target_has_atomic = "64"))]
+    fn aggregator(&self) -> Option<ClientReportAggregator> {
+        self.inner
+            .upgrade()
+            .map(|inner| ClientReportAggregator { inner })
+    }
+}

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -46,6 +46,7 @@ pub struct Recorder {
 ///
 /// This is a subset of [`Reason`], as defined in [`sentry_types`] because only some of those
 /// reasons may be applicable to transports.
+#[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum TransportLossReason {}
 

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -62,7 +62,7 @@ impl Recorder {
             aggregator.record_lost_envelope_item(envelope_item, reason.into_reason());
         }
         #[cfg(not(all(target_has_atomic = "8", target_has_atomic = "64")))]
-        let _ = (envelope, reason);
+        let _ = (envelope_item, reason);
     }
 
     /// Creates a new no-op [`Recorder`].

--- a/sentry-core/src/client/envelope_sender.rs
+++ b/sentry-core/src/client/envelope_sender.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use sentry_types::protocol::v7::EnvelopeItem;
 
 use self::slot::TransportSlot;
-use super::client_reports::ClientReportAggregator;
+use super::client_reports::{ClientReportAggregator, ClientReportRecorder};
 use crate::{Envelope, Transport};
 
 /// Sends envelopes through the client's transport and tracks lost data.
@@ -65,10 +65,11 @@ impl EnvelopeSender {
     /// Creates a sender using the transport returned by the provided builder callback.
     pub(super) fn new<F>(transport_builder: F) -> Self
     where
-        F: FnOnce() -> Arc<dyn Transport>,
+        F: FnOnce(ClientReportRecorder) -> Arc<dyn Transport>,
     {
         let client_report_aggregator = ClientReportAggregator::new();
-        let transport_slot = TransportSlot::new(transport_builder());
+        let recorder = client_report_aggregator.recorder();
+        let transport_slot = TransportSlot::new(transport_builder(recorder));
 
         Self {
             transport_slot,

--- a/sentry-core/src/client/envelope_sender.rs
+++ b/sentry-core/src/client/envelope_sender.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use sentry_types::protocol::v7::EnvelopeItem;
 
 use self::slot::TransportSlot;
-use super::client_reports::{ClientReportAggregator, ClientReportRecorder};
+use super::client_reports::{ClientReportAggregator, Recorder};
 use crate::{Envelope, Transport};
 
 /// Sends envelopes through the client's transport and tracks lost data.
@@ -65,7 +65,7 @@ impl EnvelopeSender {
     /// Creates a sender using the transport returned by the provided builder callback.
     pub(super) fn new<F>(transport_builder: F) -> Self
     where
-        F: FnOnce(ClientReportRecorder) -> Arc<dyn Transport>,
+        F: FnOnce(Recorder) -> Arc<dyn Transport>,
     {
         let client_report_aggregator = ClientReportAggregator::new();
         let recorder = client_report_aggregator.recorder();

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -41,6 +41,7 @@ mod batcher;
 mod client_reports;
 mod envelope_sender;
 
+pub use self::client_reports::ClientReportRecorder;
 pub(crate) use self::envelope_sender::EnvelopeSender;
 
 impl<T: Into<ClientOptions>> From<T> for Client {
@@ -604,13 +605,14 @@ fn build_envelope_sender(client_options: &ClientOptions) -> EnvelopeSender {
     } = client_options;
 
     match (dsn.as_ref(), transport_factory.as_ref()) {
-        (Some(dsn), Some(transport_factory)) => EnvelopeSender::new(|| {
+        (Some(dsn), Some(transport_factory)) => EnvelopeSender::new(|client_report_recorder| {
             let options = TransportOptions {
                 dsn: dsn.clone(),
                 user_agent: user_agent.clone(),
                 http_proxy: http_proxy.clone(),
                 https_proxy: https_proxy.clone(),
                 accept_invalid_certs: *accept_invalid_certs,
+                client_report_recorder,
             };
 
             transport_factory.create_transport_with_options(options)

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -38,10 +38,10 @@ use sentry_types::protocol::v7::LogAttribute;
 use sentry_types::protocol::v7::Metric;
 
 mod batcher;
-mod client_reports;
 mod envelope_sender;
 
-pub use self::client_reports::ClientReportRecorder;
+pub(crate) mod client_reports;
+
 pub(crate) use self::envelope_sender::EnvelopeSender;
 
 impl<T: Into<ClientOptions>> From<T> for Client {

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -152,6 +152,9 @@ pub use crate::clientoptions::MaxRequestBodySize;
 #[cfg(feature = "client")]
 pub use crate::{client::Client, hub_impl::SwitchGuard as HubSwitchGuard};
 
+#[cfg(feature = "client")]
+pub use crate::client::ClientReportRecorder;
+
 // test utilities
 #[cfg(feature = "test")]
 pub mod test;

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -152,8 +152,13 @@ pub use crate::clientoptions::MaxRequestBodySize;
 #[cfg(feature = "client")]
 pub use crate::{client::Client, hub_impl::SwitchGuard as HubSwitchGuard};
 
+/// Types which enable transports to capture [client reports] to report lost data to Sentry.
+///
+/// [client reports]: https://develop.sentry.dev/sdk/telemetry/client-reports/
 #[cfg(feature = "client")]
-pub use crate::client::ClientReportRecorder;
+pub mod client_report {
+    pub use crate::client::client_reports::{Recorder, TransportLossReason as Reason};
+}
 
 // test utilities
 #[cfg(feature = "test")]

--- a/sentry-core/src/transport/options.rs
+++ b/sentry-core/src/transport/options.rs
@@ -4,9 +4,9 @@ use std::borrow::Cow;
 
 use sentry_types::Dsn;
 
-use crate::ClientOptions;
 #[cfg(feature = "client")]
-use crate::ClientReportRecorder;
+use crate::client_report::Recorder as ClientReportRecorder;
+use crate::ClientOptions;
 
 /// Options for a transport.
 #[derive(Debug)]

--- a/sentry-core/src/transport/options.rs
+++ b/sentry-core/src/transport/options.rs
@@ -5,6 +5,8 @@ use std::borrow::Cow;
 use sentry_types::Dsn;
 
 use crate::ClientOptions;
+#[cfg(feature = "client")]
+use crate::ClientReportRecorder;
 
 /// Options for a transport.
 #[derive(Debug)]
@@ -21,6 +23,9 @@ pub struct TransportOptions {
     pub https_proxy: Option<Cow<'static, str>>,
     /// Whether TLS certificate validation should be disabled.
     pub accept_invalid_certs: bool,
+    /// A handle for recording lost Sentry data.
+    #[cfg(feature = "client")]
+    pub client_report_recorder: ClientReportRecorder,
 }
 
 impl TransportOptions {
@@ -47,6 +52,8 @@ impl TransportOptions {
             http_proxy: http_proxy.clone(),
             https_proxy: https_proxy.clone(),
             accept_invalid_certs: *accept_invalid_certs,
+            #[cfg(feature = "client")]
+            client_report_recorder: ClientReportRecorder::new_no_op(),
         })
     }
 
@@ -64,6 +71,8 @@ impl TransportOptions {
             http_proxy,
             https_proxy,
             accept_invalid_certs,
+            #[cfg(feature = "client")]
+                client_report_recorder: _,
         } = self;
 
         let dsn = Some(dsn);


### PR DESCRIPTION
Add a public `ClientReportRecorder` handle for transports to record lost Sentry data without exposing the full client-report aggregator.

Pass the recorder through `TransportOptions` when the SDK client builds a transport. Recorded losses are aggregated into future `client_report` envelope items, so transports can report drops without sending extra requests.

Keep backwards-compatible transport construction paths working by using a no-op recorder when no client-report aggregator is available. Built-in transports will start calling the recorder in follow-up PRs.

Resolves [#1148](https://github.com/getsentry/sentry-rust/issues/1148)
Resolves [RUST-223](https://linear.app/getsentry/issue/RUST-223)