### PR TITLE
build(cargo): Finish workspace dependency inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ curl = "0.4.25"
 debugid = "0.8.0"
 embedded-svc = "0.28.1"
 erased-serde = "0.3.12"
+esp-idf-svc = "0.51.0"
 findshlibs = "=0.10.2"
 futures = "0.3.24"
 futures-util = { version = "0.3.5", default-features = false }
@@ -57,6 +58,7 @@ log = "0.4.8"
 native-tls = "0.2.8"
 opentelemetry = { version = "0.32.0", default-features = false }
 opentelemetry_sdk = { version = "0.32.1", default-features = false }
+os_info = "3.5.0"
 pin-project = "1.0.10"
 pretty_env_logger = "0.5.0"
 prost = "0.13.3"
@@ -67,14 +69,20 @@ reqwest = { version = "0.13.2", default-features = false }
 rstest = "0.25.0"
 rustc_version = "0.4.0"
 rustls = { version = "0.23.18", default-features = false }
-sentry = { path = "sentry", default-features = false }
+sentry = { version = "0.48.5", path = "sentry", default-features = false }
 sentry-actix = { version = "0.48.5", path = "sentry-actix", default-features = false }
-sentry-backtrace = { version = "0.48.5", path = "sentry-backtrace" }
-sentry-contexts = { version = "0.48.5", path = "sentry-contexts" }
-sentry-debug-images = { version = "0.48.5", path = "sentry-debug-images" }
-sentry-opentelemetry = { version = "0.48.5", path = "sentry-opentelemetry" }
-sentry-panic = { version = "0.48.5", path = "sentry-panic" }
-sentry-types = { version = "0.48.5", path = "sentry-types" }
+sentry-anyhow = { version = "0.48.5", path = "sentry-anyhow", default-features = false, features = ["backtrace"] }
+sentry-backtrace = { version = "0.48.5", path = "sentry-backtrace", default-features = false }
+sentry-contexts = { version = "0.48.5", path = "sentry-contexts", default-features = false }
+sentry-core = { version = "0.48.5", path = "sentry-core", default-features = false }
+sentry-debug-images = { version = "0.48.5", path = "sentry-debug-images", default-features = false }
+sentry-log = { version = "0.48.5", path = "sentry-log", default-features = false }
+sentry-opentelemetry = { version = "0.48.5", path = "sentry-opentelemetry", default-features = false }
+sentry-panic = { version = "0.48.5", path = "sentry-panic", default-features = false }
+sentry-slog = { version = "0.48.5", path = "sentry-slog", default-features = false }
+sentry-tower = { version = "0.48.5", path = "sentry-tower", default-features = false }
+sentry-tracing = { version = "0.48.5", path = "sentry-tracing", default-features = false }
+sentry-types = { version = "0.48.5", path = "sentry-types", default-features = false, features = ["protocol"] }
 serde = "1.0.117"
 serde_json = "1.0.48"
 slog = "2.5.2"
@@ -88,6 +96,7 @@ tower-service = "0.3"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3.20", default-features = false }
+uname = "0.1.1"
 ureq = { version = "3.0.11", default-features = false }
 url = "2.2.2"
 uuid = "1.0.0"

--- a/sentry-actix/Cargo.toml
+++ b/sentry-actix/Cargo.toml
@@ -23,9 +23,7 @@ release-health = ["sentry-core/release-health"]
 actix-web = { workspace = true }
 bytes = { workspace = true }
 futures-util = { workspace = true }
-sentry-core = { version = "0.48.5", path = "../sentry-core", default-features = false, features = [
-    "client",
-] }
+sentry-core = { workspace = true, features = ["client"] }
 actix-http = { workspace = true }
 
 [dev-dependencies]

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -21,7 +21,7 @@ backtrace = []
 
 [dependencies]
 sentry-backtrace = { workspace = true }
-sentry-core = { version = "0.48.5", path = "../sentry-core" }
+sentry-core = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]

--- a/sentry-backtrace/Cargo.toml
+++ b/sentry-backtrace/Cargo.toml
@@ -18,4 +18,4 @@ workspace = true
 [dependencies]
 backtrace = { workspace = true }
 regex = { workspace = true, features = ["std", "unicode-perl"] }
-sentry-core = { version = "0.48.5", path = "../sentry-core" }
+sentry-core = { workspace = true }

--- a/sentry-contexts/Cargo.toml
+++ b/sentry-contexts/Cargo.toml
@@ -17,15 +17,15 @@ rust-version = { workspace = true }
 workspace = true
 
 [dependencies]
-sentry-core = { version = "0.48.5", path = "../sentry-core" }
+sentry-core = { workspace = true }
 libc = { workspace = true }
 hostname = { workspace = true }
 
 [target."cfg(not(windows))".dependencies]
-uname = "0.1.1"
+uname = { workspace = true }
 
 [target."cfg(windows)".dependencies]
-os_info = "3.5.0"
+os_info = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/sentry-debug-images/Cargo.toml
+++ b/sentry-debug-images/Cargo.toml
@@ -17,4 +17,4 @@ workspace = true
 
 [dependencies]
 findshlibs = { workspace = true }
-sentry-core = { version = "0.48.5", path = "../sentry-core" }
+sentry-core = { workspace = true }

--- a/sentry-log/Cargo.toml
+++ b/sentry-log/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 logs = ["sentry-core/logs"]
 
 [dependencies]
