### PR TITLE
chore(client-reports): Prevent client report loss when envelope dropped

### DIFF
--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -59,8 +59,15 @@ impl ClientReportAggregator {
         #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
         data.losses().for_each(|loss| {
             let ItemLoss {
-                category, quantity, ..
+                category,
+                quantity,
+                reason: reason_override,
+                ..
             } = loss;
+
+            // If a reason was already set, use that reason. Otherwise, use the reason supplied
+            // when this function was called.
+            let reason = reason_override.unwrap_or(reason);
             self.record_loss(category, reason, quantity)
         });
         #[cfg(not(all(target_has_atomic = "64", target_has_atomic = "8")))]

--- a/sentry-types/src/protocol/client_report/envelope_losses.rs
+++ b/sentry-types/src/protocol/client_report/envelope_losses.rs
@@ -1,13 +1,14 @@
 //! Computes client report loss categories and quantities for dropped envelope items.
 
 use std::mem;
+use std::slice::Iter as SliceIter;
 
 use crate::protocol::v7::{
     Attachment, ClientReport, Envelope, EnvelopeItem, Event, ItemContainer, Log, Metric,
     MonitorCheckIn, SessionAggregateItem, SessionAggregates, SessionUpdate, Span, Transaction,
 };
 
-use super::{relay_size, Category};
+use super::{relay_size, Category, Item as ClientReportItem, Reason};
 
 /// A trait for protocol types which can be a source of lost Sentry data if discarded.
 pub trait LossSource: private::Sealed {
@@ -28,6 +29,11 @@ pub struct ItemLoss {
     pub category: Category,
     /// The number of lost items or bytes, depending on the category.
     pub quantity: u64,
+    /// In the case where this [`ItemLoss`] comes from a [`ClientReport`] which failed to get sent,
+    /// the reason why this item was lost per that original client report.
+    ///
+    /// This field remains [`None`] for items which are being lost now for the first time.
+    pub reason: Option<Reason>,
 }
 
 impl LossSource for Envelope {
@@ -38,14 +44,15 @@ impl LossSource for Envelope {
 
 /// An iterator over up to two [`ItemLoss`] values for a discarded protocol item.
 #[derive(Default)]
-enum ItemLossIter {
+enum ItemLossIter<'a> {
     #[default]
     Empty,
     One(ItemLoss),
     Two(ItemLoss, ItemLoss),
+    ClientReportItems(SliceIter<'a, ClientReportItem>),
 }
 
-impl Iterator for ItemLossIter {
+impl Iterator for ItemLossIter<'_> {
     type Item = ItemLoss;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -53,6 +60,10 @@ impl Iterator for ItemLossIter {
             Self::Empty => (None, Self::Empty),
             Self::One(info) => (Some(info), Self::Empty),
             Self::Two(info1, info2) => (Some(info1), Self::One(info2)),
+            Self::ClientReportItems(mut iter) => (
+                iter.next().copied().map(Into::into),
+                Self::ClientReportItems(iter),
+            ),
         };
 
         *self = next;
@@ -148,7 +159,7 @@ impl LossSource for [ItemLoss] {
 }
 
 /// Returns an iterator over the lost items in an envelope item, if it is dropped.
-fn envelope_item_losses(envelope_item: &EnvelopeItem) -> ItemLossIter {
+fn envelope_item_losses(envelope_item: &EnvelopeItem) -> ItemLossIter<'_> {
     match envelope_item {
         EnvelopeItem::Event(event) => event_losses(event),
         EnvelopeItem::SessionUpdate(update) => session_update_losses(update),
@@ -165,18 +176,18 @@ fn envelope_item_losses(envelope_item: &EnvelopeItem) -> ItemLossIter {
 }
 
 /// Returns error-event losses for a discarded event.
-fn event_losses(_event: &Event<'_>) -> ItemLossIter {
+fn event_losses(_event: &Event<'_>) -> ItemLossIter<'static> {
     ItemLossIter::new([ItemLoss::new(Category::Error, 1)])
 }
 
 /// Returns session losses for a discarded session update.
-fn session_update_losses(_update: &SessionUpdate<'_>) -> ItemLossIter {
+fn session_update_losses(_update: &SessionUpdate<'_>) -> ItemLossIter<'static> {
     ItemLossIter::new([ItemLoss::new(Category::Session, 1)])
 }
 
 /// Returns session losses from aggregate bucket status counts.
 /// The quantity is the saturated sum of exited, errored, abnormal, and crashed sessions.
-fn session_aggregate_losses(session_aggregates: &SessionAggregates<'_>) -> ItemLossIter {
+fn session_aggregate_losses(session_aggregates: &SessionAggregates<'_>) -> ItemLossIter<'static> {
     let quantity = session_aggregates
         .aggregates
         .iter()
@@ -199,7 +210,7 @@ fn session_aggregate_losses(session_aggregates: &SessionAggregates<'_>) -> ItemL
 
 /// Returns one transaction loss and the span losses for a transaction item.
 /// Span quantity includes the transaction root span plus all child spans.
-fn transaction_losses(transaction: &Transaction<'_>) -> ItemLossIter {
+fn transaction_losses(transaction: &Transaction<'_>) -> ItemLossIter<'static> {
     ItemLossIter::new([
         ItemLoss::new(Category::Transaction, 1),
         ItemLoss::new(
@@ -216,7 +227,7 @@ fn transaction_losses(transaction: &Transaction<'_>) -> ItemLossIter {
 
 /// Returns attachment losses measured by serialized payload bytes.
 /// The quantity is the attachment buffer length, saturated to `u64::MAX`.
-fn attachment_losses(attachment: &Attachment) -> ItemLossIter {
+fn attachment_losses(attachment: &Attachment) -> ItemLossIter<'static> {
     ItemLossIter::new([ItemLoss::new(
         Category::Attachment,
         attachment.buffer.len().try_into().unwrap_or(u64::MAX),
@@ -224,20 +235,25 @@ fn attachment_losses(attachment: &Attachment) -> ItemLossIter {
 }
 
 /// Returns monitor losses for a discarded check-in.
-fn monitor_check_in_losses(_check_in: &MonitorCheckIn) -> ItemLossIter {
+fn monitor_check_in_losses(_check_in: &MonitorCheckIn) -> ItemLossIter<'static> {
     ItemLossIter::new([ItemLoss::new(Category::Monitor, 1)])
 }
 
-/// Returns no losses for a discarded client report.
+/// Returns the losses for a discarded client report.
 ///
-/// Client reports are never themselves recorded as losses.
-fn client_report_losses(_client_report: &ClientReport) -> ItemLossIter {
-    ItemLossIter::new([])
+/// Client reports are never themselves recorded as losses; however, all the items recorded as
+/// losses within the client report are themselves considered as losses because they likely have
+/// not successfully been reported yet if the client report is being dropped.
+///
+/// Unlike losses for other types, these losses will also contain a reason: that reason is the
+/// loss reason originally recorded for the loss.
+fn client_report_losses(client_report: &ClientReport) -> ItemLossIter<'_> {
+    ItemLossIter::new(client_report.discarded_events.as_ref().iter())
 }
 
 /// Returns losses for the container's item kind.
 /// Each container variant maps to the category and quantity used by Relay.
-fn item_container_losses(item_container: &ItemContainer) -> ItemLossIter {
+fn item_container_losses(item_container: &ItemContainer) -> ItemLossIter<'static> {
     match item_container {
         ItemContainer::Logs(logs) => log_losses(logs),
         ItemContainer::Metrics(metrics) => metric_losses(metrics),
@@ -245,7 +261,7 @@ fn item_container_losses(item_container: &ItemContainer) -> ItemLossIter {
 }
 
 /// Returns log losses measured by item count and Relay-compatible content size.
-fn log_losses(logs: &[Log]) -> ItemLossIter {
+fn log_losses(logs: &[Log]) -> ItemLossIter<'static> {
     let item_quantity = logs.len().try_into().unwrap_or(u64::MAX);
     let byte_quantity = logs.iter().fold(0u64, |sum, log| {
         sum.saturating_add(relay_size::log_byte_size(log))
@@ -258,7 +274,7 @@ fn log_losses(logs: &[Log]) -> ItemLossIter {
 }
 
 /// Returns trace metric losses measured by item count and Relay-compatible content size.
-fn metric_losses(metrics: &[Metric]) -> ItemLossIter {
+fn metric_losses(metrics: &[Metric]) -> ItemLossIter<'static> {
     let item_quantity = metrics.len().try_into().unwrap_or(u64::MAX);
     let byte_quantity = metrics.iter().fold(0u64, |sum, metric| {
         sum.saturating_add(relay_size::metric_byte_size(metric))
@@ -271,11 +287,11 @@ fn metric_losses(metrics: &[Metric]) -> ItemLossIter {
 }
 
 /// A span always results in a loss of a single span.
-fn span_losses(_span: &Span) -> ItemLossIter {
+fn span_losses(_span: &Span) -> ItemLossIter<'static> {
     ItemLossIter::new([ItemLoss::new(Category::Span, 1)])
 }
 
-impl ItemLossIter {
+impl ItemLossIter<'_> {
     /// Creates an iterator from zero, one, or two [`ItemLoss`] values.
     fn new<T>(value: T) -> Self
     where
@@ -288,27 +304,54 @@ impl ItemLossIter {
 impl ItemLoss {
     /// Creates a new item loss with the given category and quantity.
     fn new(category: Category, quantity: u64) -> Self {
-        Self { category, quantity }
+        Self {
+            category,
+            quantity,
+            reason: None,
+        }
+    }
+
+    /// Sets a reason on the [`ItemLoss`].
+    fn with_reason(self, reason: Reason) -> Self {
+        let reason = Some(reason);
+        Self { reason, ..self }
     }
 }
 
-impl From<[ItemLoss; 0]> for ItemLossIter {
+impl From<[ItemLoss; 0]> for ItemLossIter<'static> {
     fn from(_: [ItemLoss; 0]) -> Self {
         Self::Empty
     }
 }
 
-impl From<[ItemLoss; 1]> for ItemLossIter {
+impl From<[ItemLoss; 1]> for ItemLossIter<'static> {
     fn from(value: [ItemLoss; 1]) -> Self {
         let [info] = value;
         Self::One(info)
     }
 }
 
-impl From<[ItemLoss; 2]> for ItemLossIter {
+impl From<[ItemLoss; 2]> for ItemLossIter<'static> {
     fn from(value: [ItemLoss; 2]) -> Self {
         let [info1, info2] = value;
         Self::Two(info1, info2)
+    }
+}
+
+impl<'a> From<SliceIter<'a, ClientReportItem>> for ItemLossIter<'a> {
+    fn from(value: SliceIter<'a, ClientReportItem>) -> Self {
+        Self::ClientReportItems(value)
+    }
+}
+
+impl From<ClientReportItem> for ItemLoss {
+    fn from(value: ClientReportItem) -> Self {
+        let ClientReportItem {
+            category,
+            reason,
+            quantity,
+        } = value;
+        Self::new(category, quantity).with_reason(reason)
     }
 }
 

--- a/sentry-types/src/protocol/client_report/envelope_losses.rs
+++ b/sentry-types/src/protocol/client_report/envelope_losses.rs
@@ -1,13 +1,13 @@
 //! Computes client report loss categories and quantities for dropped envelope items.
 
 use std::mem;
-use std::slice::Iter as SliceIter;
 
 use crate::protocol::v7::{
     Attachment, ClientReport, Envelope, EnvelopeItem, Event, ItemContainer, Log, Metric,
     MonitorCheckIn, SessionAggregateItem, SessionAggregates, SessionUpdate, Span, Transaction,
 };
 
+use super::list::Iter as ClientReportItemIter;
 use super::{relay_size, Category, Item as ClientReportItem, Reason};
 
 /// A trait for protocol types which can be a source of lost Sentry data if discarded.
@@ -49,7 +49,7 @@ enum ItemLossIter<'a> {
     Empty,
     One(ItemLoss),
     Two(ItemLoss, ItemLoss),
-    ClientReportItems(SliceIter<'a, ClientReportItem>),
+    ClientReportItems(ClientReportItemIter<'a>),
 }
 
 impl Iterator for ItemLossIter<'_> {
@@ -248,7 +248,7 @@ fn monitor_check_in_losses(_check_in: &MonitorCheckIn) -> ItemLossIter<'static> 
 /// Unlike losses for other types, these losses will also contain a reason: that reason is the
 /// loss reason originally recorded for the loss.
 fn client_report_losses(client_report: &ClientReport) -> ItemLossIter<'_> {
-    ItemLossIter::new(client_report.discarded_events.as_ref().iter())
+    ItemLossIter::new(client_report.discarded_events.iter())
 }
 
 /// Returns losses for the container's item kind.
@@ -338,8 +338,8 @@ impl From<[ItemLoss; 2]> for ItemLossIter<'static> {
     }
 }
 
-impl<'a> From<SliceIter<'a, ClientReportItem>> for ItemLossIter<'a> {
-    fn from(value: SliceIter<'a, ClientReportItem>) -> Self {
+impl<'a> From<ClientReportItemIter<'a>> for ItemLossIter<'a> {
+    fn from(value: ClientReportItemIter<'a>) -> Self {
         Self::ClientReportItems(value)
     }
 }

--- a/sentry-types/src/protocol/client_report/list.rs
+++ b/sentry-types/src/protocol/client_report/list.rs
@@ -1,5 +1,7 @@
 //! Module with code for representing the underlying list of client reports.
 
+use std::slice::Iter as SliceIter;
+
 use serde::{Deserialize, Serialize};
 
 use super::{Category, Reason};
@@ -22,7 +24,15 @@ pub struct Item {
 #[serde(transparent)]
 pub(super) struct ClientReportList(Vec<Item>);
 
+/// An iterator over items in a client report list.
+pub(super) struct Iter<'a>(SliceIter<'a, Item>);
+
 impl ClientReportList {
+    /// Get an iterator over the items in this list.
+    pub(super) fn iter(&self) -> Iter<'_> {
+        Iter(self.0.iter())
+    }
+
     /// Private helper used in [`PartialEq`] implementation to make comparisions order-insensitive.
     ///
     /// This function aggregates all the counts into an array, where each item in the array
@@ -77,9 +87,11 @@ impl PartialEq for ClientReportList {
     }
 }
 
-impl AsRef<[Item]> for ClientReportList {
-    fn as_ref(&self) -> &[Item] {
-        &self.0
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
     }
 }
 

--- a/sentry-types/src/protocol/client_report/list.rs
+++ b/sentry-types/src/protocol/client_report/list.rs
@@ -11,11 +11,11 @@ const POSSIBLE_CATEGORY_REASONS: usize = Category::VARIANTS.len() * Reason::VARI
 /// An entry in a client report.
 ///
 /// Contains the quantity dropped for a certain category and reason.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Copy)]
 pub struct Item {
-    category: Category,
-    reason: Reason,
-    quantity: u64,
+    pub(super) category: Category,
+    pub(super) reason: Reason,
+    pub(super) quantity: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,6 +74,12 @@ impl FromIterator<Item> for ClientReportList {
 impl PartialEq for ClientReportList {
     fn eq(&self, other: &Self) -> bool {
         self.aggregate() == other.aggregate()
+    }
+}
+
+impl AsRef<[Item]> for ClientReportList {
+    fn as_ref(&self) -> &[Item] {
+        &self.0
     }
 }
 


### PR DESCRIPTION
Prevent client report data from being lost when an envelope containing a client report is dropped by adding all losses from the lost client report back into the aggregator. This ensures that the next outgoing envelope will include the loss data.

This change fixes some undesirable behavior I discovered while manually testing client reports: if the transport queue overflows when sending an error, we record a lost error event. If we then immediately try to send another error, that envelope will pick up the loss, draining it from the aggregator, but if the queue is still full, that envelope will also get lost with the client report. We will record the lost error event from the second envelope, but without this change, we would not include the loss from the first envelope. If we consider the case where many envelopes get sent in rapid succession and overflow the queue, we could end up with a severe undercount of reported losses as a result.
