### PR TITLE
feat(options): Add `org_id` and `strict_trace_continuation` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### New Features
 
 - Added [`Dsn::org_id`](https://docs.rs/sentry-types/latest/sentry_types/struct.Dsn.html#method.org_id), which parses the Sentry SaaS organization ID from DSN hosts such as `o123.ingest.sentry.io` ([#1202](https://github.com/getsentry/sentry-rust/pull/1202)).
+- Added [`ClientOptions::org_id`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#method.org_id) and [`ClientOptions::strict_trace_continuation`](https://docs.rs/sentry-core/latest/sentry_core/struct.ClientOptions.html#method.strict_trace_continuation) ([#1203](https://github.com/getsentry/sentry-rust/pull/1203)). These options control how traces are continued and can help prevent traces from third-party services, which happen to be instrumented with Sentry, from being continued.
 
 ### Fixes
 

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -145,17 +145,6 @@ pub struct ClientOptions {
     ///
     /// See [`dsn`](method@ClientOptions::dsn) for details.
     pub dsn: Option<Dsn>,
-    /// The Sentry organization ID used for trace continuation decisions.
-    ///
-    /// The SDK can derive this value automatically from Sentry SaaS DSNs. Set this explicitly for
-    /// DSNs whose organization ID cannot be inferred, mainly self-hosted Sentry and local Relay
-    /// setups.
-    pub org_id: Option<OrganizationId>,
-    /// Enables strict trace continuation.
-    ///
-    /// When enabled, the SDK will only continue incoming traces whose organization ID matches this
-    /// SDK's organization ID.
-    pub strict_trace_continuation: bool,
     /// Enables debug mode.
     ///
     /// See [`debug`](method@ClientOptions::debug) for details.
@@ -179,6 +168,15 @@ pub struct ClientOptions {
     /// [`traces_sampler`](method@ClientOptions::traces_sampler), or can be left at the default
     /// disabled value.
     pub traces_sampling_strategy: TracesSamplingStrategy,
+    /// The organization ID used for trace continuation.
+    ///
+    /// See [`org_id`](method@ClientOptions::org_id) for details.
+    pub org_id: Option<OrganizationId>,
+    /// Enables strict trace continuation.
+    ///
+    /// See [`strict_trace_continuation`](method@ClientOptions::strict_trace_continuation) for
+    /// details.
+    pub strict_trace_continuation: bool,
     /// Maximum number of breadcrumbs.
     ///
     /// See [`max_breadcrumbs`](method@ClientOptions::max_breadcrumbs) for details.
@@ -412,6 +410,38 @@ impl ClientOptions {
 
         Self {
             traces_sampling_strategy,
+            ..self
+        }
+    }
+
+    /// Sets the [organization ID](field@ClientOptions::org_id) used for trace continuation.
+    ///
+    /// By default, we infer the organization ID from the DSN when available. Setting this option
+    /// overrides the DSN-derived organization ID.
+    ///
+    /// This option should be used in local Relay and self-hosted setups, as the organization ID
+    /// cannot be inferred from the DSN in these cases.
+    #[inline]
+    pub fn org_id(self, org_id: OrganizationId) -> Self {
+        let org_id = Some(org_id);
+        Self { org_id, ..self }
+    }
+
+    /// Enables or disables [strict trace continuation](field@ClientOptions::strict_trace_continuation).
+    ///
+    /// Strict trace continuation helps prevent the SDK from continuing traces that originate from
+    /// services instrumented with Sentry by another organization.
+    ///
+    /// By default, the SDK will always continue incoming traces, unless this SDK has an org ID
+    /// embedded in the DSN or explicitly set with [`Self::org_id`] **and** the incoming trace
+    /// includes a different org ID.
+    ///
+    /// When strict trace continuation is enabled, the SDK additionally will not continue traces in
+    /// the case where one of the SDK's org ID or the incoming trace org ID are missing.
+    #[inline]
+    pub fn strict_trace_continuation(self, strict_trace_continuation: bool) -> Self {
+        Self {
+            strict_trace_continuation,
             ..self
         }
     }

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::constants::USER_AGENT;
 use crate::performance::{TracesSampler, TransactionContext};
-use crate::protocol::{Breadcrumb, Event, Log, Metric};
+use crate::protocol::{Breadcrumb, Event, Log, Metric, OrganizationId};
 use crate::types::Dsn;
 use crate::{Integration, IntoDsn, TransportFactory};
 
@@ -145,6 +145,17 @@ pub struct ClientOptions {
     ///
     /// See [`dsn`](method@ClientOptions::dsn) for details.
     pub dsn: Option<Dsn>,
+    /// The Sentry organization ID used for trace continuation decisions.
+    ///
+    /// The SDK can derive this value automatically from Sentry SaaS DSNs. Set this explicitly for
+    /// DSNs whose organization ID cannot be inferred, mainly self-hosted Sentry and local Relay
+    /// setups.
+    pub org_id: Option<OrganizationId>,
+    /// Enables strict trace continuation.
+    ///
+    /// When enabled, the SDK will only continue incoming traces whose organization ID matches this
+    /// SDK's organization ID.
+    pub strict_trace_continuation: bool,
     /// Enables debug mode.
     ///
     /// See [`debug`](method@ClientOptions::debug) for details.
@@ -778,6 +789,8 @@ impl fmt::Debug for ClientOptions {
             .field("before_send_log", &before_send_log)
             .field("enable_metrics", &self.enable_metrics)
             .field("before_send_metric", &before_send_metric)
+            .field("org_id", &self.org_id)
+            .field("strict_trace_continuation", &self.strict_trace_continuation)
             .field("user_agent", &self.user_agent)
             .finish()
     }
@@ -787,6 +800,8 @@ impl Default for ClientOptions {
     fn default() -> ClientOptions {
         ClientOptions {
             dsn: None,
+            org_id: None,
+            strict_trace_continuation: false,
             debug: false,
             release: None,
             environment: None,


### PR DESCRIPTION
These options are needed for strict trace continuation. We will start using them in a follow up PR.

Resolves [#1199](https://github.com/getsentry/sentry-rust/issues/1199)
Resolves [RUST-251](https://linear.app/getsentry/issue/RUST-251)