### PR TITLE
fix(curl transport): Preserve full X-Sentry-Rate-Limits and Retry-After header values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed curl transport truncating `X-Sentry-Rate-Limits` and `Retry-After` response headers before they reach the rate limiter ([#1216](https://github.com/getsentry/sentry-rust/pull/1216)).
+
 ## 0.48.3
 
 The Sentry Rust SDK now reports data discarded by the SDK to Sentry’s [Stats](https://docs.sentry.io/product/stats/) page. The SDK reports approximate counts for drops from transports, queues, rate-limit backoff, sampling, event processors, and `before_send*` callbacks, including span counts for dropped transactions and byte counts for dropped logs and metrics.

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -15,6 +15,18 @@ use crate::{sentry_debug, types::Scheme, ClientOptions, Envelope, Transport};
 /// The status code returned for rate-limited envelopes.
 const HTTP_RATE_LIMIT_STATUS: u32 = 429;
 
+/// Parse a single raw header line as delivered by libcurl's `header_function`.
+///
+/// Returns the lowercased header name and the trimmed value, or `None` if the
+/// line is empty, contains a NUL byte, is not valid UTF-8, or has no `:`.
+fn parse_curl_header_line(data: &[u8]) -> Option<(String, String)> {
+    let line = std::str::from_utf8(data)
+        .ok()?
+        .trim_end_matches(['\r', '\n']);
+    let (key, value) = line.split_once(':')?;
+    Some((key.trim().to_lowercase(), value.trim().to_string()))
+}
+
 /// A [`Transport`] that sends events via the [`curl`] library.
 ///
 /// This is enabled by the `curl` feature flag.
@@ -161,15 +173,11 @@ impl CurlHttpTransport {
                 let sentry_header_setter = &mut sentry_header;
                 handle
                     .header_function(move |data| {
-                        if let Ok(data) = std::str::from_utf8(data) {
-                            let mut iter = data.split(':');
-                            if let Some(key) = iter.next().map(str::to_lowercase) {
-                                if key == "retry-after" {
-                                    *retry_after_setter = iter.next().map(|x| x.trim().to_string());
-                                } else if key == "x-sentry-rate-limits" {
-                                    *sentry_header_setter =
-                                        iter.next().map(|x| x.trim().to_string());
-                                }
+                        if let Some((key, value)) = parse_curl_header_line(data) {
+                            match key.as_str() {
+                                "retry-after" => *retry_after_setter = Some(value),
+                                "x-sentry-rate-limits" => *sentry_header_setter = Some(value),
+                                _ => {}
                             }
                         }
                         true
@@ -264,5 +272,101 @@ impl CurlHttpTransportOptions {
     #[inline]
     pub fn build(self) -> CurlHttpTransport {
         CurlHttpTransport::with_options(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_curl_header_line;
+
+    #[test]
+    fn parses_sentry_rate_limits_with_categories() {
+        // Direct regression for issue #1111.
+        let (key, value) =
+            parse_curl_header_line(b"X-Sentry-Rate-Limits: 120:error:project:reason\r\n").unwrap();
+        assert_eq!(key, "x-sentry-rate-limits");
+        assert_eq!(value, "120:error:project:reason");
+    }
+
+    #[test]
+    fn parses_sentry_rate_limits_multi_group_comma() {
+        let (key, value) = parse_curl_header_line(
+            b"X-Sentry-Rate-Limits: 60:transaction:key, 2700:default;error;security:organization\r\n",
+        )
+        .unwrap();
+        assert_eq!(key, "x-sentry-rate-limits");
+        assert_eq!(
+            value,
+            "60:transaction:key, 2700:default;error;security:organization"
+        );
+    }
+
+    #[test]
+    fn parses_sentry_rate_limits_empty_categories() {
+        let (key, value) =
+            parse_curl_header_line(b"x-sentry-rate-limits: 60::organization\r\n").unwrap();
+        assert_eq!(key, "x-sentry-rate-limits");
+        assert_eq!(value, "60::organization");
+    }
+
+    #[test]
+    fn parses_retry_after_integer() {
+        let (key, value) = parse_curl_header_line(b"Retry-After: 60\r\n").unwrap();
+        assert_eq!(key, "retry-after");
+        assert_eq!(value, "60");
+    }
+
+    #[test]
+    fn parses_retry_after_http_date() {
+        // Before the fix this was truncated to "Wed, 21 Oct 2015 07".
+        let (key, value) =
+            parse_curl_header_line(b"Retry-After: Wed, 21 Oct 2015 07:28:00 GMT\r\n").unwrap();
+        assert_eq!(key, "retry-after");
+        assert_eq!(value, "Wed, 21 Oct 2015 07:28:00 GMT");
+    }
+
+    #[test]
+    fn strips_trailing_cr_only() {
+        let (_, value) = parse_curl_header_line(b"Retry-After: 5\r").unwrap();
+        assert_eq!(value, "5");
+    }
+
+    #[test]
+    fn strips_trailing_lf_only() {
+        let (_, value) = parse_curl_header_line(b"Retry-After: 5\n").unwrap();
+        assert_eq!(value, "5");
+    }
+
+    #[test]
+    fn lowercases_and_trims_unrelated_header() {
+        let (key, value) = parse_curl_header_line(b"Content-Length: 42\r\n").unwrap();
+        assert_eq!(key, "content-length");
+        assert_eq!(value, "42");
+    }
+
+    #[test]
+    fn trims_leading_and_inner_whitespace() {
+        let (key, value) = parse_curl_header_line(b"  X-Sentry-Rate-Limits :  120 \r\n").unwrap();
+        assert_eq!(key, "x-sentry-rate-limits");
+        assert_eq!(value, "120");
+    }
+
+    #[test]
+    fn returns_none_for_empty_line() {
+        assert!(parse_curl_header_line(b"\r\n").is_none());
+    }
+
+    #[test]
+    fn returns_none_for_line_without_colon() {
+        // "X-Sentry-Rate-Limits\r\n" (no colon) — old code's iter.next() on a
+        // one-element split iterator returned None, so the setter was untouched.
+        // The new helper preserves that behavior by returning None for the
+        // whole call.
+        assert!(parse_curl_header_line(b"X-Sentry-Rate-Limits\r\n").is_none());
+    }
+
+    #[test]
+    fn returns_none_for_non_utf8_input() {
+        assert!(parse_curl_header_line(&[0xFF, 0xFE, 0xFD]).is_none());
     }
 }


### PR DESCRIPTION
fix(curl transport): Preserve full X-Sentry-Rate-Limits and Retry-After header values

The curl transport's `header_function` callback parsed each response header
line with `data.split(':')` and only kept the second segment, dropping
everything after the second colon. For real Sentry responses the
`X-Sentry-Rate-Limits` header carries 4-6 colon-separated segments per quota
group and is commonly delivered with multiple comma-separated groups on one
line, so the captured value was just the first retry-after duration with all
category and scope information lost.

The same defect truncated `Retry-After: Wed, 21 Oct 2015 07:28:00 GMT`
(HTTP-date form) to `"Wed, 21 Oct 2015 07"`, which the rate limiter cannot
parse as either an integer or a valid HTTP-date, so it fell back to the 60s
default.

Extract a small `parse_curl_header_line` helper that preserves the full
value tail after the first colon, then wire it into the callback. Behavior
matches how `reqwest` and `ureq` transports already expose header values.
`embedded_svc_http` does not currently parse response headers, so it is
unaffected; adding rate-limit awareness there is left as a follow-up.

Fixes [#1111](https://github.com/getsentry/sentry-rust/issues/1111)
Fixes [RUST-209](https://linear.app/getsentry/issue/RUST-209/fix-curl-transport-parsing-of-x-sentry-rate-limits-header)

