### PR TITLE
chore(client-reports): Record event pipeline drops

### DIFF
--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -8,8 +8,9 @@
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use std::sync::Arc;
 
+use sentry_types::protocol::v7::client_report::{Category, Reason};
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
-use sentry_types::protocol::v7::client_report::{Category, ItemLoss, LossSource, Reason};
+use sentry_types::protocol::v7::client_report::{ItemLoss, LossSource};
 use sentry_types::protocol::v7::ClientReport;
 
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -66,9 +66,12 @@ impl ClientReportAggregator {
     /// This method updates aggregate counters only. The loss is not sent until a later call to
     /// [`Self::take_pending_report`] drains the counters and returns a [`ClientReport`] for an
     /// outgoing envelope. A `quantity` of zero is ignored.
-    #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
     pub(crate) fn record_loss(&self, category: Category, reason: Reason, quantity: u64) {
+        #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
         self.inner.record_loss(category, reason, quantity);
+
+        #[cfg(not(all(target_has_atomic = "64", target_has_atomic = "8")))]
+        let _ = (category, reason, quantity);
     }
 
     /// Drains recorded losses into a [`ClientReport`].

--- a/sentry-core/src/client/envelope_sender.rs
+++ b/sentry-core/src/client/envelope_sender.rs
@@ -7,6 +7,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use sentry_types::protocol::v7::client_report::{
+    Category as ClientReportCategory, Reason as ClientReportReason,
+};
 use sentry_types::protocol::v7::EnvelopeItem;
 
 use self::slot::TransportSlot;
@@ -75,6 +78,17 @@ impl EnvelopeSender {
             transport_slot,
             client_report_aggregator,
         }
+    }
+
+    /// Records `quantity` lost items for `category` and `reason`.
+    pub(super) fn record_loss(
+        &self,
+        category: ClientReportCategory,
+        reason: ClientReportReason,
+        quantity: u64,
+    ) {
+        self.client_report_aggregator
+            .record_loss(category, reason, quantity);
     }
 
     /// Flushes the transport if it is still available.

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -15,6 +15,9 @@ use crate::metrics::IntoProtocolMetric;
 use crate::protocol::SessionUpdate;
 use crate::transport::TransportOptions;
 use rand::random;
+use sentry_types::protocol::v7::client_report::{
+    Category as ClientReportCategory, Reason as ClientReportReason,
+};
 use sentry_types::random_uuid;
 
 #[cfg(any(feature = "logs", feature = "metrics"))]
@@ -333,7 +336,13 @@ impl Client {
         }
 
         if let Some(scope) = scope {
-            event = scope.apply_to_event(event)?;
+            event = match scope.apply_to_event(event) {
+                Some(event) => event,
+                None => {
+                    self.record_lost_event(ClientReportReason::EventProcessor);
+                    return None;
+                }
+            };
         }
 
         for (_, integration) in self.integrations.iter() {
@@ -342,6 +351,7 @@ impl Client {
                 Some(event) => event,
                 None => {
                     sentry_debug!("integration dropped event {:?}", id);
+                    self.record_lost_event(ClientReportReason::EventProcessor);
                     return None;
                 }
             }
@@ -367,6 +377,7 @@ impl Client {
                 event = processed_event;
             } else {
                 sentry_debug!("before_send dropped event {:?}", id);
+                self.record_lost_event(ClientReportReason::BeforeSend);
                 return None;
             }
         }
@@ -376,6 +387,7 @@ impl Client {
         }
 
         if !self.sample_should_send(self.options.sample_rate) {
+            self.record_lost_event(ClientReportReason::SampleRate);
             None
         } else {
             Some(event)
@@ -453,6 +465,21 @@ impl Client {
             })
         });
         event_id
+    }
+
+    /// Records `quantity` lost items for `category` and `reason`.
+    fn record_loss(
+        &self,
+        category: ClientReportCategory,
+        reason: ClientReportReason,
+        quantity: u64,
+    ) {
+        self.envelope_sender.record_loss(category, reason, quantity);
+    }
+
+    /// Records one lost error event for `reason`.
+    fn record_lost_event(&self, reason: ClientReportReason) {
+        self.record_loss(ClientReportCategory::Error, reason, 1);
     }
 
     /// Sends the specified [`Envelope`] to sentry.

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -484,7 +484,9 @@ mod session_impl {
             } else {
                 panic!("expected session");
             }
-            assert_eq!(items.next(), None);
+            // A client report gets captured for the dropped event.
+            assert!(matches!(items.next(), Some(EnvelopeItem::ClientReport(_))));
+            assert!(items.next().is_none());
         }
 
         #[test]
@@ -566,7 +568,12 @@ mod session_impl {
             } else {
                 panic!("expected session");
             }
