### PR TITLE
ref(core): Migrate ClientOptions call sites to builder API

### DIFF
--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -26,10 +26,9 @@ async fn failing(_req: HttpRequest) -> Result<String, Error> {
 }
 
 fn main() -> io::Result<()> {
-    let _guard = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        ..Default::default()
-    });
+    let _guard = sentry::init(
+        sentry::ClientOptions::new().maybe_release(sentry::release_name!()),
+    );
     std::env::set_var("RUST_BACKTRACE", "1");
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -55,12 +54,12 @@ when `auto_session_tracking` is enabled and the client is configured to
 use `SessionMode::Request`.
 
 ```rust
-let _sentry = sentry::init(sentry::ClientOptions {
-    release: sentry::release_name!(),
-    session_mode: sentry::SessionMode::Request,
-    auto_session_tracking: true,
-    ..Default::default()
-});
+let _sentry = sentry::init(
+    sentry::ClientOptions::new()
+        .maybe_release(sentry::release_name!())
+        .session_mode(sentry::SessionMode::Request)
+        .auto_session_tracking(true),
+);
 ```
 
 ## Reusing the Hub

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -22,14 +22,14 @@ async fn captures_message(_req: HttpRequest) -> Result<String, Error> {
 
 // cargo run -p sentry-actix --example basic
 fn main() -> io::Result<()> {
-    let _guard = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        auto_session_tracking: true,
-        traces_sample_rate: 1.0,
-        session_mode: sentry::SessionMode::Request,
-        debug: true,
-        ..Default::default()
-    });
+    let _guard = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .auto_session_tracking(true)
+            .traces_sample_rate(1.0)
+            .session_mode(sentry::SessionMode::Request)
+            .debug(true),
+    );
     env::set_var("RUST_BACKTRACE", "1");
 
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -18,10 +18,9 @@
 //! }
 //!
 //! fn main() -> io::Result<()> {
-//!     let _guard = sentry::init(sentry::ClientOptions {
-//!         release: sentry::release_name!(),
-//!         ..Default::default()
-//!     });
+//!     let _guard = sentry::init(
+//!         sentry::ClientOptions::new().maybe_release(sentry::release_name!()),
+//!     );
 //!     std::env::set_var("RUST_BACKTRACE", "1");
 //!
 //!     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -47,12 +46,12 @@
 //! use `SessionMode::Request`.
 //!
 //! ```
-//! let _sentry = sentry::init(sentry::ClientOptions {
-//!     release: sentry::release_name!(),
-//!     session_mode: sentry::SessionMode::Request,
-//!     auto_session_tracking: true,
-//!     ..Default::default()
-//! });
+//! let _sentry = sentry::init(
+//!     sentry::ClientOptions::new()
+//!         .maybe_release(sentry::release_name!())
+//!         .session_mode(sentry::SessionMode::Request)
+//!         .auto_session_tracking(true),
+//! );
 //! ```
 //!
 //! # Reusing the Hub
@@ -765,12 +764,10 @@ mod tests {
                     }
                 })
             },
-            sentry::ClientOptions {
-                release: Some("some-release".into()),
-                session_mode: sentry::SessionMode::Request,
-                auto_session_tracking: true,
-                ..Default::default()
-            },
+            sentry::ClientOptions::new()
+                .release("some-release")
+                .session_mode(sentry::SessionMode::Request)
+                .auto_session_tracking(true),
         );
         assert_eq!(envelopes.len(), 1);
 

--- a/sentry-core/benches/scope_benchmark.rs
+++ b/sentry-core/benches/scope_benchmark.rs
@@ -134,13 +134,11 @@ fn discarding_hub() -> sentry::Hub {
         }
     }
 
-    let client = Arc::new(sentry::Client::from(sentry::ClientOptions {
-        dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
-        // lol, this double arcing -_-
-        transport: Some(Arc::new(Arc::new(NoopTransport))),
-        // before_send: Some(Arc::new(|_| None)),
-        ..Default::default()
-    }));
+    let client = Arc::new(sentry::Client::from(
+        sentry::ClientOptions::new()
+            .dsn("https://public@sentry.invalid/1")
+            .transport(Arc::new(NoopTransport)),
+    ));
     let scope = Arc::new(sentry::Scope::default());
     sentry::Hub::new(Some(client), scope)
 }

--- a/sentry-core/src/client/batcher.rs
+++ b/sentry-core/src/client/batcher.rs
@@ -178,10 +178,7 @@ mod tests {
                     logger_info!("test log {}", i);
                 }
             },
-            crate::ClientOptions {
-                enable_logs: true,
-                ..Default::default()
-            },
+            crate::ClientOptions::new().enable_logs(true),
         );
 
         assert_eq!(2, envelopes.len());
