### PR TITLE
chore(transport): Record std thread client report losses

### DIFF
--- a/sentry-core/src/client/client_reports/inner.rs
+++ b/sentry-core/src/client/client_reports/inner.rs
@@ -11,7 +11,7 @@ use sentry_types::IndexedEnum;
 
 const ARRAY_SIZE: usize = Reason::VARIANTS.len() * Category::VARIANTS.len();
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(super) struct ClientReportAggregatorInner {
     inner: [AtomicU64; ARRAY_SIZE],
     has_reports: AtomicBool,
@@ -83,4 +83,13 @@ fn iter_reason_categories() -> impl Iterator<Item = CategoryReason> {
             .iter()
             .map(move |&reason| CategoryReason { category, reason })
     })
+}
+
+impl Default for ClientReportAggregatorInner {
+    fn default() -> Self {
+        Self {
+            inner: [const { AtomicU64::new(0) }; ARRAY_SIZE],
+            has_reports: Default::default(),
+        }
+    }
 }

--- a/sentry-core/src/client/client_reports/recorder.rs
+++ b/sentry-core/src/client/client_reports/recorder.rs
@@ -27,7 +27,7 @@ use super::ClientReportAggregatorInner;
 /// platforms which lack support for 8-bit and/or 64-bit atomic operations.
 ///
 /// [client report]: https://develop.sentry.dev/sdk/telemetry/client-reports/
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Recorder {
     /// The inner aggregator.
     ///
@@ -71,6 +71,14 @@ pub enum TransportLossReason {
     ///
     /// Converts to [`Reason::NetworkError`].
     NetworkError,
+    /// Used when the SDK is backing off due to a rate limit.
+    ///
+    /// Converts to [`Reason::RatelimitBackoff`]
+    RatelimitBackoff,
+    /// Used when the transport queue overflows.
+    ///
+    /// Converts to [`Reason::QueueOverflow`]
+    QueueOverflow,
 }
 
 impl Recorder {
@@ -136,6 +144,8 @@ impl TransportLossReason {
             Self::SendError => Reason::SendError,
             Self::InternalError => Reason::InternalSdkError,
             Self::NetworkError => Reason::NetworkError,
+            Self::RatelimitBackoff => Reason::RatelimitBackoff,
+            Self::QueueOverflow => Reason::QueueOverflow,
         }
     }
 }

--- a/sentry-types/src/protocol/client_report/mod.rs
+++ b/sentry-types/src/protocol/client_report/mod.rs
@@ -43,6 +43,10 @@ indexed_enum! {
         InternalSdkError,
         /// A network error occurred while sending the envelope.
         NetworkError,
+        /// The SDK is backing off due to a rate limit.
+        RatelimitBackoff,
+        /// An internal queue overflowed (e.g. the transport queue).
+        QueueOverflow,
     }
 
     /// The category of data which was dropped.

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -95,6 +95,8 @@ impl CurlHttpTransport {
 
         let mut handle = client;
 
+        let send_fn_client_report_recorder = client_report_recorder.clone();
+
         let send_fn = move |envelope: Envelope, rl: &mut RateLimiter| {
             handle.reset();
             handle.url(&url).unwrap();
@@ -123,7 +125,8 @@ impl CurlHttpTransport {
             envelope
                 .to_writer(&mut body)
                 .inspect_err(|_| {
-                    client_report_recorder.record_lost_data(&envelope, LossReason::InternalError);
+                    send_fn_client_report_recorder
+                        .record_lost_data(&envelope, LossReason::InternalError);
                 })
                 .expect("envelope should serialize successfully");
             let mut body = Cursor::new(body);
@@ -195,12 +198,13 @@ impl CurlHttpTransport {
                     {
                         // The server returned an HTTP error response, so the envelope was rejected
                         // at the HTTP layer even if curl also reported a transfer error.
-                        client_report_recorder.record_lost_data(&envelope, LossReason::SendError);
+                        send_fn_client_report_recorder
+                            .record_lost_data(&envelope, LossReason::SendError);
                     } else if perform_failed && response_code == 0 {
                         // curl documents `CURLINFO_RESPONSE_CODE` as zero when no server response
                         // code has been received. If `perform` also failed, this means the send
                         // failed before an HTTP status was available, which is a network error.
-                        client_report_recorder
+                        send_fn_client_report_recorder
                             .record_lost_data(&envelope, LossReason::NetworkError);
                     }
                 }
@@ -213,12 +217,14 @@ impl CurlHttpTransport {
                     } else {
                         LossReason::SendError
                     };
-                    client_report_recorder.record_lost_data(&envelope, reason);
+                    send_fn_client_report_recorder.record_lost_data(&envelope, reason);
                 }
             }
         };
 
-        let thread = TransportThreadOptions::new(send_fn).spawn_thread();
+        let thread = TransportThreadOptions::new(send_fn)
+            .with_client_report_recorder(client_report_recorder)
+            .spawn_thread();
         Self { thread }
     }
 }

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -146,7 +146,7 @@ impl RateLimiter {
             },
             |item| {
                 client_report_recorder
-                    .record_lost_envelope_item(&item, ClientReportReason::RatelimitBackoff);
+                    .record_lost_data(&item, ClientReportReason::RatelimitBackoff);
             },
         ))
     }

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -1,4 +1,6 @@
 use httpdate::parse_http_date;
