### PR TITLE
fix(transport): Handle ureq HTTP error statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed `ureq` transport handling for HTTP error statuses so `429` rate limits and `413` payload-too-large responses are processed correctly ([#1177](https://github.com/getsentry/sentry-rust/pull/1177)).
+
 ## 0.48.2
 
 ### New Features

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -90,7 +90,13 @@ impl UreqHttpTransport {
         let thread = TransportThread::new(move |envelope, rl| {
             let mut body = Vec::new();
             envelope.to_writer(&mut body).unwrap();
-            let request = agent.post(&url).header("X-Sentry-Auth", &auth).send(&body);
+            let request = agent
+                .post(&url)
+                .header("X-Sentry-Auth", &auth)
+                .config()
+                .http_status_as_error(false)
+                .build()
+                .send(&body);
 
             match request {
                 Ok(mut response) => {


### PR DESCRIPTION
Previously, ureq returned HTTP 4xx and 5xx responses as send errors, so the transport skipped the response-handling logic for those statuses. As a result, fallback `429` rate-limit handling and `413` payload-too-large logging were not reached.

Set `http_status_as_error(false)` on ureq envelope requests so HTTP error statuses return as responses and flow through the existing response handling.

Fixes [#1176](https://github.com/getsentry/sentry-rust/issues/1176)
Fixes [RUST-243](https://linear.app/getsentry/issue/RUST-243)
