### PR TITLE
ci: Add compilation check for ESP-IDF targets

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,3 +53,33 @@ jobs:
       - name: Check sentry-actix
         run: cargo check --locked
         working-directory: sentry-actix
+
+  embedded-esp-idf-check:
+    # This checks the `sentry-core` and `sentry` crates on ESP-IDF.
+    name: Check ESP-IDF compile errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust nightly-2026-06-18 toolchain
+        run: rustup toolchain install nightly-2026-06-18 --profile minimal --component rust-src --no-self-update
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Check ESP-IDF compile errors
+        env:
+          MCU: esp32c3
+          ESP_IDF_VERSION: v5.4.3
+          ESP_IDF_TOOLS_INSTALL_DIR: global
+          RUSTFLAGS: -Dwarnings --cfg espidf_time64
+        run: |
+          cargo +nightly-2026-06-18 check \
+            -Zbuild-std=std,panic_abort \
+            -p sentry-core \
+            -p sentry \
+            --target riscv32imc-esp-espidf \
+            --no-default-features \
+            --features sentry/embedded-svc-http \
+            --locked


### PR DESCRIPTION
Closes [#1179](https://github.com/getsentry/sentry-rust/issues/1179)
Closes [RUST-244](https://linear.app/getsentry/issue/RUST-244)