+use sentry_core::client_report::{Reason as ClientReportReason, Recorder as ClientReportRecorder};
+use sentry_core::protocol::EnvelopeFilterCallbacks;
 use std::time::{Duration, SystemTime};
 
 use crate::protocol::EnvelopeItem;
@@ -110,24 +112,43 @@ impl RateLimiter {
     /// Filters the [`Envelope`] according to the current rate limits.
     ///
     /// Returns [`None`] if all the envelope items were filtered out.
+    #[deprecated = "Deprecated with no new public API equivalent."]
     pub fn filter_envelope(&self, envelope: Envelope) -> Option<Envelope> {
-        envelope.filter(|item: &_| {
-            self.is_enabled(match item {
-                EnvelopeItem::Event(_) => RateLimitingCategory::Error,
-                EnvelopeItem::SessionUpdate(_) | EnvelopeItem::SessionAggregates(_) => {
-                    RateLimitingCategory::Session
-                }
-                EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
-                EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
-                EnvelopeItem::ItemContainer(ItemContainer::Logs(_)) => {
-                    RateLimitingCategory::LogItem
-                }
-                EnvelopeItem::ItemContainer(ItemContainer::Metrics(_)) => {
-                    RateLimitingCategory::TraceMetric
-                }
-                _ => RateLimitingCategory::Any,
-            })
-        })
+        self.filter(envelope, &Default::default())
+    }
+
+    /// Filters the [`Envelope`] according to current rate limits, recording any discarded items
+    /// as lost via the client report recorder.
+    ///
+    /// Returns [`None`] if all the envelope items were filtered out.
+    pub(super) fn filter(
+        &self,
+        envelope: Envelope,
+        client_report_recorder: &ClientReportRecorder,
+    ) -> Option<Envelope> {
+        envelope.filter(EnvelopeFilterCallbacks::new(
+            |item: &_| {
+                self.is_enabled(match item {
+                    EnvelopeItem::Event(_) => RateLimitingCategory::Error,
+                    EnvelopeItem::SessionUpdate(_) | EnvelopeItem::SessionAggregates(_) => {
+                        RateLimitingCategory::Session
+                    }
+                    EnvelopeItem::Transaction(_) => RateLimitingCategory::Transaction,
+                    EnvelopeItem::Attachment(_) => RateLimitingCategory::Attachment,
+                    EnvelopeItem::ItemContainer(ItemContainer::Logs(_)) => {
+                        RateLimitingCategory::LogItem
+                    }
+                    EnvelopeItem::ItemContainer(ItemContainer::Metrics(_)) => {
+                        RateLimitingCategory::TraceMetric
+                    }
+                    _ => RateLimitingCategory::Any,
+                })
+            },
+            |item| {
+                client_report_recorder
+                    .record_lost_envelope_item(&item, ClientReportReason::RatelimitBackoff);
+            },
+        ))
     }
 }
 

--- a/sentry/src/transports/thread.rs
+++ b/sentry/src/transports/thread.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use sentry_core::client_report::{Reason as ClientReportReason, Recorder as ClientReportRecorder};
 
-use super::client_report;
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 #[cfg(doc)]
 use super::{StdTransportThread, StdTransportThreadOptions}; // so we can use pub re-exports in docs
@@ -116,11 +115,8 @@ impl TransportThread {
                             "Skipping event send because we're disabled due to rate limits for {}s",
                             time_left.as_secs()
                         );
-                        client_report::record_lost_envelope(
-                            &handle_client_report_recorder,
-                            &envelope,
-                            ClientReportReason::RatelimitBackoff,
-                        );
+                        handle_client_report_recorder
+                            .record_lost_data(&envelope, ClientReportReason::RatelimitBackoff);
                         continue;
                     }
                     match rl.filter(envelope, &handle_client_report_recorder) {
@@ -162,7 +158,8 @@ impl TransportThread {
                 unreachable!("we sent a `SendEnvelope` task");
             };
 
-            client_report::record_lost_envelope(&self.client_report_recorder, &envelope, reason);
+            self.client_report_recorder
+                .record_lost_data(&envelope, reason);
         }
     }
 

--- a/sentry/src/transports/thread.rs
+++ b/sentry/src/transports/thread.rs
@@ -1,9 +1,12 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::mpsc::{sync_channel, SyncSender, TrySendError};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use sentry_core::client_report::{Reason as ClientReportReason, Recorder as ClientReportRecorder};
+
+use super::client_report;
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 #[cfg(doc)]
 use super::{StdTransportThread, StdTransportThreadOptions}; // so we can use pub re-exports in docs
