### PR TITLE
chore(curl): Record envelope losses in the Curl transport

### DIFF
--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -6,6 +6,7 @@ use sentry_core::client_report::Reason as LossReason;
 use sentry_core::TransportOptions;
 
 use super::{
+    client_report,
     thread::{TransportThread, TransportThreadOptions},
     RateLimiter, HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE,
 };
@@ -123,8 +124,11 @@ impl CurlHttpTransport {
             envelope
                 .to_writer(&mut body)
                 .inspect_err(|_| {
-                    client_report_recorder
-                        .record_lost_envelope(&envelope, LossReason::InternalError)
+                    client_report::record_lost_envelope(
+                        &client_report_recorder,
+                        &envelope,
+                        LossReason::InternalError,
+                    );
                 })
                 .expect("envelope should serialize successfully");
             let mut body = Cursor::new(body);
@@ -196,14 +200,20 @@ impl CurlHttpTransport {
                     {
                         // The server returned an HTTP error response, so the envelope was rejected
                         // at the HTTP layer even if curl also reported a transfer error.
-                        client_report_recorder
-                            .record_lost_envelope(&envelope, LossReason::SendError);
+                        client_report::record_lost_envelope(
+                            &client_report_recorder,
+                            &envelope,
+                            LossReason::SendError,
+                        );
                     } else if perform_failed && response_code == 0 {
                         // curl documents `CURLINFO_RESPONSE_CODE` as zero when no server response
                         // code has been received. If `perform` also failed, this means the send
                         // failed before an HTTP status was available, which is a network error.
-                        client_report_recorder
-                            .record_lost_envelope(&envelope, LossReason::NetworkError);
+                        client_report::record_lost_envelope(
+                            &client_report_recorder,
+                            &envelope,
+                            LossReason::NetworkError,
+                        );
                     }
                 }
                 Err(err) => {
@@ -215,7 +225,7 @@ impl CurlHttpTransport {
                     } else {
                         LossReason::SendError
                     };
-                    client_report_recorder.record_lost_envelope(&envelope, reason);
+                    client_report::record_lost_envelope(&client_report_recorder, &envelope, reason);
                 }
             }
         };

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -2,6 +2,7 @@ use std::io::{Cursor, Read};
 use std::time::Duration;
 
 use curl::easy::Easy as CurlClient;
+use sentry_core::client_report::Reason as LossReason;
 use sentry_core::TransportOptions;
 
 use super::{
@@ -10,6 +11,9 @@ use super::{
 };
 
 use crate::{sentry_debug, types::Scheme, ClientOptions, Envelope, Transport};
+
+/// The status code returned for rate-limited envelopes.
+const HTTP_RATE_LIMIT_STATUS: u32 = 429;
 
 /// A [`Transport`] that sends events via the [`curl`] library.
 ///
@@ -78,6 +82,7 @@ impl CurlHttpTransport {
                     http_proxy,
                     https_proxy,
                     accept_invalid_certs,
+                    client_report_recorder,
                     ..
                 },
             client,
@@ -115,7 +120,13 @@ impl CurlHttpTransport {
             }
 
             let mut body = Vec::new();
-            envelope.to_writer(&mut body).unwrap();
+            envelope
+                .to_writer(&mut body)
+                .inspect_err(|_| {
+                    client_report_recorder
+                        .record_lost_envelope(&envelope, LossReason::InternalError)
+                })
+                .expect("envelope should serialize successfully");
             let mut body = Cursor::new(body);
 
             let mut retry_after = None;
@@ -142,7 +153,7 @@ impl CurlHttpTransport {
                 })
                 .unwrap();
 
