### PR TITLE
chore(ureq): Record envelope losses in the Ureq transport

### DIFF
--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -12,6 +12,7 @@ use ureq::tls::{TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
 
 use super::{
+    client_report,
     thread::{TransportThread, TransportThreadOptions},
     RateLimiter, HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE,
 };
@@ -155,8 +156,11 @@ impl UreqHttpTransport {
             envelope
                 .to_writer(&mut body)
                 .inspect_err(|_| {
-                    client_report_recorder
-                        .record_lost_envelope(&envelope, LossReason::InternalError)
+                    client_report::record_lost_envelope(
+                        &client_report_recorder,
+                        &envelope,
+                        LossReason::InternalError,
+                    );
                 })
                 .expect("envelope should serialize successfully");
             let request = agent
@@ -198,14 +202,20 @@ impl UreqHttpTransport {
                     if (400..=599).contains(&response_status)
                         && response_status != HTTP_RATE_LIMIT_STATUS
                     {
-                        client_report_recorder
-                            .record_lost_envelope(&envelope, LossReason::SendError);
+                        client_report::record_lost_envelope(
+                            &client_report_recorder,
+                            &envelope,
+                            LossReason::SendError,
+                        );
                     }
                 }
                 Err(err) => {
                     sentry_debug!("Failed to send envelope: {}", err);
-                    client_report_recorder
-                        .record_lost_envelope(&envelope, LossReason::NetworkError);
+                    client_report::record_lost_envelope(
+                        &client_report_recorder,
+                        &envelope,
+                        LossReason::NetworkError,
+                    );
                 }
             }
         };

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use sentry_core::client_report::Reason as LossReason;
 use sentry_core::TransportOptions;
 use ureq::http::Response;
 #[cfg(any(
@@ -16,6 +17,9 @@ use super::{
 };
 
 use crate::{sentry_debug, types::Scheme, ClientOptions, Envelope, Transport};
+
+/// The status code returned for rate-limited envelopes.
+const HTTP_RATE_LIMIT_STATUS: u16 = 429;
 
 /// A [`Transport`] that sends events via the [`ureq`] library.
 ///
@@ -89,6 +93,7 @@ impl UreqHttpTransport {
                         feature = "rustls-no-provider"
                     ))]
                     accept_invalid_certs,
+                    client_report_recorder,
                     ..
                 },
             agent,
@@ -147,7 +152,13 @@ impl UreqHttpTransport {
 
         let send_fn = move |envelope: Envelope, rl: &mut RateLimiter| {
             let mut body = Vec::new();
-            envelope.to_writer(&mut body).unwrap();
+            envelope
+                .to_writer(&mut body)
+                .inspect_err(|_| {
+                    client_report_recorder
+                        .record_lost_envelope(&envelope, LossReason::InternalError)
+                })
+                .expect("envelope should serialize successfully");
             let request = agent
                 .post(&url)
                 .header("X-Sentry-Auth", &auth)
@@ -166,9 +177,11 @@ impl UreqHttpTransport {
                         rl.update_from_sentry_header(sentry_header);
                     } else if let Some(retry_after) = header_str(&response, "retry-after") {
                         rl.update_from_retry_after(retry_after);
-                    } else if response.status() == 429 {
+                    } else if response.status() == HTTP_RATE_LIMIT_STATUS {
                         rl.update_from_429();
                     }
+
+                    let response_status = response.status().as_u16();
 
                     match response.body_mut().read_to_string() {
                         Err(err) => {
@@ -178,12 +191,21 @@ impl UreqHttpTransport {
                             sentry_debug!("Get response: `{}`", text);
                         }
                     }
-                    if response.status() == HTTP_PAYLOAD_TOO_LARGE {
+                    if response_status == HTTP_PAYLOAD_TOO_LARGE {
                         sentry_debug!("{HTTP_PAYLOAD_TOO_LARGE_MESSAGE}");
+                    }
+
+                    if (400..=599).contains(&response_status)
+                        && response_status != HTTP_RATE_LIMIT_STATUS
+                    {
+                        client_report_recorder
+                            .record_lost_envelope(&envelope, LossReason::SendError);
                     }
                 }
                 Err(err) => {
                     sentry_debug!("Failed to send envelope: {}", err);
+                    client_report_recorder
+                        .record_lost_envelope(&envelope, LossReason::NetworkError);
                 }
             }
         };

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -12,7 +12,6 @@ use ureq::tls::{TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
 
 use super::{
-    client_report,
     thread::{TransportThread, TransportThreadOptions},
     RateLimiter, HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE,
 };
@@ -156,11 +155,7 @@ impl UreqHttpTransport {
             envelope
                 .to_writer(&mut body)
                 .inspect_err(|_| {
-                    client_report::record_lost_envelope(
-                        &client_report_recorder,
-                        &envelope,
-                        LossReason::InternalError,
-                    );
+                    client_report_recorder.record_lost_data(&envelope, LossReason::InternalError);
                 })
                 .expect("envelope should serialize successfully");
             let request = agent
@@ -202,20 +197,12 @@ impl UreqHttpTransport {
                     if (400..=599).contains(&response_status)
                         && response_status != HTTP_RATE_LIMIT_STATUS
                     {
-                        client_report::record_lost_envelope(
-                            &client_report_recorder,
-                            &envelope,
-                            LossReason::SendError,
-                        );
+                        client_report_recorder.record_lost_data(&envelope, LossReason::SendError);
                     }
                 }
                 Err(err) => {
                     sentry_debug!("Failed to send envelope: {}", err);
-                    client_report::record_lost_envelope(
-                        &client_report_recorder,
-                        &envelope,
-                        LossReason::NetworkError,
-                    );
+                    client_report_recorder.record_lost_data(&envelope, LossReason::NetworkError);
                 }
             }
         };


### PR DESCRIPTION
Record lost envelopes in the `ureq` transport after the transport thread accepts them for sending. Ureq request failures are recorded as `network_error`; non-`429` HTTP `4xx`/`5xx` responses are recorded as `send_error`.

Keep existing rate-limit handling for `429` responses and the existing payload-too-large debug message for `413` responses.

Closes [#1153](https://github.com/getsentry/sentry-rust/issues/1153)
Closes [RUST-228](https://linear.app/getsentry/issue/RUST-228)