### PR TITLE
chore(transport): Record tokio thread client report losses

### DIFF
--- a/sentry/src/transports/reqwest.rs
+++ b/sentry/src/transports/reqwest.rs
@@ -122,17 +122,20 @@ impl ReqwestHttpTransport {
         let auth = dsn.to_auth(Some(&user_agent)).to_string();
         let url = dsn.envelope_api_url().to_string();
 
+        let send_fn_client_report_recorder = client_report_recorder.clone();
+
         let send_fn = move |envelope: Envelope, mut rl: RateLimiter| {
             let mut body = Vec::new();
             envelope
                 .to_writer(&mut body)
                 .inspect_err(|_| {
-                    client_report_recorder.record_lost_data(&envelope, LossReason::InternalError);
+                    send_fn_client_report_recorder
+                        .record_lost_data(&envelope, LossReason::InternalError);
                 })
                 .expect("envelope should serialize successfully");
             let request = client.post(&url).header("X-Sentry-Auth", &auth).body(body);
 
-            let client_report_recorder = client_report_recorder.clone();
+            let client_report_recorder = send_fn_client_report_recorder.clone();
 
             // NOTE: because of lifetime issues, building the request using the
             // `client` has to happen outside of this async block.
@@ -187,7 +190,9 @@ impl ReqwestHttpTransport {
             }
         };
 
-        let thread = TransportThreadOptions::new(send_fn).spawn_thread();
+        let thread = TransportThreadOptions::new(send_fn)
+            .with_client_report_recorder(client_report_recorder)
+            .spawn_thread();
         Self { thread }
     }
 }

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use sentry_core::client_report::{Reason as ClientReportReason, Recorder as ClientReportRecorder};
 
-use super::client_report;
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 #[cfg(doc)]
 use super::{TokioTransportThread, TokioTransportThreadOptions}; // so we can use pub re-exports in docs
@@ -130,11 +129,8 @@ impl TransportThread {
                                 "Skipping event send because we're disabled due to rate limits for {}s",
                                 time_left.as_secs()
                             );
-                            client_report::record_lost_envelope(
-                                &handle_client_report_recorder,
-                                &envelope,
-                                ClientReportReason::RatelimitBackoff,
-                            );
+                            handle_client_report_recorder
+                                .record_lost_data(&envelope, ClientReportReason::RatelimitBackoff);
                             continue;
                         }
                         match rl.filter(envelope, &handle_client_report_recorder) {
@@ -177,7 +173,8 @@ impl TransportThread {
                 unreachable!("we sent a `SendEnvelope` task");
             };
 
-            client_report::record_lost_envelope(&self.client_report_recorder, &envelope, reason);
+            self.client_report_recorder
+                .record_lost_data(&envelope, reason);
         }
     }
 

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -1,9 +1,12 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::mpsc::{sync_channel, SyncSender, TrySendError};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
+use sentry_core::client_report::{Reason as ClientReportReason, Recorder as ClientReportRecorder};
+
+use super::client_report;
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 #[cfg(doc)]
 use super::{TokioTransportThread, TokioTransportThreadOptions}; // so we can use pub re-exports in docs
@@ -25,18 +28,31 @@ pub struct TransportThread {
     sender: SyncSender<Task>,
     shutdown: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
+    client_report_recorder: ClientReportRecorder,
 }
 
 /// Options for constructing a [`TokioTransportThread`].
 #[must_use]
 pub struct TransportThreadOptions<F> {
     send_fn: F,
+    client_report_recorder: ClientReportRecorder,
 }
 
 impl<F> TransportThreadOptions<F> {
     /// Creates options with the function used to send envelopes.
     pub fn new(send_fn: F) -> Self {
-        Self { send_fn }
+        Self {
+            send_fn,
+            client_report_recorder: Default::default(),
+        }
+    }
+
+    /// Set the [`ClientReportRecorder`] on the options.
+    pub fn with_client_report_recorder(self, client_report_recorder: ClientReportRecorder) -> Self {
+        Self {
+            client_report_recorder,
+            ..self
+        }
     }
 }
 
@@ -73,10 +89,14 @@ impl TransportThread {
         // NOTE: return RateLimiter to avoid lifetime issues with mutable borrowing across await.
         SendFuture: std::future::Future<Output = RateLimiter>,
     {
-        let TransportThreadOptions { send_fn: mut send } = options;
+        let TransportThreadOptions {
+            send_fn: mut send,
+            client_report_recorder,
+        } = options;
         let (sender, receiver) = sync_channel(30);
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_worker = shutdown.clone();
+        let handle_client_report_recorder = client_report_recorder.clone();
         let handle = thread::Builder::new()
             .name("sentry-transport".into())
             .spawn(move || {
@@ -105,21 +125,25 @@ impl TransportThread {
                             }
                         };
 
-                        if let Some(time_left) =  rl.is_disabled(RateLimitingCategory::Any) {
+                        if let Some(time_left) = rl.is_disabled(RateLimitingCategory::Any) {
                             sentry_debug!(
                                 "Skipping event send because we're disabled due to rate limits for {}s",
                                 time_left.as_secs()
                             );
+                            client_report::record_lost_envelope(
+                                &handle_client_report_recorder,
+                                &envelope,
+                                ClientReportReason::RatelimitBackoff,
+                            );
                             continue;
                         }
-                        #[expect(deprecated, reason = "will fix in future PR")]
-                        match rl.filter_envelope(envelope) {
+                        match rl.filter(envelope, &handle_client_report_recorder) {
                             Some(envelope) => {
                                 rl = send(envelope, rl).await;
-                            },
+                            }
                             None => {
                                 sentry_debug!("Envelope was discarded due to per-item rate limits");
-                            },
+                            }
                         };
                     }
                 })
@@ -130,6 +154,7 @@ impl TransportThread {
             sender,
             shutdown,
             handle,
+            client_report_recorder,
         }
     }
 
@@ -142,6 +167,17 @@ impl TransportThread {
         // drop the envelope in that case.
         if let Err(e) = self.sender.try_send(Task::SendEnvelope(envelope)) {
             sentry_debug!("envelope dropped: {e}");
+
+            // Get back the envelope from the TrySendError so we can record it as lost.
+            let (task, reason) = match e {
+                TrySendError::Full(task) => (task, ClientReportReason::QueueOverflow),
+                TrySendError::Disconnected(task) => (task, ClientReportReason::InternalError),
+            };
+            let Task::SendEnvelope(envelope) = task else {
+                unreachable!("we sent a `SendEnvelope` task");
+            };
+
+            client_report::record_lost_envelope(&self.client_report_recorder, &envelope, reason);
         }
     }
 


### PR DESCRIPTION
Record envelopes dropped before the reqwest HTTP transport sees them. The tokio transport thread now reports queue overflow, disconnected worker, and rate-limit drops through the client report recorder.

Shutdown losses remain unreported because shutdown ends the opportunity to send another envelope carrying the aggregated client report.

Fixes [#1150](https://github.com/getsentry/sentry-rust/issues/1150)
Fixes [RUST-225](https://linear.app/getsentry/issue/RUST-225)