-            assert_eq!(items.next(), None);
+            // The envelope may or may not contain a client report.
+            assert!(matches!(
+                items.next(),
+                None | Some(EnvelopeItem::ClientReport(_))
+            ));
+            assert!(items.next().is_none());
         }
 
         /// For _user-mode_ sessions, we want to inherit the session for any _new_

--- a/sentry-core/tests/client_reports.rs
+++ b/sentry-core/tests/client_reports.rs
@@ -1,0 +1,118 @@
+#![cfg(feature = "test")]
+
+use std::sync::Arc;
+
+use sentry_core::protocol::client_report::Reason;
+use sentry_core::protocol::{EnvelopeItem, Event};
+use sentry_core::test::TestTransport;
+use sentry_core::{Client, ClientOptions, Envelope, Integration, Scope};
+
+struct DroppingIntegration;
+
+impl Integration for DroppingIntegration {
+    fn process_event(
+        &self,
+        _event: Event<'static>,
+        _options: &ClientOptions,
+    ) -> Option<Event<'static>> {
+        None
+    }
+}
+
+fn client_with_options(transport: Arc<TestTransport>, options: ClientOptions) -> Client {
+    Client::with_options(ClientOptions {
+        dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
+        transport: Some(Arc::new(transport)),
+        ..options
+    })
+}
+
+fn assert_client_report(envelope: &Envelope, reason: Reason) {
+    let client_report = envelope
+        .items()
+        .find_map(|item| match item {
+            EnvelopeItem::ClientReport(report) => Some(report),
+            _ => None,
+        })
+        .expect("envelope should contain a client report");
+
+    let value = serde_json::to_value(client_report).unwrap();
+    assert_eq!(
+        value["discarded_events"],
+        serde_json::json!([{ "category": "error", "reason": reason, "quantity": 1 }])
+    );
+}
+
+fn assert_drop_records_client_report<F>(options: ClientOptions, capture: F, reason: Reason)
+where
+    F: FnOnce(&Client),
+{
+    let transport = TestTransport::new();
+    let client = client_with_options(transport.clone(), options);
+
+    capture(&client);
+    client.send_envelope(Envelope::new());
+
+    let envelopes = transport.fetch_and_clear_envelopes();
+    assert_eq!(envelopes.len(), 1);
+    assert_client_report(&envelopes[0], reason);
+}
+
+#[test]
+fn client_report_records_scope_event_processor_drop() {
+    let mut scope = Scope::default();
+    scope.add_event_processor(|_| None);
+
+    assert_drop_records_client_report(
+        ClientOptions::default(),
+        |client| {
+            client.capture_event(Event::default(), Some(&scope));
+        },
+        Reason::EventProcessor,
+    );
+}
+
+#[test]
+fn client_report_records_integration_event_processor_drop() {
+    let options = ClientOptions::new().add_integration(DroppingIntegration);
+
+    assert_drop_records_client_report(
+        options,
+        |client| {
+            client.capture_event(Event::default(), None);
+        },
+        Reason::EventProcessor,
+    );
+}
+
+#[test]
+fn client_report_records_before_send_drop() {
+    let options = ClientOptions {
+        before_send: Some(Arc::new(|_| None)),
+        ..Default::default()
+    };
+
+    assert_drop_records_client_report(
+        options,
+        |client| {
+            client.capture_event(Event::default(), None);
+        },
+        Reason::BeforeSend,
+    );
+}
+
+#[test]
+fn client_report_records_sample_rate_drop() {
+    let options = ClientOptions {
+        sample_rate: 0.0,
+        ..Default::default()
+    };
+
+    assert_drop_records_client_report(
+        options,
+        |client| {
+            client.capture_event(Event::default(), None);
+        },
+        Reason::SampleRate,
+    );
+}

--- a/sentry-types/src/protocol/client_report/mod.rs
+++ b/sentry-types/src/protocol/client_report/mod.rs
@@ -47,6 +47,12 @@ indexed_enum! {
         RatelimitBackoff,
         /// An internal queue overflowed (e.g. the transport queue).
         QueueOverflow,
+        /// An event was dropped by an event processor.
+        EventProcessor,
+        /// An event was dropped by a `before_send` callback.
+        BeforeSend,
+        /// An event was dropped because of error event sampling.
+        SampleRate,
     }
 
     /// The category of data which was dropped.


### PR DESCRIPTION
Record SDK-side error event drops in client reports for the event pipeline paths that can discard events before they reach transport. Scope processors and integration processors now report `event_processor`, `before_send` reports `before_send`, and error event sampling reports `sample_rate`.

Add integration coverage that verifies each drop path is attached to the next outgoing envelope as a client report.

Fixes [#1187](https://github.com/getsentry/sentry-rust/issues/1187)
Fixes [RUST-246](https://linear.app/getsentry/issue/RUST-246)