### PR TITLE
docs(types): Update Envelope filter docs

### DIFF
--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -518,10 +518,9 @@ impl Envelope {
         })
     }
 
-    /// Filters the Envelope's [`EnvelopeItem`]s based on a predicate,
+    /// Filters the Envelope's [`EnvelopeItem`]s with an [`EnvelopeFilter`],
     /// and returns a new Envelope containing only the filtered items.
     ///
-    /// Retains the [`EnvelopeItem`]s for which the predicate returns `true`.
     /// Additionally, [`EnvelopeItem::Attachment`]s are only kept if the Envelope
     /// contains an [`EnvelopeItem::Event`] or [`EnvelopeItem::Transaction`].
     ///


### PR DESCRIPTION
Refer to `EnvelopeFilter` from `Envelope::filter` docs now that filtering is configured through the trait instead of only a predicate callback.