-            {
+            let perform_result = {
                 let mut handle = handle.transfer();
                 let retry_after_setter = &mut retry_after;
                 let sentry_header_setter = &mut sentry_header;
@@ -162,8 +173,10 @@ impl CurlHttpTransport {
                         true
                     })
                     .unwrap();
-                handle.perform().ok();
-            }
+                handle.perform()
+            };
+
+            let perform_failed = perform_result.is_err();
 
             match handle.response_code() {
                 Ok(response_code) => {
@@ -171,15 +184,38 @@ impl CurlHttpTransport {
                         rl.update_from_sentry_header(&sentry_header);
                     } else if let Some(retry_after) = retry_after {
                         rl.update_from_retry_after(&retry_after);
-                    } else if response_code == 429 {
+                    } else if response_code == HTTP_RATE_LIMIT_STATUS {
                         rl.update_from_429();
                     }
                     if response_code == HTTP_PAYLOAD_TOO_LARGE as u32 {
                         sentry_debug!("{HTTP_PAYLOAD_TOO_LARGE_MESSAGE}");
                     }
+
+                    if (400..=599).contains(&response_code)
+                        && response_code != HTTP_RATE_LIMIT_STATUS
+                    {
+                        // The server returned an HTTP error response, so the envelope was rejected
+                        // at the HTTP layer even if curl also reported a transfer error.
+                        client_report_recorder
+                            .record_lost_envelope(&envelope, LossReason::SendError);
+                    } else if perform_failed && response_code == 0 {
+                        // curl documents `CURLINFO_RESPONSE_CODE` as zero when no server response
+                        // code has been received. If `perform` also failed, this means the send
+                        // failed before an HTTP status was available, which is a network error.
+                        client_report_recorder
+                            .record_lost_envelope(&envelope, LossReason::NetworkError);
+                    }
                 }
                 Err(err) => {
                     sentry_debug!("Failed to send envelope: {}", err);
+                    let reason = if perform_failed {
+                        // `response_code` only errors when `CURLINFO_RESPONSE_CODE` is not
+                        // supported. If `perform` failed too, treat the loss as the transfer error.
+                        LossReason::NetworkError
+                    } else {
+                        LossReason::SendError
+                    };
+                    client_report_recorder.record_lost_envelope(&envelope, reason);
                 }
             }
         };

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -6,7 +6,6 @@ use sentry_core::client_report::Reason as LossReason;
 use sentry_core::TransportOptions;
 
 use super::{
-    client_report,
     thread::{TransportThread, TransportThreadOptions},
     RateLimiter, HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE,
 };
@@ -124,11 +123,7 @@ impl CurlHttpTransport {
             envelope
                 .to_writer(&mut body)
                 .inspect_err(|_| {
-                    client_report::record_lost_envelope(
-                        &client_report_recorder,
-                        &envelope,
-                        LossReason::InternalError,
-                    );
+                    client_report_recorder.record_lost_data(&envelope, LossReason::InternalError);
                 })
                 .expect("envelope should serialize successfully");
             let mut body = Cursor::new(body);
@@ -200,20 +195,13 @@ impl CurlHttpTransport {
                     {
                         // The server returned an HTTP error response, so the envelope was rejected
                         // at the HTTP layer even if curl also reported a transfer error.
-                        client_report::record_lost_envelope(
-                            &client_report_recorder,
-                            &envelope,
-                            LossReason::SendError,
-                        );
+                        client_report_recorder.record_lost_data(&envelope, LossReason::SendError);
                     } else if perform_failed && response_code == 0 {
                         // curl documents `CURLINFO_RESPONSE_CODE` as zero when no server response
                         // code has been received. If `perform` also failed, this means the send
                         // failed before an HTTP status was available, which is a network error.
-                        client_report::record_lost_envelope(
-                            &client_report_recorder,
-                            &envelope,
-                            LossReason::NetworkError,
-                        );
+                        client_report_recorder
+                            .record_lost_data(&envelope, LossReason::NetworkError);
                     }
                 }
                 Err(err) => {
@@ -225,7 +213,7 @@ impl CurlHttpTransport {
                     } else {
                         LossReason::SendError
                     };
-                    client_report::record_lost_envelope(&client_report_recorder, &envelope, reason);
+                    client_report_recorder.record_lost_data(&envelope, reason);
                 }
             }
         };


### PR DESCRIPTION
Record lost envelopes in the `curl` transport after the transport thread accepts them for sending. Curl execution failures are recorded as `network_error`; response-code lookup failures and non-`429` HTTP `4xx`/`5xx` responses are recorded as `send_error`.

Keep existing rate-limit handling for `429` responses and the existing payload-too-large debug message for `413` responses.

Closes [#1152](https://github.com/getsentry/sentry-rust/issues/1152)
Closes [RUST-227](https://linear.app/getsentry/issue/RUST-227)