### PR TITLE
feat(core): Add `read_scope` for read-only scope access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- Added `sentry::read_scope` and `Hub::read_scope`, read-only counterparts to [`configure_scope`](https://docs.rs/sentry-core/0.48.4/sentry_core/fn.configure_scope.html) that avoid cloning the scope and writing it back.
+
 ## 0.48.4
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- Added `sentry::read_scope` and `Hub::read_scope`, read-only counterparts to [`configure_scope`](https://docs.rs/sentry-core/0.48.4/sentry_core/fn.configure_scope.html) that avoid cloning the scope and writing it back.
+- Added `sentry::read_scope` and `Hub::read_scope`, read-only counterparts to [`configure_scope`](https://docs.rs/sentry-core/0.48.4/sentry_core/fn.configure_scope.html) that avoid cloning the scope and writing it back. The `sentry-tracing` integration now uses this to resolve the parent span when creating a new span.
 
 ## 0.48.4
 

--- a/sentry-core/src/api.rs
+++ b/sentry-core/src/api.rs
@@ -157,6 +157,28 @@ where
     Hub::with_active(|hub| hub.configure_scope(f))
 }
 
+/// Invokes a function with read-only access to the current scope.
+///
+/// The function is passed a shared reference to the [`Scope`].  Because there
+/// might currently not be a scope or client active it's possible that the
+/// callback might not be called at all.  As a result of this the return value
+/// of this closure must have a default that is returned in such cases.
+///
+/// # Examples
+///
+/// ```
+/// # sentry::test::with_captured_events(|| {
+/// let span = sentry::read_scope(|scope| scope.get_span());
+/// # });
+/// ```
+pub fn read_scope<F, R>(f: F) -> R
+where
+    R: Default,
+    F: FnOnce(&Scope) -> R,
+{
+    Hub::with_active(|hub| hub.read_scope(f))
+}
+
 /// Temporarily pushes a scope for a single call optionally reconfiguring it.
 ///
 /// This function takes two arguments: the first is a callback that is passed

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -216,6 +216,24 @@ impl Hub {
         }
     }
 
+    /// Invokes a function with read-only access to the current scope.
+    ///
+    /// See the global [`read_scope`](crate::read_scope)
+    /// for more documentation.
+    pub fn read_scope<F, R>(&self, f: F) -> R
+    where
+        R: Default,
+        F: FnOnce(&Scope) -> R,
+    {
+        use_without_client!(f);
+        with_client_impl! {{
+            // Clone the `Arc<Scope>` out so the callback runs without
+            // holding the stack lock, keeping reentrant hub calls safe.
+            let scope = self.inner.with(|stack| stack.top().scope.clone());
+            f(&scope)
+        }}
+    }
+
     /// Invokes a function that can modify the current scope.
     ///
     /// See the global [`configure_scope`](fn.configure_scope.html)

--- a/sentry-tracing/src/layer/mod.rs
+++ b/sentry-tracing/src/layer/mod.rs
@@ -309,7 +309,7 @@ where
             sentry_op.unwrap_or_else(|| format!("{}::{}", span.metadata().target(), span.name()));
 
         let hub = sentry_core::Hub::current();
-        let parent_sentry_span = hub.configure_scope(|scope| scope.get_span());
+        let parent_sentry_span = hub.read_scope(|scope| scope.get_span());
 
         let mut sentry_span: sentry_core::TransactionOrSpan = match &parent_sentry_span {
             Some(parent) => parent.start_child(&sentry_op, sentry_name).into(),

--- a/sentry/examples/performance-demo.rs
+++ b/sentry/examples/performance-demo.rs
@@ -37,7 +37,7 @@ fn main_span1() {
         let transaction_ctx = sentry::TransactionContext::continue_from_span(
             "background transaction",
             "root span",
-            sentry::configure_scope(|scope| scope.get_span()),
+            sentry::read_scope(|scope| scope.get_span()),
         );
         thread::spawn(move || {
             let transaction = sentry::start_transaction(transaction_ctx);
@@ -76,7 +76,7 @@ fn wrap_in_span<F, R>(op: &str, description: &str, f: F) -> R
 where
     F: FnOnce() -> R,
 {
-    let parent = sentry::configure_scope(|scope| scope.get_span());
+    let parent = sentry::read_scope(|scope| scope.get_span());
     let span1: sentry::TransactionOrSpan = match &parent {
         Some(parent) => parent.start_child(op, description).into(),
         None => {

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -35,9 +35,7 @@ fn test_event_trace_context_from_propagation_context() {
     let mut last_event_id = None::<Uuid>;
     let mut span = None;
     let events = sentry::test::with_captured_events(|| {
-        sentry::configure_scope(|scope| {
-            span = scope.get_span();
-        });
+        span = sentry::read_scope(|scope| scope.get_span());
         sentry::capture_message("Hello World!", sentry::Level::Warning);
         last_event_id = sentry::last_event_id();
     });

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -161,6 +161,22 @@ fn test_reentrant_configure_scope() {
 }
 
 #[test]
+fn test_reentrant_read_scope() {
+    let events = sentry::test::with_captured_events(|| {
+        sentry::read_scope(|_scope| {
+            sentry::configure_scope(|scope| {
+                scope.set_tag("which_scope", "reentrant");
+            });
+        });
+
+        sentry::capture_message("look ma, no deadlock!", sentry::Level::Info);
+    });
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].tags["which_scope"], "reentrant");
+}
+
+#[test]
 fn test_attached_stacktrace() {
     let logger = sentry_log::SentryLogger::new();
 


### PR DESCRIPTION
`Hub::configure_scope` clones the entire scope and writes it back under the hub's write lock, which is wasteful on hot paths that only need to read scope data (e.g. integrations resolving the current span per event).

This PR adds `Hub::read_scope` which provides read-only access without the clone and write-back, and the global `sentry::read_scope` exposes the same via the active hub, mirroring `sentry::configure_scope`. It also switches existing call sites where appropriate.