### PR TITLE
chore!(core): Make `ClientOptions` non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- [`ClientOptions`](https://docs.rs/sentry-core/0.49.0/sentry_core/struct.ClientOptions.html) is now `#[non_exhaustive]`. The struct must now be constructed with the builder-style setters:
+
+  ```rust
+  // Before
+  let options = sentry::ClientOptions {
+      dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+      debug: true,
+      release: Some("my-app@1.0.0".into()),
+      ..Default::default()
+  };
+
+  // After
+  let options = sentry::ClientOptions::new()
+      .dsn("https://examplePublicKey@o0.ingest.sentry.io/0")
+      .debug(true)
+      .release("my-app@1.0.0");
+  ```
+
 ## 0.48.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- [`ClientOptions`](https://docs.rs/sentry-core/0.49.0/sentry_core/struct.ClientOptions.html) is now `#[non_exhaustive]`. The struct must now be constructed with the builder-style setters:
+- [`ClientOptions`](https://docs.rs/sentry-core/0.49.0/sentry_core/struct.ClientOptions.html) is now `#[non_exhaustive]` ([#1230](https://github.com/getsentry/sentry-rust/pull/1230)). The struct must now be constructed with the builder-style setters:
 
   ```rust
   // Before

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -91,6 +91,7 @@ impl MaxRequestBodySize {
 /// ```
 #[derive(Clone)]
 #[must_use = "ClientOptions must be passed to sentry::init to have any effect"]
+#[non_exhaustive]
 pub struct ClientOptions {
     // Common options
     /// The DSN to use.


### PR DESCRIPTION
Make the `ClientOptions` struct `#[non_exhaustive]`.

Users will now have to rely on the builder methods to construct `ClientOptions`. This change will allow us to introduce new configuration options in future SDK releases without requiring a breaking release.

Closes [#1219](https://github.com/getsentry/sentry-rust/issues/1219)
Closes [RUST-258](https://linear.app/getsentry/issue/RUST-258)
