### PR TITLE
ref: Rename `SentryTrace` to `TracePropagationContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+- Added [`TracePropagationContext`](https://docs.rs/sentry-core/latest/sentry_core/struct.TracePropagationContext.html) as the preferred name for Sentry trace propagation metadata. The existing [`SentryTrace`](https://docs.rs/sentry-core/latest/sentry_core/type.SentryTrace.html) name remains available as a deprecated type alias ([#1206](https://github.com/getsentry/sentry-rust/pull/1206)).
 - Added [`Dsn::org_id`](https://docs.rs/sentry-types/latest/sentry_types/struct.Dsn.html#method.org_id), which parses the Sentry SaaS organization ID from DSN hosts such as `o123.ingest.sentry.io` ([#1202](https://github.com/getsentry/sentry-rust/pull/1202)).
 
 ## 0.48.3

--- a/sentry-core/src/performance/headers.rs
+++ b/sentry-core/src/performance/headers.rs
@@ -1,24 +1,35 @@
 //! Module containing utilities for interacting with Sentry tracing headers.
 
-use crate::protocol;
+use crate::protocol::{SpanId, TraceId};
 
-/// A container for distributed tracing metadata that can be extracted from e.g. the `sentry-trace`
-/// HTTP header.
+/// The [trace propagation] context.
+///
+/// Contains the information necessary for propagating Sentry traces and continuing traces from
+/// incoming requests.
+///
+/// The data stored in this struct can be parsed from and transmitted as `sentry-trace` and Sentry
+/// baggage headers.
+///
+/// Note that the Rust SDK only partially supports trace propagation, certain features such as
+/// [dynamic sampling] may be missing or incomplete.
+///
+/// [trace propagation]: https://develop.sentry.dev/sdk/foundations/trace-propagation/
+/// [dynamic sampling]: https://develop.sentry.dev/sdk/foundations/trace-propagation/dynamic-sampling-context/
 #[derive(Debug, PartialEq, Clone, Copy, Default)]
-pub struct SentryTrace {
-    pub(crate) trace_id: protocol::TraceId,
-    pub(crate) span_id: protocol::SpanId,
+pub struct TracePropagationContext {
+    pub(crate) trace_id: TraceId,
+    pub(crate) span_id: SpanId,
     pub(crate) sampled: Option<bool>,
 }
 
-impl SentryTrace {
-    /// Creates a new [`SentryTrace`] from the provided parameters
-    pub fn new(
-        trace_id: protocol::TraceId,
-        span_id: protocol::SpanId,
-        sampled: Option<bool>,
-    ) -> Self {
-        SentryTrace {
+/// Deprecated alias for [`TracePropagationContext`] for backwards-compatibility.
+#[deprecated = "Please use `TracePropagationContext` instead"]
+pub type SentryTrace = TracePropagationContext;
+
+impl TracePropagationContext {
+    /// Creates a new [`TracePropagationContext`] from the provided parameters
+    pub fn new(trace_id: TraceId, span_id: SpanId, sampled: Option<bool>) -> Self {
+        TracePropagationContext {
             trace_id,
             span_id,
             sampled,
@@ -26,7 +37,7 @@ impl SentryTrace {
     }
 }
 
-fn parse_sentry_trace(header: &str) -> Option<SentryTrace> {
+fn parse_sentry_trace(header: &str) -> Option<TracePropagationContext> {
     let header = header.trim();
     let mut parts = header.splitn(3, '-');
 
@@ -38,10 +49,14 @@ fn parse_sentry_trace(header: &str) -> Option<SentryTrace> {
         _ => None,
     });
 
-    Some(SentryTrace::new(trace_id, parent_span_id, parent_sampled))
+    Some(TracePropagationContext::new(
+        trace_id,
+        parent_span_id,
+        parent_sampled,
+    ))
 }
 
-impl std::fmt::Display for SentryTrace {
+impl std::fmt::Display for TracePropagationContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}-{}", self.trace_id, self.span_id)?;
         if let Some(sampled) = self.sampled {
@@ -53,7 +68,10 @@ impl std::fmt::Display for SentryTrace {
 
 /// Extracts distributed tracing metadata from headers (or, generally, key-value pairs),
 /// considering the values for `sentry-trace`.
-pub fn parse<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(headers: I) -> Option<SentryTrace> {
+pub fn parse<'a, I>(headers: I) -> Option<TracePropagationContext>
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
     let mut trace = None;
     for (k, v) in headers.into_iter() {
         if k.eq_ignore_ascii_case("sentry-trace") {
@@ -66,22 +84,24 @@ pub fn parse<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(headers: I) -> Opti
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr as _;
-
     use super::*;
 
     #[test]
     fn parses_sentry_trace() {
-        let trace_id = protocol::TraceId::from_str("09e04486820349518ac7b5d2adbf6ba5").unwrap();
-        let parent_trace_id = protocol::SpanId::from_str("9cf635fa5b870b3a").unwrap();
+        let trace_id = "09e04486820349518ac7b5d2adbf6ba5".parse().unwrap();
+        let parent_trace_id = "9cf635fa5b870b3a".parse().unwrap();
 
         let trace = parse_sentry_trace("09e04486820349518ac7b5d2adbf6ba5-9cf635fa5b870b3a-0");
         assert_eq!(
             trace,
-            Some(SentryTrace::new(trace_id, parent_trace_id, Some(false)))
+            Some(TracePropagationContext::new(
+                trace_id,
+                parent_trace_id,
+                Some(false)
+            ))
         );
 
-        let trace = SentryTrace::new(Default::default(), Default::default(), None);
+        let trace = TracePropagationContext::new(Default::default(), Default::default(), None);
         let parsed = parse_sentry_trace(&trace.to_string());
         assert_eq!(parsed, Some(trace));
     }

--- a/sentry-core/src/performance/mod.rs
+++ b/sentry-core/src/performance/mod.rs
@@ -13,7 +13,9 @@ use crate::{protocol, Hub};
 #[cfg(feature = "client")]
 use crate::Client;
 
-pub use self::headers::{parse as parse_headers, SentryTrace};
+#[expect(deprecated, reason = "backwards-compatibility re-export")]
+pub use self::headers::SentryTrace;
+pub use self::headers::{parse as parse_headers, TracePropagationContext};
 
 mod headers;
 
@@ -202,7 +204,7 @@ impl TransactionContext {
     pub fn continue_from_sentry_trace(
         name: &str,
         op: &str,
-        sentry_trace: &SentryTrace,
+        sentry_trace: &TracePropagationContext,
         span_id: Option<SpanId>,
     ) -> Self {
         Self {
@@ -836,7 +838,7 @@ impl Transaction {
     /// trace's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let inner = self.inner.lock().unwrap();
-        let trace = SentryTrace::new(
+        let trace = TracePropagationContext::new(
             inner.context.trace_id,
             inner.context.span_id,
             Some(inner.sampled),
@@ -1123,7 +1125,7 @@ impl Span {
     /// trace's distributed tracing headers.
     pub fn iter_headers(&self) -> TraceHeadersIter {
         let span = self.span.lock().unwrap();
-        let trace = SentryTrace::new(span.trace_id, span.span_id, Some(self.sampled));
+        let trace = TracePropagationContext::new(span.trace_id, span.span_id, Some(self.sampled));
         TraceHeadersIter {
             sentry_trace: Some(trace.to_string()),
         }

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -20,7 +20,7 @@ use crate::protocol::{
 };
 #[cfg(feature = "release-health")]
 use crate::session::Session;
-use crate::{Client, SentryTrace, TraceHeader, TraceHeadersIter};
+use crate::{Client, TraceHeader, TraceHeadersIter, TracePropagationContext};
 
 #[derive(Debug)]
 pub struct Stack {
@@ -64,7 +64,7 @@ pub struct Scope {
     pub(crate) session: Arc<Mutex<Option<Session>>>,
     pub(crate) span: Arc<Option<TransactionOrSpan>>,
     pub(crate) attachments: Arc<Vec<Attachment>>,
-    pub(crate) propagation_context: SentryTrace,
+    pub(crate) propagation_context: TracePropagationContext,
 }
 
 impl fmt::Debug for Scope {
@@ -482,7 +482,7 @@ impl Scope {
         if let Some(span) = self.get_span() {
             span.iter_headers()
         } else {
-            let data = SentryTrace::new(
+            let data = TracePropagationContext::new(
                 self.propagation_context.trace_id,
                 self.propagation_context.span_id,
                 None,

--- a/sentry-opentelemetry/src/processor.rs
+++ b/sentry-opentelemetry/src/processor.rs
@@ -19,7 +19,6 @@ use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{Span, SpanData, SpanProcessor};
 
 use opentelemetry_sdk::Resource;
-use sentry_core::SentryTrace;
 use sentry_core::{TransactionContext, TransactionOrSpan};
 
 use crate::converters::{
@@ -128,7 +127,7 @@ impl SpanProcessor for SentrySpanProcessor {
                 ))
             } else {
                 let sentry_ctx = {
-                    if let Some(sentry_trace) = ctx.get::<SentryTrace>() {
+                    if let Some(sentry_trace) = ctx.get() {
                         // continue remote trace
                         TransactionContext::continue_from_sentry_trace(
                             span_description,

--- a/sentry-opentelemetry/src/propagator.rs
+++ b/sentry-opentelemetry/src/propagator.rs
@@ -20,7 +20,7 @@ use opentelemetry::{
     Context, SpanId, TraceId,
 };
 use sentry_core::parse_headers;
-use sentry_core::SentryTrace;
+use sentry_core::TracePropagationContext;
 
 use crate::converters::{convert_span_id, convert_trace_id};
 
@@ -57,7 +57,7 @@ impl TextMapPropagator for SentryPropagator {
         if trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
             return;
         }
-        let sentry_trace = SentryTrace::new(
+        let sentry_trace = TracePropagationContext::new(
             convert_trace_id(&trace_id),
             convert_span_id(&span_id),
             Some(sampled),


### PR DESCRIPTION
This is done in preparation for #1200, as we intend to store the org ID on `TracePropagationContext`.

The rename supports this, as it makes it clear that data in `SentryTrace` does not only come from the `sentry-trace` header.