@@ -210,10 +207,7 @@ mod tests {
                     logger_info!("test log {}", i);
                 }
             },
-            crate::ClientOptions {
-                enable_logs: true,
-                ..Default::default()
-            },
+            crate::ClientOptions::new().enable_logs(true),
         );
 
         assert_eq!(1, envelopes.len());

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -411,19 +411,14 @@ impl Client {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::Arc;
-    ///
-    /// let client = sentry::Client::from(sentry::ClientOptions::default());
+    /// let client = sentry::Client::from(sentry::ClientOptions::new());
     /// assert!(!client.is_enabled());
     ///
     /// let dsn = "https://public@example.com/1";
     /// let transport = sentry::test::TestTransport::new();
     /// let client = sentry::Client::from((
     ///     dsn,
-    ///     sentry::ClientOptions {
-    ///         transport: Some(Arc::new(transport)),
-    ///         ..Default::default()
-    ///     },
+    ///     sentry::ClientOptions::new().transport(transport),
     /// ));
     /// assert!(client.is_enabled());
     /// ```

--- a/sentry-core/src/macros.rs
+++ b/sentry-core/src/macros.rs
@@ -8,10 +8,9 @@
 /// ```
 /// # #[macro_use] extern crate sentry;
 /// # fn main() {
-/// let _sentry = sentry::init(sentry::ClientOptions {
-///     release: sentry::release_name!(),
-///     ..Default::default()
-/// });
+/// let _sentry = sentry::init(
+///     sentry::ClientOptions::new().maybe_release(sentry::release_name!()),
+/// );
 /// # }
 /// ```
 #[macro_export]

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -376,10 +376,7 @@ mod session_impl {
         {
             crate::test::with_captured_envelopes_options(
                 f,
-                crate::ClientOptions {
-                    release: Some("some-release".into()),
-                    ..Default::default()
-                },
+                crate::ClientOptions::new().release("some-release"),
             )
         }
 
@@ -452,11 +449,9 @@ mod session_impl {
                     let err = "NaN".parse::<usize>().unwrap_err();
                     sentry::capture_error(&err);
                 },
-                crate::ClientOptions {
-                    release: Some("some-release".into()),
-                    session_mode: SessionMode::Request,
-                    ..Default::default()
-                },
+                crate::ClientOptions::new()
+                    .release("some-release")
+                    .session_mode(SessionMode::Request),
             );
             assert_eq!(envelopes.len(), 2);
 
@@ -551,11 +546,9 @@ mod session_impl {
                         sentry::capture_error(&err);
                     }
                 },
-                crate::ClientOptions {
-                    release: Some("some-release".into()),
-                    sample_rate: 0.5,
-                    ..Default::default()
-                },
+                crate::ClientOptions::new()
+                    .release("some-release")
+                    .sample_rate(0.5),
             );
             assert!(envelopes.len() > 25);
             assert!(envelopes.len() < 75);

--- a/sentry-core/src/test.rs
+++ b/sentry-core/src/test.rs
@@ -38,11 +38,9 @@ static TEST_DSN: LazyLock<Dsn> =
 /// use std::sync::Arc;
 ///
 /// let transport = TestTransport::new();
