### PR TITLE
test(tracing): Print count and debug output in assertion helpers

### DIFF
--- a/sentry-tracing/tests/await_cross_thread_guard.rs
+++ b/sentry-tracing/tests/await_cross_thread_guard.rs
@@ -136,8 +136,8 @@ fn futures_cross_thread_common(span: Span) -> Result<(), Box<dyn Any + Send + 's
 /// containing exactly one [`EnvelopeItem`], which is a [`Transaction`],
 /// with given [`name`](Transaction::name).
 fn assert_transaction(envelopes: Vec<Envelope>, name: &str) {
-    let envelope = get_and_assert_only_item(envelopes, "expected exactly one envelope");
-    let item = get_and_assert_only_item(envelope.into_items(), "expected exactly one item");
+    let envelope = get_and_assert_only_item(envelopes, "envelope");
+    let item = get_and_assert_only_item(envelope.into_items(), "envelope item");
 
     assert!(
         matches!(
@@ -180,15 +180,16 @@ fn noop_context() -> Context<'static> {
     Context::from_waker(Waker::noop())
 }
 
-/// Helper function to get and assert that there is exactly one item in the iterator.
-/// Extracts the only item from the iterator and returns it, or panics with the
-/// provided message if there are zero or multiple items.
-fn get_and_assert_only_item<I>(item_iter: I, message: &str) -> I::Item
+fn get_and_assert_only_item<I>(item_iter: I, what: &str) -> I::Item
 where
     I: IntoIterator,
+    I::Item: std::fmt::Debug,
 {
-    let mut iter = item_iter.into_iter();
-    let item = iter.next().expect(message);
-    assert!(iter.next().is_none(), "{message}");
-    item
+    let items: Vec<_> = item_iter.into_iter().collect();
+    assert!(
+        items.len() == 1,
+        "expected exactly one {what}, got {}: {items:#?}",
+        items.len()
+    );
+    items.into_iter().next().unwrap()
 }


### PR DESCRIPTION
I encountered the failing test described in https://github.com/getsentry/sentry-rust/issues/1112 again in https://github.com/getsentry/sentry-rust/actions/runs/29080836630/job/86323043895?pr=1214.
Given that that test failure could indicate a problem in the SDK, I'm making this change to the assertion helper to print more information, which will help understand what's going on.

Refs https://github.com/getsentry/sentry-rust/issues/1112
#skip-changelog