### PR TITLE
fix(curl): preserve rate limit header values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The Sentry Rust SDK now reports data discarded by the SDK to Sentry’s [Stats](
 ### Fixes
 
 - Fixed `ureq` transport handling for HTTP error statuses so `429` rate limits and `413` payload-too-large responses are processed correctly ([#1177](https://github.com/getsentry/sentry-rust/pull/1177)).
+- Fixed `curl` transport parsing of `X-Sentry-Rate-Limits` headers so colon-separated rate limit values are preserved ([#1111](https://github.com/getsentry/sentry-rust/issues/1111)).
 
 ### Behavior Changes
 

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -15,6 +15,11 @@ use crate::{sentry_debug, types::Scheme, ClientOptions, Envelope, Transport};
 /// The status code returned for rate-limited envelopes.
 const HTTP_RATE_LIMIT_STATUS: u32 = 429;
 
+fn header_value<'a>(data: &'a str, name: &str) -> Option<&'a str> {
+    let (key, value) = data.split_once(':')?;
+    key.eq_ignore_ascii_case(name).then_some(value.trim())
+}
+
 /// A [`Transport`] that sends events via the [`curl`] library.
 ///
 /// This is enabled by the `curl` feature flag.
@@ -162,14 +167,10 @@ impl CurlHttpTransport {
                 handle
                     .header_function(move |data| {
                         if let Ok(data) = std::str::from_utf8(data) {
-                            let mut iter = data.split(':');
-                            if let Some(key) = iter.next().map(str::to_lowercase) {
-                                if key == "retry-after" {
-                                    *retry_after_setter = iter.next().map(|x| x.trim().to_string());
-                                } else if key == "x-sentry-rate-limits" {
-                                    *sentry_header_setter =
-                                        iter.next().map(|x| x.trim().to_string());
-                                }
+                            if let Some(value) = header_value(data, "retry-after") {
+                                *retry_after_setter = Some(value.to_string());
+                            } else if let Some(value) = header_value(data, "x-sentry-rate-limits") {
+                                *sentry_header_setter = Some(value.to_string());
                             }
                         }
                         true
@@ -264,5 +265,28 @@ impl CurlHttpTransportOptions {
     #[inline]
     pub fn build(self) -> CurlHttpTransport {
         CurlHttpTransport::with_options(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ratelimit::RateLimitingCategory;
+    use super::*;
+
+    #[test]
+    fn test_sentry_rate_limit_header_value_preserves_colons() {
+        let value = header_value(
+            "X-Sentry-Rate-Limits: 120:error:project\r\n",
+            "x-sentry-rate-limits",
+        )
+        .unwrap();
+
+        assert_eq!(value, "120:error:project");
+
+        let mut rate_limiter = RateLimiter::new();
+        rate_limiter.update_from_sentry_header(value);
+        assert!(rate_limiter
+            .is_disabled(RateLimitingCategory::Error)
+            .is_some());
     }
 }


### PR DESCRIPTION
### Description

The curl transport parsed response header lines with `split(':')`, so `X-Sentry-Rate-Limits: 120:error:project` was truncated to `120` before reaching `RateLimiter::update_from_sentry_header`. That malformed value is ignored by the rate limiter, and the presence of a parsed Sentry header also prevents the `Retry-After` / bare `429` fallback path from running.

This keeps only the first colon as the header-name separator and preserves the complete trimmed value for both `X-Sentry-Rate-Limits` and `Retry-After`. The regression test covers the curl-style raw header line and confirms the error category is rate limited.

#### Issues

* resolves: #1111

#### Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p sentry --features curl test_sentry_rate_limit_header_value_preserves_colons -- --nocapture` (failed before the fix, passed after)
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p sentry --features curl --lib`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p sentry --features curl --tests --examples --locked -- -D clippy::all`
- `git diff --check`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.