### PR TITLE
feat!(core): Add event sampling strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
       .release("my-app@1.0.0");
   ```
 - The `logs` and `metrics` features are now enabled by default in the `sentry` crate. This does not break the API, but may cause new telemetry to be sent to Sentry: log and tracing integrations can send structured logs, and applications can send metrics without adding the feature flags. Disable these features explicitly if this additional telemetry is not desired ([#1251](https://github.com/getsentry/sentry-rust/pull/1251)).
+- Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling.
 - Removed the public `ClientOptions::traces_sample_rate` and `ClientOptions::traces_sampler` fields. Use `ClientOptions::traces_sampling_strategy` to inspect the configured traces sampling strategy, and use the existing `ClientOptions::traces_sample_rate(...)` and `ClientOptions::traces_sampler(...)` builder setters to configure fixed-rate and callback-based sampling ([#1227](https://github.com/getsentry/sentry-rust/pull/1227)).
 
 ## 0.48.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   ```
 - The `logs` and `metrics` features are now enabled by default in the `sentry` crate. This does not break the API, but may cause new telemetry to be sent to Sentry: log and tracing integrations can send structured logs, and applications can send metrics without adding the feature flags. Disable these features explicitly if this additional telemetry is not desired ([#1251](https://github.com/getsentry/sentry-rust/pull/1251)).
 - Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling.
+- Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling ([#1228](https://github.com/getsentry/sentry-rust/pull/1228)).
 - Removed the public `ClientOptions::traces_sample_rate` and `ClientOptions::traces_sampler` fields. Use `ClientOptions::traces_sampling_strategy` to inspect the configured traces sampling strategy, and use the existing `ClientOptions::traces_sample_rate(...)` and `ClientOptions::traces_sampler(...)` builder setters to configure fixed-rate and callback-based sampling ([#1227](https://github.com/getsentry/sentry-rust/pull/1227)).
 
 ## 0.48.5

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -29,7 +29,7 @@ use crate::session::SessionFlusher;
 use crate::types::{Dsn, Uuid};
 #[cfg(feature = "release-health")]
 use crate::SessionMode;
-use crate::{ClientOptions, Envelope, Hub, Integration, Scope};
+use crate::{ClientOptions, Envelope, EventSamplingStrategy, Hub, Integration, Scope};
 
 #[cfg(feature = "logs")]
 use sentry_types::protocol::v7::Context;
@@ -46,6 +46,13 @@ mod envelope_sender;
 pub(crate) mod client_reports;
 
 pub(crate) use self::envelope_sender::EnvelopeSender;
+
+/// Functional implementation of how an event's sample rate is chosen.
+fn event_sample_rate(event_sampling_strategy: &EventSamplingStrategy) -> f32 {
+    match event_sampling_strategy {
+        &EventSamplingStrategy::FixedRate(rate) => rate,
+    }
+}
 
 impl<T: Into<ClientOptions>> From<T> for Client {
     fn from(o: T) -> Client {
@@ -386,7 +393,8 @@ impl Client {
             scope.update_session_from_event(&event);
         }
 
-        if !self.sample_should_send(self.options.sample_rate) {
+        let sample_rate = event_sample_rate(&self.options.event_sampling_strategy);
+        if !self.sample_should_send(sample_rate) {
             self.record_lost_event(ClientReportReason::SampleRate);
             None
         } else {

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -110,6 +110,22 @@ impl fmt::Debug for TracesSamplingStrategy {
     }
 }
 
+/// The sampling strategy for events.
+///
+/// Currently, we only support fixed rates. This defaults to `Self::FixedRate(1.0)`.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum EventSamplingStrategy {
+    /// Sample events at a fixed sample rate. The rate should be between 0.0 and 1.0, inclusive.
+    FixedRate(f32),
+}
+
+impl Default for EventSamplingStrategy {
+    fn default() -> Self {
+        Self::FixedRate(1.0)
+    }
+}
+
 /// Configuration settings for the client.
 ///
 /// These options are explained in more detail in the general
@@ -141,10 +157,10 @@ pub struct ClientOptions {
     ///
     /// See [`environment`](method@ClientOptions::environment) for details.
     pub environment: Option<Cow<'static, str>>,
-    /// The sample rate for event submission.
+    /// The sampling strategy for event submission.
     ///
-    /// See [`sample_rate`](method@ClientOptions::sample_rate) for details.
-    pub sample_rate: f32,
+    /// This can be set to with [`sample_rate`](method@ClientOptions::sample_rate).
+    pub event_sampling_strategy: EventSamplingStrategy,
     /// The traces sampling strategy.
     ///
     /// This can be set to a fixed rate with
@@ -319,7 +335,8 @@ impl ClientOptions {
         }
     }
 
-    /// Sets the [sample rate](field@ClientOptions::sample_rate) for event submission.
+    /// Sets the [event sampling strategy](field@ClientOptions::event_sampling_strategy) to a fixed
+    /// sample rate for event submission.
     ///
     /// Must be between `0.0` and `1.0`. Defaults to `1.0`.
     ///
@@ -332,8 +349,10 @@ impl ClientOptions {
             panic!("Sample rate {sample_rate} is outside the allowed range [0.0, 1.0].")
         }
 
+        let event_sampling_strategy = EventSamplingStrategy::FixedRate(sample_rate);
+
         Self {
-            sample_rate,
+            event_sampling_strategy,
             ..self
         }
     }
@@ -736,7 +755,7 @@ impl fmt::Debug for ClientOptions {
             .field("debug", &self.debug)
             .field("release", &self.release)
             .field("environment", &self.environment)
-            .field("sample_rate", &self.sample_rate)
+            .field("event_sampling_strategy", &self.event_sampling_strategy)
             .field("traces_sampling_strategy", &self.traces_sampling_strategy)
             .field("max_breadcrumbs", &self.max_breadcrumbs)
             .field("attach_stacktrace", &self.attach_stacktrace)
@@ -771,7 +790,7 @@ impl Default for ClientOptions {
             debug: false,
             release: None,
             environment: None,
-            sample_rate: 1.0,
+            event_sampling_strategy: Default::default(),
             traces_sampling_strategy: Default::default(),
             max_breadcrumbs: 100,
             attach_stacktrace: false,

--- a/sentry-core/src/lib.rs
+++ b/sentry-core/src/lib.rs
@@ -124,7 +124,7 @@ mod transport;
 pub use crate::api::*;
 pub use crate::breadcrumbs::IntoBreadcrumbs;
 pub use crate::clientoptions::{
-    BeforeCallback, ClientOptions, SessionMode, TracesSamplingStrategy,
+    BeforeCallback, ClientOptions, EventSamplingStrategy, SessionMode, TracesSamplingStrategy,
 };
 pub use crate::error::{capture_error, event_from_error, parse_type_from_debug};
 pub use crate::futures::{SentryFuture, SentryFutureExt};


### PR DESCRIPTION
Replace the public `ClientOptions::sample_rate` field with an `EventSamplingStrategy` enum while preserving the existing `sample_rate(...)` builder API for fixed-rate event sampling.

This mirrors the traces sampling model added in getsentry/sentry-rust#1227 and unblocks getsentry/sentry-rust#1127 by making it possible to add a sampling function variant to `EventSamplingStrategy` without another public field replacement.

BREAKING CHANGE: Remove the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect event sampling configuration, and continue using `ClientOptions::sample_rate(...)` to configure a fixed sample rate.

References [#1127](<https://github.com/getsentry/sentry-rust/issues/1127>)  <br>References getsentry/sentry-rust#1127