### PR TITLE
build(cargo): Centralize dependency declatations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "actix-router"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,11 +129,13 @@ checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
 dependencies = [
  "actix-codec",
  "actix-http",
+ "actix-macros",
  "actix-router",
  "actix-rt",
  "actix-server",
  "actix-service",
  "actix-utils",
+ "actix-web-codegen",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -148,6 +160,18 @@ dependencies = [
  "time",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,43 +29,25 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "base64",
  "bitflags 2.11.0",
- "brotli",
  "bytes",
  "bytestring",
  "derive_more",
  "encoding_rs",
- "flate2",
  "foldhash",
  "futures-core",
- "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
  "language-tags",
- "local-channel",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.10.1",
- "sha1",
  "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
- "zstd",
-]
-
-[[package]]
-name = "actix-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -77,7 +59,6 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "http 0.2.12",
- "regex",
  "regex-lite",
  "serde",
  "tracing",
@@ -138,17 +119,14 @@ checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
 dependencies = [
  "actix-codec",
  "actix-http",
- "actix-macros",
  "actix-router",
  "actix-rt",
  "actix-server",
  "actix-service",
  "actix-utils",
- "actix-web-codegen",
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
  "derive_more",
  "encoding_rs",
  "foldhash",
@@ -161,7 +139,6 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite",
- "regex",
  "regex-lite",
  "serde",
  "serde_json",
@@ -171,18 +148,6 @@ dependencies = [
  "time",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -216,21 +181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
 dependencies = [
  "as-slice",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -486,42 +436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -652,17 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,12 +665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "const_format"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,17 +694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,24 +708,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "criterion"
@@ -907,15 +781,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
 
 [[package]]
 name = "curl"
@@ -1081,17 +946,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
 ]
 
 [[package]]
@@ -1426,16 +1280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,7 +1465,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1660,25 +1503,6 @@ dependencies = [
  "bitflags 1.3.2",
  "ignore",
  "walkdir",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1859,15 +1683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,7 +1692,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body",
  "httparse",
@@ -2319,17 +2134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
 name = "local-waker"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,7 +2197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2479,15 +2282,6 @@ name = "normpath"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3123,17 +2917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,12 +2953,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -3810,17 +3587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,12 +3610,6 @@ dependencies = [
  "errno",
  "libc",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
@@ -4243,7 +4003,7 @@ dependencies = [
  "axum 0.7.9",
  "base64",
  "bytes",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -4377,9 +4137,7 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
- "nu-ansi-term",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing-core",
  "tracing-log",
@@ -4390,12 +4148,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uname"
@@ -5249,31 +5001,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,64 @@ arithmetic-side-effects.level = "warn"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+
+[workspace.dependencies]
+actix-http = "3.12"
+actix-web = { version = "4", default-features = false }
+anyhow = "1.0.77"
+axum = { version = "0.8", default-features = false }
+backtrace = "0.3.44"
+bitflags = "2.9.4"
+bytes = "1.11.1"
+cfg_aliases = "0.2.1"
+criterion = "0.5"
+curl = "0.4.25"
+debugid = "0.8.0"
+embedded-svc = "0.28.1"
+erased-serde = "0.3.12"
+findshlibs = "=0.10.2"
+futures = "0.3.24"
+futures-util = { version = "0.3.5", default-features = false }
+hex = "0.4.3"
+hostname = "0.4"
+http = "1.0.0"
+httpdate = "1.0.0"
+libc = "0.2.66"
+log = "0.4.8"
+native-tls = "0.2.8"
+opentelemetry = { version = "0.29.0", default-features = false }
+opentelemetry_sdk = { version = "0.29.0", default-features = false }
+pin-project = "1.0.10"
+pretty_env_logger = "0.5.0"
+prost = "0.13.3"
+rand = "0.9.3"
+rayon = "1.5.3"
+regex = { version = "1.5.5", default-features = false }
+reqwest = { version = "0.13.2", default-features = false }
+rstest = "0.25.0"
+rustc_version = "0.4.0"
+rustls = { version = "0.23.18", default-features = false }
+sentry = { path = "sentry", default-features = false }
+sentry-actix = { version = "0.48.5", path = "sentry-actix", default-features = false }
+sentry-backtrace = { version = "0.48.5", path = "sentry-backtrace" }
+sentry-contexts = { version = "0.48.5", path = "sentry-contexts" }
+sentry-debug-images = { version = "0.48.5", path = "sentry-debug-images" }
+sentry-opentelemetry = { version = "0.48.5", path = "sentry-opentelemetry" }
+sentry-panic = { version = "0.48.5", path = "sentry-panic" }
+sentry-types = { version = "0.48.5", path = "sentry-types" }
+serde = "1.0.117"
+serde_json = "1.0.48"
+slog = "2.5.2"
+thiserror = "2.0.12"
+time = "0.3.47"
+tokio = "1.44"
+tonic = "0.12.3"
+tower = "0.5.2"
+tower-layer = "0.3"
+tower-service = "0.3"
+tracing = "0.1"
+tracing-core = "0.1"
+tracing-subscriber = { version = "0.3.20", default-features = false }
+ureq = { version = "3.0.11", default-features = false }
+url = "2.2.2"
+uuid = "1.0.0"

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -29,7 +29,7 @@ sentry-core = { version = "0.48.5", path = "../sentry-core", default-features = 
 actix-http = { workspace = true }
 
 [dev-dependencies]
-actix-web = { workspace = true }
+actix-web = { workspace = true, features = ["macros"] }
 futures = { workspace = true }
 sentry = { workspace = true, features = ["test"] }
 tokio = { workspace = true, features = ["full"] }

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -20,16 +20,16 @@ default = ["release-health"]
 release-health = ["sentry-core/release-health"]
 
 [dependencies]
-actix-web = { version = "4", default-features = false }
-bytes = "1.11.1"
-futures-util = { version = "0.3.5", default-features = false }
+actix-web = { workspace = true }
+bytes = { workspace = true }
+futures-util = { workspace = true }
 sentry-core = { version = "0.48.5", path = "../sentry-core", default-features = false, features = [
     "client",
 ] }
-actix-http = "3.12"
+actix-http = { workspace = true }
 
 [dev-dependencies]
-actix-web = { version = "4" }
-futures = "0.3"
-sentry = { path = "../sentry", features = ["test"] }
-tokio = { version = "1.44", features = ["full"] }
+actix-web = { workspace = true }
+futures = { workspace = true }
+sentry = { workspace = true, features = ["test"] }
+tokio = { workspace = true, features = ["full"] }

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -20,9 +20,9 @@ default = ["backtrace"]
 backtrace = []
 
 [dependencies]
-sentry-backtrace = { version = "0.48.5", path = "../sentry-backtrace" }
+sentry-backtrace = { workspace = true }
 sentry-core = { version = "0.48.5", path = "../sentry-core" }
-anyhow = "1.0.77"
+anyhow = { workspace = true }
 
 [dev-dependencies]
-sentry = { path = "../sentry", default-features = false, features = ["test"] }
+sentry = { workspace = true, features = ["test"] }

--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -16,9 +16,6 @@ rust-version = { workspace = true }
 workspace = true
 
 [dependencies]
-backtrace = "0.3.44"
-regex = { version = "1.5.5", default-features = false, features = [
-    "std",
-    "unicode-perl",
-] }
+backtrace = { workspace = true }
+regex = { workspace = true, features = ["std", "unicode-perl"] }
 sentry-core = { version = "0.48.5", path = "../sentry-core" }

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 sentry-core = { version = "0.48.5", path = "../sentry-core" }
-libc = "0.2.66"
-hostname = "0.4"
+libc = { workspace = true }
+hostname = { workspace = true }
 
 [target."cfg(not(windows))".dependencies]
 uname = "0.1.1"
@@ -28,7 +28,7 @@ uname = "0.1.1"
 os_info = "3.5.0"
 
 [build-dependencies]
-rustc_version = "0.4.0"
+rustc_version = { workspace = true }
 
 [dev-dependencies]
-sentry = { path = "../sentry", default-features = false, features = ["test"] }
+sentry = { workspace = true, features = ["test"] }

--- a/sentry-core/Cargo.toml
+++ b/sentry-core/Cargo.toml
@@ -31,26 +31,22 @@ logs = []
 metrics = []
 
 [dependencies]
-log = { version = "0.4.8", optional = true, features = ["std"] }
-rand = { version = "0.9.3", optional = true }
-sentry-types = { version = "0.48.5", path = "../sentry-types" }
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = { version = "1.0.46" }
-url = { version = "2.1.1" }
-uuid = { version = "1.0.0", features = ["v4", "serde"], optional = true }
+log = { workspace = true, features = ["std"], optional = true }
+rand = { workspace = true, optional = true }
+sentry-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 
 [dev-dependencies]
 # Because we re-export all the public API in `sentry`, we actually run all the
 # doctests using the `sentry` crate. This also takes care of the doctest
 # limitation documented in https://github.com/rust-lang/rust/issues/45599.
-sentry = { path = "../sentry", default-features = false, features = [
-    "test",
-    "transport",
-    "metrics",
-] }
-anyhow = "1.0.30"
-criterion = "0.5"
-futures = "0.3.24"
-rayon = "1.5.3"
-thiserror = "2.0.12"
-tokio = { version = "1.44", features = ["rt", "rt-multi-thread", "macros"] }
+sentry = { workspace = true, features = ["test", "transport", "metrics"] }
+anyhow = { workspace = true }
+criterion = { workspace = true }
+futures = { workspace = true }
+rayon = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -16,5 +16,5 @@ rust-version = { workspace = true }
 workspace = true
 
 [dependencies]
-findshlibs = "=0.10.2"
+findshlibs = { workspace = true }
 sentry-core = { version = "0.48.5", path = "../sentry-core" }

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -21,9 +21,9 @@ logs = ["sentry-core/logs"]
 
 [dependencies]
 sentry-core = { version = "0.48.5", path = "../sentry-core" }
-log = { version = "0.4.8", features = ["std", "kv"] }
-bitflags = "2.9.4"
+log = { workspace = true, features = ["std", "kv"] }
+bitflags = { workspace = true }
 
 [dev-dependencies]
-sentry = { path = "../sentry", default-features = false, features = ["test"] }
-pretty_env_logger = "0.5.0"
+sentry = { workspace = true, features = ["test"] }
+pretty_env_logger = { workspace = true }

--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -22,15 +22,10 @@ all-features = true
 sentry-core = { version = "0.48.5", path = "../sentry-core", features = [
     "client",
 ] }
-opentelemetry = { version = "0.29.0", default-features = false }
-opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
-    "trace",
-] }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["trace"] }
 
 [dev-dependencies]
-sentry = { path = "../sentry", features = ["test", "opentelemetry"] }
+sentry = { workspace = true, features = ["test", "opentelemetry"] }
 sentry-core = { path = "../sentry-core", features = [ "test" ] }
-opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
-    "trace",
-    "testing",
-] }
+opentelemetry_sdk = { workspace = true, features = ["trace", "testing"] }

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 sentry-core = { version = "0.48.5", path = "../sentry-core", features = ["client"] }
-sentry-backtrace = { version = "0.48.5", path = "../sentry-backtrace" }
+sentry-backtrace = { workspace = true }
 
 [dev-dependencies]
-sentry = { path = "../sentry", default-features = false, features = ["test"] }
+sentry = { workspace = true, features = ["test"] }

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -17,10 +17,10 @@ workspace = true
 
 [dependencies]
 sentry-core = { version = "0.48.5", path = "../sentry-core" }
-slog = { version = "2.5.2", features = ["nested-values"] }
-serde_json = "1.0.46"
+slog = { workspace = true, features = ["nested-values"] }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-sentry = { path = "../sentry", default-features = false, features = ["test"] }
-serde = "1.0.117"
-erased-serde = "0.3.12"
+sentry = { workspace = true, features = ["test"] }
+serde = { workspace = true }
+erased-serde = { workspace = true }

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -24,21 +24,21 @@ http = ["dep:http", "pin-project", "url"]
 axum-matched-path = ["http", "axum/matched-path"]
 
 [dependencies]
-axum = { version = "0.8", optional = true, default-features = false }
-tower-layer = "0.3"
-tower-service = "0.3"
-http = { version = "1.0.0", optional = true }
-pin-project = { version = "1.0.10", optional = true }
+axum = { workspace = true, optional = true }
+tower-layer = { workspace = true }
+tower-service = { workspace = true }
+http = { workspace = true, optional = true }
+pin-project = { workspace = true, optional = true }
 sentry-core = { version = "0.48.5", path = "../sentry-core", default-features = false, features = [
     "client",
 ] }
-url = { version = "2.2.2", optional = true }
+url = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow = "1"
-prost = "0.13.3"
-sentry = { path = "../sentry", default-features = false, features = ["test"] }
+anyhow = { workspace = true }
+prost = { workspace = true }
+sentry = { workspace = true, features = ["test"] }
 sentry-anyhow = { path = "../sentry-anyhow" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tonic = { version = "0.12.3", features = ["transport"] }
-tower = { version = "0.5.2", features = ["util", "timeout"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tonic = { workspace = true, features = ["transport"] }
+tower = { workspace = true, features = ["util", "timeout"] }

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -27,17 +27,15 @@ logs = ["sentry-core/logs"]
 sentry-core = { version = "0.48.5", path = "../sentry-core", features = [
     "client",
 ] }
-tracing-core = "0.1"
-tracing-subscriber = { version = "0.3.20", default-features = false, features = [
-    "std",
-] }
-sentry-backtrace = { version = "0.48.5", path = "../sentry-backtrace", optional = true }
-bitflags = "2.9.4"
+tracing-core = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["std"] }
+sentry-backtrace = { workspace = true, optional = true }
+bitflags = { workspace = true }
 
 [dev-dependencies]
-log = "0.4"
-sentry = { path = "../sentry", default-features = false, features = ["test", "tracing"] }
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.20", features = ["fmt", "registry"] }
-tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "time"] }
+log = { workspace = true }
+sentry = { workspace = true, features = ["test", "tracing"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "registry"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }

--- a/sentry-types/Cargo.toml
+++ b/sentry-types/Cargo.toml
@@ -24,15 +24,15 @@ default = ["protocol"]
 protocol = []
 
 [dependencies]
-debugid = { version = "0.8.0", features = ["serde"] }
-hex = "0.4.3"
-rand = "0.9.3"
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.46"
-thiserror = "2.0.12"
-time = { version = "0.3.47", features = ["formatting", "parsing"] }
-url = { version = "2.1.1", features = ["serde"] }
-uuid = { version = "1.0.0", features = ["serde"] }
+debugid = { workspace = true, features = ["serde"] }
+hex = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["formatting", "parsing"] }
+url = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-rstest = "0.25.0"
+rstest = { workspace = true }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -72,28 +72,25 @@ sentry-core = { version = "0.48.5", path = "../sentry-core", features = [
     "client",
 ] }
 sentry-anyhow = { version = "0.48.5", path = "../sentry-anyhow", optional = true }
-sentry-actix = { version = "0.48.5", path = "../sentry-actix", optional = true, default-features = false }
-sentry-backtrace = { version = "0.48.5", path = "../sentry-backtrace", optional = true }
-sentry-contexts = { version = "0.48.5", path = "../sentry-contexts", optional = true }
-sentry-debug-images = { version = "0.48.5", path = "../sentry-debug-images", optional = true }
+sentry-actix = { workspace = true, optional = true }
+sentry-backtrace = { workspace = true, optional = true }
+sentry-contexts = { workspace = true, optional = true }
+sentry-debug-images = { workspace = true, optional = true }
 sentry-log = { version = "0.48.5", path = "../sentry-log", optional = true }
-sentry-panic = { version = "0.48.5", path = "../sentry-panic", optional = true }
+sentry-panic = { workspace = true, optional = true }
 sentry-slog = { version = "0.48.5", path = "../sentry-slog", optional = true }
 sentry-tower = { version = "0.48.5", path = "../sentry-tower", optional = true }
 sentry-tracing = { version = "0.48.5", path = "../sentry-tracing", optional = true }
-sentry-opentelemetry = { version = "0.48.5", path = "../sentry-opentelemetry", optional = true }
-reqwest = { version = "0.13.2", optional = true, features = [
-    "blocking",
-    "json",
-], default-features = false }
-curl = { version = "0.4.25", optional = true }
-httpdate = { version = "1.0.0", optional = true }
-serde_json = { version = "1.0.48", optional = true }
-tokio = { version = "1.44", features = ["rt"], optional = true }
-ureq = { version = "3.0.11", optional = true, default-features = false }
-native-tls = { version = "0.2.8", optional = true }
-rustls = { version = "0.23.18", optional = true, default-features = false }
-embedded-svc = { version = "0.28.1", optional = true }
+sentry-opentelemetry = { workspace = true, optional = true }
+reqwest = { workspace = true, features = ["blocking", "json"], optional = true }
+curl = { workspace = true, optional = true }
+httpdate = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
+ureq = { workspace = true, optional = true }
+native-tls = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+embedded-svc = { workspace = true, optional = true }
 [target.'cfg(target_os = "espidf")'.dependencies]
 esp-idf-svc = { version = "0.51.0", optional = true }
 
@@ -103,18 +100,18 @@ sentry-log = { path = "../sentry-log" }
 sentry-slog = { path = "../sentry-slog" }
 sentry-tower = { path = "../sentry-tower" }
 sentry-tracing = { path = "../sentry-tracing" }
-actix-web = { version = "4", default-features = false }
-anyhow = { version = "1.0.30" }
-log = { version = "0.4.8", features = ["std"] }
-pretty_env_logger = "0.5.0"
-slog = { version = "2.5.2" }
-tokio = { version = "1.44", features = ["macros"] }
-tower = { version = "0.5.2", features = ["util"] }
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["fmt", "tracing-log"] }
+actix-web = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true, features = ["std"] }
+pretty_env_logger = { workspace = true }
+slog = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+tower = { workspace = true, features = ["util"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "tracing-log"] }
 
 [lints]
 workspace = true
 
 [build-dependencies]
-cfg_aliases = "0.2.1"
+cfg_aliases = { workspace = true }


### PR DESCRIPTION
Centralize dependency declarations by moving them to the workspace-level `Cargo.toml`.

This PR contains two commits:

- 2e0608cad01df434c2504bc6e6c987b73853f18b is fully generated by [`cargo autoinherit`](https://github.com/mainmatter/cargo-autoinherit).
- 123f38a810e91e539981077f3606379b64559901 re-enables a crate feature, which got disabled by `cargo autoinherit` because if `default-features = false` is used for a dependency in one of the workspace members, then this gets centralized in the workspace.

This does not centralize all dependency declarations, because `cargo autoinherit` skips some things, but most everything is centralized now.