-/// let options = ClientOptions {
-///     dsn: Some("https://public@example.com/1".parse().unwrap()),
-///     transport: Some(Arc::new(transport.clone())),
-///     ..ClientOptions::default()
-/// };
+/// let options = ClientOptions::new()
+///     .dsn("https://public@example.com/1")
+///     .transport(transport.clone());
 /// Hub::current().bind_client(Some(Arc::new(options.into())));
 /// ```
 pub struct TestTransport {

--- a/sentry-core/tests/client_reports.rs
+++ b/sentry-core/tests/client_reports.rs
@@ -20,11 +20,11 @@ impl Integration for DroppingIntegration {
 }
 
 fn client_with_options(transport: Arc<TestTransport>, options: ClientOptions) -> Client {
-    Client::with_options(ClientOptions {
-        dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
-        transport: Some(Arc::new(transport)),
-        ..options
-    })
+    Client::with_options(
+        options
+            .dsn("https://public@sentry.invalid/1")
+            .transport(transport),
+    )
 }
 
 fn assert_client_report(envelope: &Envelope, expected: serde_json::Value) {
@@ -87,10 +87,7 @@ fn client_report_records_integration_event_processor_drop() {
 
 #[test]
 fn client_report_records_before_send_drop() {
-    let options = ClientOptions {
-        before_send: Some(Arc::new(|_| None)),
-        ..Default::default()
-    };
+    let options = ClientOptions::new().before_send(|_| None);
 
     assert_drop_records_client_report(
         options,
@@ -103,10 +100,7 @@ fn client_report_records_before_send_drop() {
 
 #[test]
 fn client_report_records_sample_rate_drop() {
-    let options = ClientOptions {
-        sample_rate: 0.0,
-        ..Default::default()
-    };
+    let options = ClientOptions::new().sample_rate(0.0);
 
     assert_drop_records_client_report(
         options,
@@ -122,10 +116,7 @@ fn client_report_records_unsampled_transaction_and_spans() {
     let transport = TestTransport::new();
     let client = Arc::new(client_with_options(
         transport.clone(),
-        ClientOptions {
-            traces_sample_rate: 0.0,
-            ..Default::default()
-        },
+        ClientOptions::new().traces_sample_rate(0.0),
     ));
 
     Hub::run(
@@ -158,10 +149,7 @@ fn client_report_records_transaction_span_cap_drop() {
     let transport = TestTransport::new();
     let client = Arc::new(client_with_options(
         transport.clone(),
-        ClientOptions {
-            traces_sample_rate: 1.0,
-            ..Default::default()
-        },
+        ClientOptions::new().traces_sample_rate(1.0),
     ));
 
     Hub::run(

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -1,7 +1,6 @@
 #![cfg(all(feature = "test", feature = "metrics"))]
 
 use std::collections::HashSet;
-use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
@@ -14,10 +13,7 @@ use sentry_types::protocol::v7::{Envelope, LogAttribute, Metric, User};
 /// Test that metrics are sent when metrics are enabled.
 #[test]
 fn sent_when_enabled() {
-    let options = ClientOptions {
-        enable_metrics: true,
-        ..Default::default()
-    };
+    let options = ClientOptions::new().enable_metrics(true);
 
     let mut envelopes =
         test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
@@ -66,10 +62,7 @@ fn metrics_enabled_by_default() {
 /// [`ClientOptions`].
 #[test]
 fn metrics_disabled_when_configured() {
-    let options = ClientOptions {
-        enable_metrics: false,
-        ..Default::default()
-    };
+    let options = ClientOptions::new().enable_metrics(false);
 
     let envelopes =
         test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
@@ -384,12 +377,10 @@ fn metrics_span_id_from_active_span() {
 /// Test that default SDK attributes are attached to metrics.
 #[test]
 fn default_attributes_attached() {
-    let options = ClientOptions {
-        environment: Some("test-env".into()),
-        release: Some("1.0.0".into()),
-        server_name: Some("test-server".into()),
-        ..Default::default()
-    };
+    let options = ClientOptions::new()
+        .environment("test-env")
+        .release("1.0.0")
+        .server_name("test-server");
 
     let envelopes =
         test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
@@ -433,10 +424,7 @@ fn optional_default_attributes_omitted_when_not_configured() {
 /// Test that explicitly set metric attributes are not overwritten by defaults.
 #[test]
 fn default_attributes_do_not_overwrite_explicit() {
-    let options = ClientOptions {
-        environment: Some("default-env".into()),
-        ..Default::default()
-    };
+    let options = ClientOptions::new().environment("default-env");
 
     let envelopes = test::with_captured_envelopes_options(
         || {
@@ -465,10 +453,7 @@ fn default_attributes_do_not_overwrite_explicit() {
 /// Test that user attributes are NOT attached when `send_default_pii` is false.
 #[test]
 fn user_attributes_absent_without_send_default_pii() {
-    let options = ClientOptions {
-        send_default_pii: false,
-        ..Default::default()
-    };
+    let options = ClientOptions::new().send_default_pii(false);
 
     let envelopes = test::with_captured_envelopes_options(
         || {
@@ -502,10 +487,7 @@ fn user_attributes_absent_without_send_default_pii() {
 /// `send_default_pii` is true.
 #[test]
 fn metric_user_attributes_from_scope_are_applied_with_send_default_pii() {
-    let options = ClientOptions {
-        send_default_pii: true,
-        ..Default::default()
-    };
+    let options = ClientOptions::new().send_default_pii(true);
 
     let envelopes = test::with_captured_envelopes_options(
         || {
@@ -541,10 +523,7 @@ fn metric_user_attributes_from_scope_are_applied_with_send_default_pii() {
 /// attributes are not merged in.
 #[test]
 fn metric_user_attributes_do_not_overwrite_explicit() {
-    let options = ClientOptions {
-        send_default_pii: true,
-        ..Default::default()
-    };
+    let options = ClientOptions::new().send_default_pii(true);
 
     let envelopes = test::with_captured_envelopes_options(
         || {
@@ -581,10 +560,7 @@ fn metric_user_attributes_do_not_overwrite_explicit() {
 /// Test that `before_send_metric` can filter out metrics.
 #[test]
 fn before_send_metric_can_drop() {
-    let options = ClientOptions {
-        before_send_metric: Some(Arc::new(|_| None)),
-        ..Default::default()
-    };
+    let options = ClientOptions::new().before_send_metric(|_| None);
 
     let envelopes =
         test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
@@ -597,15 +573,12 @@ fn before_send_metric_can_drop() {
 /// Test that `before_send_metric` can modify metrics.
 #[test]
 fn before_send_metric_can_modify() {
-    let options = ClientOptions {
-        before_send_metric: Some(Arc::new(|mut metric| {
-            metric
-                .attributes
-                .insert("added_by_callback".into(), LogAttribute(Value::from("yes")));
-            Some(metric)
-        })),
-        ..Default::default()
-    };
+    let options = ClientOptions::new().before_send_metric(|mut metric| {
+        metric
+            .attributes
+            .insert("added_by_callback".into(), LogAttribute(Value::from("yes")));
+        Some(metric)
+    });
 
     let envelopes =
         test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);

--- a/sentry-opentelemetry/README.md
+++ b/sentry-opentelemetry/README.md
@@ -45,17 +45,15 @@ use sentry::integrations::opentelemetry as sentry_opentelemetry;
 // Initialize the Sentry SDK
 let _guard = sentry::init((
     "https://your-dsn@sentry.io/0",
-    sentry::ClientOptions {
+    sentry::ClientOptions::new()
         // Enable capturing of traces; set this a to lower value in production.
         // For more sophisticated behavior use a custom
         // [`sentry::ClientOptions::traces_sampler`] instead.
         // That's the equivalent of a tail sampling processor in OpenTelemetry.
         // These options will only affect sampling of the spans that are sent to Sentry,
         // not of the underlying OpenTelemetry spans.
-        traces_sample_rate: 1.0,
-        debug: true,
-        ..sentry::ClientOptions::default()
-    },
+        .traces_sample_rate(1.0)
+        .debug(true),
 ));
 
 // Register the Sentry propagator to enable distributed tracing

--- a/sentry-opentelemetry/src/lib.rs
+++ b/sentry-opentelemetry/src/lib.rs
@@ -37,17 +37,15 @@
 //! // Initialize the Sentry SDK
 //! let _guard = sentry::init((
 //!     "https://your-dsn@sentry.io/0",
-//!     sentry::ClientOptions {
+//!     sentry::ClientOptions::new()
 //!         // Enable capturing of traces; set this a to lower value in production.
 //!         // For more sophisticated behavior use a custom
 //!         // [`sentry::ClientOptions::traces_sampler`] instead.
 //!         // That's the equivalent of a tail sampling processor in OpenTelemetry.
 //!         // These options will only affect sampling of the spans that are sent to Sentry,
 //!         // not of the underlying OpenTelemetry spans.
-//!         traces_sample_rate: 1.0,
-//!         debug: true,
-//!         ..sentry::ClientOptions::default()
-//!     },
+//!         .traces_sample_rate(1.0)
+//!         .debug(true),
 //! ));
 //!
 //! // Register the Sentry propagator to enable distributed tracing

--- a/sentry-opentelemetry/tests/shared.rs
+++ b/sentry-opentelemetry/tests/shared.rs
@@ -5,17 +5,11 @@ use std::sync::Arc;
 
 pub fn init_sentry(traces_sample_rate: f32) -> Arc<TestTransport> {
     let transport = TestTransport::new();
-    let options = ClientOptions {
-        dsn: Some(
-            "https://test@sentry-opentelemetry.com/test"
-                .parse()
-                .unwrap(),
-        ),
-        transport: Some(Arc::new(transport.clone())),
-        sample_rate: 1.0,
-        traces_sample_rate,
-        ..ClientOptions::default()
-    };
+    let options = ClientOptions::new()
+        .dsn("https://test@sentry-opentelemetry.com/test")
+        .transport(transport.clone())
+        .sample_rate(1.0)
+        .traces_sample_rate(traces_sample_rate);
     Hub::current().bind_client(Some(Arc::new(options.into())));
     transport
 }

--- a/sentry-tracing/README.md
+++ b/sentry-tracing/README.md
@@ -35,11 +35,11 @@ tracing subscriber:
 ```rust
 use tracing_subscriber::prelude::*;
 
-let _guard = sentry::init(sentry::ClientOptions {
-    // Enable capturing of traces; set this a to lower value in production:
-    traces_sample_rate: 1.0,
-    ..sentry::ClientOptions::default()
-});
+let _guard = sentry::init(
+    sentry::ClientOptions::new()
+        // Enable capturing of traces; set this a to lower value in production:
+        .traces_sample_rate(1.0),
+);
 
 // Register the Sentry tracing layer to capture breadcrumbs, events, and spans:
 tracing_subscriber::registry()

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -27,11 +27,11 @@
 //! ```
 //! use tracing_subscriber::prelude::*;
 //!
-//! let _guard = sentry::init(sentry::ClientOptions {
-//!     // Enable capturing of traces; set this a to lower value in production:
-//!     traces_sample_rate: 1.0,
-//!     ..sentry::ClientOptions::default()
-//! });
+//! let _guard = sentry::init(
+//!     sentry::ClientOptions::new()
+//!         // Enable capturing of traces; set this a to lower value in production:
+//!         .traces_sample_rate(1.0),
+//! );
 //!
 //! // Register the Sentry tracing layer to capture breadcrumbs, events, and spans:
 //! tracing_subscriber::registry()

--- a/sentry-tracing/tests/shared.rs
+++ b/sentry-tracing/tests/shared.rs
@@ -7,13 +7,11 @@ pub fn init_sentry(traces_sample_rate: f32) -> Arc<TestTransport> {
     use tracing_subscriber::prelude::*;
 
     let transport = TestTransport::new();
-    let options = ClientOptions {
-        dsn: Some("https://test@sentry-tracing.com/test".parse().unwrap()),
-        transport: Some(Arc::new(transport.clone())),
-        sample_rate: 1.0,
-        traces_sample_rate,
-        ..ClientOptions::default()
-    };
+    let options = ClientOptions::new()
+        .dsn("https://test@sentry-tracing.com/test")
+        .transport(transport.clone())
+        .sample_rate(1.0)
+        .traces_sample_rate(traces_sample_rate);
     Hub::current().bind_client(Some(Arc::new(options.into())));
 
     let _ = tracing_subscriber::registry()

--- a/sentry/examples/anyhow-demo.rs
+++ b/sentry/examples/anyhow-demo.rs
@@ -4,11 +4,11 @@ fn execute() -> anyhow::Result<usize> {
 }
 
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .debug(true),
+    );
 
     if let Err(err) = execute() {
         println!("error: {err}");

--- a/sentry/examples/before-send.rs
+++ b/sentry/examples/before-send.rs
@@ -1,18 +1,16 @@
-use std::sync::Arc;
-
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        before_send: Some(Arc::new(|mut event| {
-            event.request = Some(sentry::protocol::Request {
-                url: Some("https://example.com/".parse().unwrap()),
-                method: Some("GET".into()),
-                ..Default::default()
-            });
-            Some(event)
-        })),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .before_send(|mut event| {
+                event.request = Some(sentry::protocol::Request {
+                    url: Some("https://example.com/".parse().unwrap()),
+                    method: Some("GET".into()),
+                    ..Default::default()
+                });
+                Some(event)
+            })
+            .debug(true),
+    );
 
     let id = sentry::capture_message("An HTTP request failed.", sentry::Level::Error);
     println!("sent event {id}");

--- a/sentry/examples/event-processors.rs
+++ b/sentry/examples/event-processors.rs
@@ -1,9 +1,9 @@
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .debug(true),
+    );
 
     sentry::configure_scope(|scope| {
         scope.add_event_processor(|mut event| {

--- a/sentry/examples/health.rs
+++ b/sentry/examples/health.rs
@@ -1,13 +1,13 @@
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        // release health requires a release to be set
-        release: sentry::release_name!(),
-        debug: true,
-        // session tracking is enabled by default, but we want to explicitly
-        // create the session
-        auto_session_tracking: false,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            // release health requires a release to be set
+            .maybe_release(sentry::release_name!())
+            .debug(true)
+            // session tracking is enabled by default, but we want to explicitly
+            // create the session
+            .auto_session_tracking(false),
+    );
 
     let handle = std::thread::spawn(|| {
         // this session will be set to crashed

--- a/sentry/examples/log-demo.rs
+++ b/sentry/examples/log-demo.rs
@@ -3,11 +3,11 @@ use log::{debug, error, info, warn};
 fn main() {
     init_log();
 
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .debug(true),
+    );
 
     debug!("System is booting");
     info!("System is booting");

--- a/sentry/examples/message-demo.rs
+++ b/sentry/examples/message-demo.rs
@@ -1,9 +1,9 @@
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .debug(true),
+    );
     sentry::configure_scope(|scope| {
         scope.set_fingerprint(Some(["a-message"].as_ref()));
         scope.set_tag("foo", "bar");

--- a/sentry/examples/panic-demo.rs
+++ b/sentry/examples/panic-demo.rs
@@ -1,9 +1,9 @@
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .debug(true),
+    );
 
     {
         let _guard = sentry::Hub::current().push_scope();

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -5,12 +5,12 @@ use sentry::protocol::Request;
 
 // cargo run --example performance-demo
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        traces_sample_rate: 1.0,
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .traces_sample_rate(1.0)
+            .debug(true),
+    );
 
     let transaction =
         sentry::start_transaction(sentry::TransactionContext::new("transaction", "root span"));

--- a/sentry/examples/send-with-extra.rs
+++ b/sentry/examples/send-with-extra.rs
@@ -1,9 +1,9 @@
 fn main() {
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .debug(true),
+    );
 
     sentry::with_scope(
         |scope| {

--- a/sentry/examples/thread-demo.rs
+++ b/sentry/examples/thread-demo.rs
@@ -7,11 +7,11 @@ fn main() {
     // this initializes sentry.  It also gives the thread that calls this some
     // special behavior in that all other threads spawned will get a hub based on
     // the hub from here.
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .debug(true),
+    );
 
     // the log integration sends to Hub::current()
     log::info!("Spawning thread");

--- a/sentry/examples/tracing-demo.rs
+++ b/sentry/examples/tracing-demo.rs
@@ -11,12 +11,12 @@ fn main() {
         .try_init()
         .unwrap();
 
-    let _sentry = sentry::init(sentry::ClientOptions {
-        release: sentry::release_name!(),
-        traces_sample_rate: 1.0,
-        debug: true,
-        ..Default::default()
-    });
+    let _sentry = sentry::init(
+        sentry::ClientOptions::new()
+            .maybe_release(sentry::release_name!())
+            .traces_sample_rate(1.0)
+            .debug(true),
+    );
 
     tracing::debug!("System is booting");
     tracing::info!("System is booting");

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -121,10 +121,7 @@ mod tests {
 
     #[test]
     fn test_default_environment() {
-        let opts = ClientOptions {
-            environment: Some("explicit-env".into()),
-            ..Default::default()
-        };
+        let opts = ClientOptions::new().environment("explicit-env");
         let opts = apply_defaults(opts);
         assert_eq!(opts.environment.unwrap(), "explicit-env");
 

--- a/sentry/src/init.rs
+++ b/sentry/src/init.rs
@@ -70,10 +70,7 @@ impl Drop for ClientInitGuard {
 /// created to enable further configuration:
 ///
 /// ```
-/// let sentry = sentry::init(sentry::ClientOptions {
-///     release: Some("foo-bar-baz@1.0.0".into()),
-///     ..Default::default()
-/// });
+/// let sentry = sentry::init(sentry::ClientOptions::new().release("foo-bar-baz@1.0.0"));
 /// if sentry.is_enabled() {
 ///     // some other initialization
 /// }

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -172,11 +172,9 @@ pub use crate::init::{init, ClientInitGuard};
 /// use sentry::integrations::debug_images::DebugImagesIntegration;
 /// use sentry::ClientOptions;
 ///
-/// let options = ClientOptions {
-///     default_integrations: false,
-///     ..Default::default()
-/// }
-/// .add_integration(DebugImagesIntegration::new());
+/// let options = ClientOptions::new()
+///     .default_integrations(false)
+///     .add_integration(DebugImagesIntegration::new());
 /// let _guard = sentry::init(options);
 /// # }
 /// ```

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -119,16 +119,14 @@ fn test_factory() {
     let events = Arc::new(AtomicUsize::new(0));
 
     let events_for_options = events.clone();
-    let options = sentry::ClientOptions {
-        dsn: "http://foo@example.com/42".parse().ok(),
-        transport: Some(Arc::new(
+    let options = sentry::ClientOptions::new()
+        .dsn("http://foo@example.com/42")
+        .transport(
             move |opts: &sentry::ClientOptions| -> Arc<dyn sentry::Transport> {
                 assert_eq!(opts.dsn.as_ref().unwrap().host(), "example.com");
                 Arc::new(TestTransport(events_for_options.clone()))
             },
-        )),
-        ..Default::default()
-    };
+        );
 
     sentry::Hub::run(
         Arc::new(sentry::Hub::new(
@@ -170,10 +168,7 @@ fn test_attached_stacktrace() {
         .map(|()| log::set_max_level(log::LevelFilter::Info))
         .unwrap();
 
-    let options = sentry::apply_defaults(sentry::ClientOptions {
-        attach_stacktrace: true,
-        ..Default::default()
-    });
+    let options = sentry::apply_defaults(sentry::ClientOptions::new().attach_stacktrace(true));
     let events = sentry::test::with_captured_events_options(
         || {
             let error = "thisisnotanumber".parse::<u32>().unwrap_err();
@@ -274,10 +269,7 @@ fn test_basic_capture_log() {
 
     use sentry::{protocol::Log, protocol::LogAttribute, protocol::Map, Hub};
 
-    let options = sentry::ClientOptions {
-        enable_logs: true,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().enable_logs(true);
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             let mut attributes: Map<String, LogAttribute> = Map::new();
@@ -321,10 +313,7 @@ fn test_basic_capture_log() {
 fn test_basic_capture_log_macro_message() {
     use sentry_core::logger_info;
 
-    let options = sentry::ClientOptions {
-        enable_logs: true,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().enable_logs(true);
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             logger_info!("Hello, world!");
@@ -357,10 +346,7 @@ fn test_basic_capture_log_macro_message_formatted() {
     use sentry::protocol::LogAttribute;
     use sentry_core::logger_warn;
 
-    let options = sentry::ClientOptions {
-        enable_logs: true,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().enable_logs(true);
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             let failed_requests = ["request1", "request2", "request3"];
@@ -424,10 +410,7 @@ fn test_basic_capture_log_macro_message_with_attributes() {
     use sentry::protocol::LogAttribute;
     use sentry_core::logger_error;
 
-    let options = sentry::ClientOptions {
-        enable_logs: true,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().enable_logs(true);
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             logger_error!(
@@ -483,10 +466,7 @@ fn test_basic_capture_log_macro_message_formatted_with_attributes() {
     use sentry::protocol::LogAttribute;
     use sentry_core::logger_debug;
 
-    let options = sentry::ClientOptions {
-        enable_logs: true,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().enable_logs(true);
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             logger_debug!(
@@ -584,7 +564,7 @@ fn test_basic_capture_log_macro_message_formatted_with_attributes() {
 #[test]
 fn test_transaction_envelope_dsc_headers() {
     let mut trace_id: Option<sentry::protocol::TraceId> = None;
-    let dsn: Option<Dsn> = "http://foo@example.com/42".parse().ok();
+    let dsn = "http://foo@example.com/42";
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             let transaction_ctx = sentry::TransactionContext::new("name transaction", "op");
@@ -593,11 +573,9 @@ fn test_transaction_envelope_dsc_headers() {
             sentry::configure_scope(|scope| scope.set_span(Some(transaction.clone().into())));
             transaction.finish();
         },
-        sentry::ClientOptions {
-            dsn: dsn.clone(),
-            traces_sample_rate: 1.0,
-            ..Default::default()
-        },
+        sentry::ClientOptions::new()
+            .dsn(dsn)
+            .traces_sample_rate(1.0),
     );
 
     assert!(trace_id.is_some());
@@ -610,7 +588,12 @@ fn test_transaction_envelope_dsc_headers() {
     let expected = EnvelopeHeaders::new().with_event_id(uuid).with_trace(
         DynamicSamplingContext::new()
             .with_trace_id(trace_id)
-            .with_public_key(dsn.unwrap().public_key().to_owned())
+            .with_public_key(
+                dsn.parse::<Dsn>()
+                    .expect("should parse as DSN")
+                    .public_key()
+                    .to_owned(),
+            )
             .with_sample_rate(1.0)
             .with_sampled(true),
     );

--- a/sentry/tests/test_client.rs
+++ b/sentry/tests/test_client.rs
@@ -16,13 +16,9 @@ fn test_into_client() {
 
     let c: sentry::Client = sentry::Client::from_config((
         "https://public@example.com/42%21",
-        sentry::ClientOptions {
-            release: Some("foo@1.0".into()),
-            traces_sampler: Some(Arc::new(
-                |ctx| if ctx.name().is_empty() { 0.0 } else { 1.0 },
-            )),
-            ..Default::default()
-        },
+        sentry::ClientOptions::new()
+            .release("foo@1.0")
+            .traces_sampler(|ctx| if ctx.name().is_empty() { 0.0 } else { 1.0 }),
     ));
     {
         let dsn = c.dsn().unwrap();
@@ -39,11 +35,9 @@ fn test_into_client() {
 #[test]
 fn test_unwind_safe() {
     let transport = sentry::test::TestTransport::new();
-    let options = sentry::ClientOptions {
-        dsn: Some("https://public@example.com/1".parse().unwrap()),
-        transport: Some(Arc::new(transport.clone())),
-        ..sentry::ClientOptions::default()
-    };
+    let options = sentry::ClientOptions::new()
+        .dsn("https://public@example.com/1")
+        .transport(transport.clone());
 
     let client: Arc<sentry::Client> = Arc::new(options.into());
 
@@ -62,14 +56,10 @@ fn test_unwind_safe() {
 
 #[test]
 fn test_concurrent_init() {
-    let _guard = sentry::init(sentry::ClientOptions {
-        ..Default::default()
-    });
+    let _guard = sentry::init(sentry::ClientOptions::new());
 
     std::thread::spawn(|| {
-        let _guard = sentry::init(sentry::ClientOptions {
-            ..Default::default()
-        });
+        let _guard = sentry::init(sentry::ClientOptions::new());
     })
     .join()
     .unwrap();
@@ -77,8 +67,5 @@ fn test_concurrent_init() {
 
 #[test]
 fn test_invalid_proxy() {
-    let _guard = sentry::init(sentry::ClientOptions {
-        https_proxy: Some("".into()),
-        ..Default::default()
-    });
+    let _guard = sentry::init(sentry::ClientOptions::new().https_proxy(""));
 }

--- a/sentry/tests/test_log_logs.rs
+++ b/sentry/tests/test_log_logs.rs
@@ -11,10 +11,7 @@ fn test_log_logs() {
         .map(|()| log::set_max_level(log::LevelFilter::Trace))
         .unwrap();
 
-    let options = sentry::ClientOptions {
-        enable_logs: true,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().enable_logs(true);
 
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {

--- a/sentry/tests/test_processors.rs
+++ b/sentry/tests/test_processors.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "test")]
 #![allow(clippy::unnecessary_wraps)]
-use std::sync::Arc;
 
 #[test]
 fn test_event_processors() {
@@ -52,11 +51,9 @@ fn test_before_callbacks() {
             });
             sentry::capture_message("Hello World!", sentry::Level::Warning);
         },
-        sentry::ClientOptions {
-            before_send: Some(Arc::new(Box::new(before_send))),
-            before_breadcrumb: Some(Arc::new(Box::new(before_breadcrumb))),
-            ..Default::default()
-        },
+        sentry::ClientOptions::new()
+            .before_send(before_send)
+            .before_breadcrumb(before_breadcrumb),
     );
 
     assert_eq!(events.len(), 1);
@@ -84,10 +81,7 @@ fn test_before_event_callback_drop() {
             });
             sentry::capture_message("Hello World!", sentry::Level::Warning);
         },
-        sentry::ClientOptions {
-            before_send: Some(Arc::new(Box::new(before_send))),
-            ..Default::default()
-        },
+        sentry::ClientOptions::new().before_send(before_send),
     );
 
     assert_eq!(events.len(), 0);
@@ -107,10 +101,7 @@ fn test_before_breadcrumb_callback_drop() {
             });
             sentry::capture_message("Hello World!", sentry::Level::Warning);
         },
-        sentry::ClientOptions {
-            before_breadcrumb: Some(Arc::new(Box::new(before_breadcrumb))),
-            ..Default::default()
-        },
+        sentry::ClientOptions::new().before_breadcrumb(before_breadcrumb),
     );
 
     assert_eq!(events.len(), 1);

--- a/sentry/tests/test_tower.rs
+++ b/sentry/tests/test_tower.rs
@@ -14,11 +14,9 @@ use tower::{ServiceBuilder, ServiceExt};
 fn test_tower_hub() {
     // Create a fake transport for new hubs
     let transport = TestTransport::new();
-    let opts = ClientOptions {
-        dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
-        transport: Some(Arc::new(transport.clone())),
-        ..Default::default()
-    };
+    let opts = ClientOptions::new()
+        .dsn("https://public@sentry.invalid/1")
+        .transport(transport.clone());
 
     let events = sentry::test::with_captured_events(|| {
         // This breadcrumb should be in all subsequent requests

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -128,10 +128,7 @@ fn test_span_record() {
         .with(sentry_tracing::layer())
         .set_default();
 
-    let options = sentry::ClientOptions {
-        traces_sample_rate: 1.0,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().traces_sample_rate(1.0);
 
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
@@ -157,10 +154,7 @@ fn test_span_record() {
 
 #[test]
 fn test_set_transaction() {
-    let options = sentry::ClientOptions {
-        traces_sample_rate: 1.0,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().traces_sample_rate(1.0);
 
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
@@ -203,10 +197,7 @@ fn test_tracing_logs() {
         .with(sentry_layer)
         .set_default();
 
-    let options = sentry::ClientOptions {
-        enable_logs: true,
-        ..Default::default()
-    };
+    let options = sentry::ClientOptions::new().enable_logs(true);
 
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {


### PR DESCRIPTION
Use the new `ClientOptions` builder methods in examples, docs, tests, and internal call sites that previously relied on struct literals with default updates. This keeps existing behavior while making these call sites compatible with a future `#[non_exhaustive]` `ClientOptions`.

References [#1219](https://github.com/getsentry/sentry-rust/issues/1219)
References [RUST-258](https://linear.app/getsentry/issue/RUST-258)