-sentry-core = { version = "0.48.5", path = "../sentry-core" }
+sentry-core = { workspace = true }
 log = { workspace = true, features = ["std", "kv"] }
 bitflags = { workspace = true }
 

--- a/sentry-opentelemetry/Cargo.toml
+++ b/sentry-opentelemetry/Cargo.toml
@@ -19,13 +19,11 @@ workspace = true
 all-features = true
 
 [dependencies]
-sentry-core = { version = "0.48.5", path = "../sentry-core", features = [
-    "client",
-] }
+sentry-core = { workspace = true, features = ["client"] }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["trace"] }
 
 [dev-dependencies]
 sentry = { workspace = true, features = ["test", "opentelemetry"] }
-sentry-core = { path = "../sentry-core", features = [ "test" ] }
+sentry-core = { workspace = true, features = ["test"] }
 opentelemetry_sdk = { workspace = true, features = ["trace", "testing"] }

--- a/sentry-panic/Cargo.toml
+++ b/sentry-panic/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = { workspace = true }
 workspace = true
 
 [dependencies]
-sentry-core = { version = "0.48.5", path = "../sentry-core", features = ["client"] }
+sentry-core = { workspace = true, features = ["client"] }
 sentry-backtrace = { workspace = true }
 
 [dev-dependencies]

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = { workspace = true }
 workspace = true
 
 [dependencies]
-sentry-core = { version = "0.48.5", path = "../sentry-core" }
+sentry-core = { workspace = true }
 slog = { workspace = true, features = ["nested-values"] }
 serde_json = { workspace = true }
 

--- a/sentry-tower/Cargo.toml
+++ b/sentry-tower/Cargo.toml
@@ -29,16 +29,14 @@ tower-layer = { workspace = true }
 tower-service = { workspace = true }
 http = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
-sentry-core = { version = "0.48.5", path = "../sentry-core", default-features = false, features = [
-    "client",
-] }
+sentry-core = { workspace = true, features = ["client"] }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 prost = { workspace = true }
 sentry = { workspace = true, features = ["test"] }
-sentry-anyhow = { path = "../sentry-anyhow" }
+sentry-anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true, features = ["transport"] }
 tower = { workspace = true, features = ["util", "timeout"] }

--- a/sentry-tracing/Cargo.toml
+++ b/sentry-tracing/Cargo.toml
@@ -24,9 +24,7 @@ backtrace = ["dep:sentry-backtrace"]
 logs = ["sentry-core/logs"]
 
 [dependencies]
-sentry-core = { version = "0.48.5", path = "../sentry-core", features = [
-    "client",
-] }
+sentry-core = { workspace = true, features = ["client"] }
 tracing-core = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["std"] }
 sentry-backtrace = { workspace = true, optional = true }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -68,19 +68,17 @@ rustls-no-provider = ["dep:rustls", "reqwest?/rustls-no-provider", "ureq?/rustls
 embedded-svc-http = ["dep:embedded-svc", "dep:esp-idf-svc"]
 
 [dependencies]
-sentry-core = { version = "0.48.5", path = "../sentry-core", features = [
-    "client",
-] }
-sentry-anyhow = { version = "0.48.5", path = "../sentry-anyhow", optional = true }
+sentry-core = { workspace = true, features = ["client"] }
+sentry-anyhow = { workspace = true, optional = true }
 sentry-actix = { workspace = true, optional = true }
 sentry-backtrace = { workspace = true, optional = true }
 sentry-contexts = { workspace = true, optional = true }
 sentry-debug-images = { workspace = true, optional = true }
-sentry-log = { version = "0.48.5", path = "../sentry-log", optional = true }
+sentry-log = { workspace = true, optional = true }
 sentry-panic = { workspace = true, optional = true }
-sentry-slog = { version = "0.48.5", path = "../sentry-slog", optional = true }
-sentry-tower = { version = "0.48.5", path = "../sentry-tower", optional = true }
-sentry-tracing = { version = "0.48.5", path = "../sentry-tracing", optional = true }
+sentry-slog = { workspace = true, optional = true }
+sentry-tower = { workspace = true, optional = true }
+sentry-tracing = { workspace = true, optional = true }
 sentry-opentelemetry = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["blocking", "json"], optional = true }
 curl = { workspace = true, optional = true }
@@ -92,14 +90,14 @@ native-tls = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 embedded-svc = { workspace = true, optional = true }
 [target.'cfg(target_os = "espidf")'.dependencies]
-esp-idf-svc = { version = "0.51.0", optional = true }
+esp-idf-svc = { workspace = true, optional = true }
 
 [dev-dependencies]
-sentry-anyhow = { path = "../sentry-anyhow" }
-sentry-log = { path = "../sentry-log" }
-sentry-slog = { path = "../sentry-slog" }
-sentry-tower = { path = "../sentry-tower" }
-sentry-tracing = { path = "../sentry-tracing" }
+sentry-anyhow = { workspace = true }
+sentry-log = { workspace = true }
+sentry-slog = { workspace = true }
+sentry-tower = { workspace = true }
+sentry-tracing = { workspace = true }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
 log = { workspace = true, features = ["std"] }


### PR DESCRIPTION
`cargo autoinherit` left path and target-specific dependencies local. Centralize the remaining internal crates and target-only externals, unify internal path deps on `default-features = false`, and keep shared feature baselines on the workspace entries that every consumer needs (`sentry-anyhow/backtrace`, `sentry-types/protocol`).

Also, ensure every `sentry` dep has a version.