@@ -25,18 +28,31 @@ pub struct TransportThread {
     sender: SyncSender<Task>,
     shutdown: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
+    client_report_recorder: ClientReportRecorder,
 }
 
 /// Options for constructing a [`StdTransportThread`].
 #[must_use]
 pub struct TransportThreadOptions<F> {
     send_fn: F,
+    client_report_recorder: ClientReportRecorder,
 }
 
 impl<F> TransportThreadOptions<F> {
     /// Creates options with the function used to send envelopes.
     pub fn new(send_fn: F) -> Self {
-        Self { send_fn }
+        Self {
+            send_fn,
+            client_report_recorder: Default::default(),
+        }
+    }
+
+    /// Set the [`ClientReportRecorder`] on the options.
+    pub fn with_client_report_recorder(self, client_report_recorder: ClientReportRecorder) -> Self {
+        Self {
+            client_report_recorder,
+            ..self
+        }
     }
 }
 
@@ -67,10 +83,14 @@ impl TransportThread {
     where
         SendFn: FnMut(Envelope, &mut RateLimiter) + Send + 'static,
     {
-        let TransportThreadOptions { send_fn: mut send } = options;
+        let TransportThreadOptions {
+            send_fn: mut send,
+            client_report_recorder,
+        } = options;
         let (sender, receiver) = sync_channel(30);
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_worker = shutdown.clone();
+        let handle_client_report_recorder = client_report_recorder.clone();
         let handle = thread::Builder::new()
             .name("sentry-transport".into())
             .spawn(move || {
@@ -96,9 +116,14 @@ impl TransportThread {
                             "Skipping event send because we're disabled due to rate limits for {}s",
                             time_left.as_secs()
                         );
+                        client_report::record_lost_envelope(
+                            &handle_client_report_recorder,
+                            &envelope,
+                            ClientReportReason::RatelimitBackoff,
+                        );
                         continue;
                     }
-                    match rl.filter_envelope(envelope) {
+                    match rl.filter(envelope, &handle_client_report_recorder) {
                         Some(envelope) => {
                             send(envelope, &mut rl);
                         }
@@ -114,6 +139,7 @@ impl TransportThread {
             sender,
             shutdown,
             handle,
+            client_report_recorder,
         }
     }
 
@@ -126,6 +152,17 @@ impl TransportThread {
         // drop the envelope in that case.
         if let Err(e) = self.sender.try_send(Task::SendEnvelope(envelope)) {
             sentry_debug!("envelope dropped: {e}");
+
+            // Get back the envelope from the TrySendError so we can record it as lost.
+            let (task, reason) = match e {
+                TrySendError::Full(task) => (task, ClientReportReason::QueueOverflow),
+                TrySendError::Disconnected(task) => (task, ClientReportReason::InternalError),
+            };
+            let Task::SendEnvelope(envelope) = task else {
+                unreachable!("we sent a `SendEnvelope` task");
+            };
+
+            client_report::record_lost_envelope(&self.client_report_recorder, &envelope, reason);
         }
     }
 

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -112,6 +112,7 @@ impl TransportThread {
                             );
                             continue;
                         }
+                        #[expect(deprecated, reason = "will fix in future PR")]
                         match rl.filter_envelope(envelope) {
                             Some(envelope) => {
                                 rl = send(envelope, rl).await;

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -150,12 +150,15 @@ impl UreqHttpTransport {
         let auth = dsn.to_auth(Some(&user_agent)).to_string();
         let url = dsn.envelope_api_url().to_string();
 
+        let send_fn_client_report_recorder = client_report_recorder.clone();
+
         let send_fn = move |envelope: Envelope, rl: &mut RateLimiter| {
             let mut body = Vec::new();
             envelope
                 .to_writer(&mut body)
                 .inspect_err(|_| {
-                    client_report_recorder.record_lost_data(&envelope, LossReason::InternalError);
+                    send_fn_client_report_recorder
+                        .record_lost_data(&envelope, LossReason::InternalError);
                 })
                 .expect("envelope should serialize successfully");
             let request = agent
@@ -197,17 +200,21 @@ impl UreqHttpTransport {
                     if (400..=599).contains(&response_status)
                         && response_status != HTTP_RATE_LIMIT_STATUS
                     {
-                        client_report_recorder.record_lost_data(&envelope, LossReason::SendError);
+                        send_fn_client_report_recorder
+                            .record_lost_data(&envelope, LossReason::SendError);
                     }
                 }
                 Err(err) => {
                     sentry_debug!("Failed to send envelope: {}", err);
-                    client_report_recorder.record_lost_data(&envelope, LossReason::NetworkError);
+                    send_fn_client_report_recorder
+                        .record_lost_data(&envelope, LossReason::NetworkError);
                 }
             }
         };
 
-        let thread = TransportThreadOptions::new(send_fn).spawn_thread();
+        let thread = TransportThreadOptions::new(send_fn)
+            .with_client_report_recorder(client_report_recorder)
+            .spawn_thread();
         Self { thread }
     }
 }


### PR DESCRIPTION
Record envelopes dropped before the curl and ureq HTTP transports see them. The std transport thread now reports queue overflow, disconnected worker, and rate-limit drops through the client report recorder.

Shutdown losses remain unreported because shutdown ends the opportunity to send another envelope carrying the aggregated client report.

Fixes [#1149](https://github.com/getsentry/sentry-rust/issues/1149)
Fixes [RUST-224](https://linear.app/getsentry/issue/RUST-224)