### PR TITLE
feat!(sentry): Enable logs and metrics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
       .debug(true)
       .release("my-app@1.0.0");
   ```
+- The `logs` and `metrics` features are now enabled by default in the `sentry` crate. This does not break the API, but may cause new telemetry to be sent to Sentry: log and tracing integrations can send structured logs, and applications can send metrics without adding the feature flags. Disable these features explicitly if this additional telemetry is not desired.
 
 ## 0.48.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
       .debug(true)
       .release("my-app@1.0.0");
   ```
-- The `logs` and `metrics` features are now enabled by default in the `sentry` crate. This does not break the API, but may cause new telemetry to be sent to Sentry: log and tracing integrations can send structured logs, and applications can send metrics without adding the feature flags. Disable these features explicitly if this additional telemetry is not desired.
+- The `logs` and `metrics` features are now enabled by default in the `sentry` crate. This does not break the API, but may cause new telemetry to be sent to Sentry: log and tracing integrations can send structured logs, and applications can send metrics without adding the feature flags. Disable these features explicitly if this additional telemetry is not desired ([#1251](https://github.com/getsentry/sentry-rust/pull/1251)).
 
 ## 0.48.5
 

--- a/sentry-log/README.md
+++ b/sentry-log/README.md
@@ -21,8 +21,8 @@ The `log` crate is supported in three ways:
 
 By default anything at or above `Info` is recorded as a breadcrumb and
 anything at or above `Error` is captured as error event.
-Additionally, if the `sentry` crate is used with the `logs` feature flag, anything at or above `Info`
-is captured as a [Structured Log](https://docs.sentry.io/product/explore/logs/).
+When the `logs` feature is enabled (as it is by default in the `sentry` crate), anything at or above
+`Info` is captured as a [Structured Log](https://docs.sentry.io/product/explore/logs/).
 
 ## Examples
 

--- a/sentry-tracing/README.md
+++ b/sentry-tracing/README.md
@@ -93,8 +93,9 @@ for i in 0..10 {
 ## Capturing logs
 
 Tracing events can be captured as traditional structured logs in Sentry.
-This is gated by the `logs` feature flag and requires setting up a custom Event filter/mapper
-to capture logs. You also need to pass `enable_logs: true` in your `sentry::init` call.
+This requires the `logs` feature, which is enabled by default in the `sentry` crate, and setting up
+a custom Event filter/mapper to capture logs. `enable_logs` defaults to `true`, but can be set explicitly
+in your `sentry::init` call.
 
 ```rust
 // assuming `tracing::Level::INFO => EventFilter::Log` in your `event_filter`

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -25,6 +25,8 @@ default = [
     "backtrace",
     "contexts",
     "debug-images",
+    "logs",
+    "metrics",
     "panic",
     "transport",
     "release-health",

--- a/sentry/README.md
+++ b/sentry/README.md
@@ -74,7 +74,8 @@ extra setup to function properly.
 | `transport`       | ✅      |                |            |                                                                                          |
 | `anyhow`          |         | 🔌             |            |                                                                                          |
 | `test`            |         |                |            |                                                                                          |
-| `metrics`         |         |                |            | Enables metrics capture APIs.                                                            |
+| `logs`            | ✅      |                |            | Enables structured log capture APIs.                                                     |
+| `metrics`         | ✅      |                |            | Enables metrics capture APIs.                                                            |
 | `debug-images`    | ✅      | 🔌             |            |                                                                                          |
 | `log`             |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 | `slog`            |         | 🔌             |            | Requires extra setup; See [`sentry-slog`]'s documentation.                               |
@@ -102,6 +103,8 @@ extra setup to function properly.
 - `panic`: Enables support for capturing panics.
 - `transport`: Enables the default transport, which is currently `reqwest` with `native-tls`.
 - `debug-images`: Enables capturing metadata about the loaded shared libraries.
+- `logs`: Enables structured log capture APIs and support in the `log` and `tracing` integrations.
+- `metrics`: Enables metric capture APIs.
 
 ### Debugging/Testing
 - `anyhow`: Enables support for the `anyhow` crate.

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -66,7 +66,8 @@
 //! | `transport`       | ✅      |                |            |                                                                                          |
 //! | `anyhow`          |         | 🔌             |            |                                                                                          |
 //! | `test`            |         |                |            |                                                                                          |
-//! | `metrics`         |         |                |            | Enables metrics capture APIs.                                                            |
+//! | `logs`            | ✅      |                |            | Enables structured log capture APIs.                                                     |
+//! | `metrics`         | ✅      |                |            | Enables metrics capture APIs.                                                            |
 //! | `debug-images`    | ✅      | 🔌             |            |                                                                                          |
 //! | `log`             |         | 🔌             |            | Requires extra setup; See [`sentry-log`]'s documentation.                                |
 //! | `slog`            |         | 🔌             |            | Requires extra setup; See [`sentry-slog`]'s documentation.                               |
@@ -94,6 +95,8 @@
 //! - `panic`: Enables support for capturing panics.
 //! - `transport`: Enables the default transport, which is currently `reqwest` with `native-tls`.
 //! - `debug-images`: Enables capturing metadata about the loaded shared libraries.
+//! - `logs`: Enables structured log capture APIs and support in the `log` and `tracing` integrations.
+//! - `metrics`: Enables metric capture APIs.
 //!
 //! ## Debugging/Testing
 //! - `anyhow`: Enables support for the `anyhow` crate.


### PR DESCRIPTION
Enable the `logs` and `metrics` features in the default feature set and update the crate documentation to reflect the new defaults and telemetry behavior.

Resolves [#1104](https://github.com/getsentry/sentry-rust/issues/1104)
Resolves [RUST-206](https://linear.app/getsentry/issue/RUST-206/enable-logging-by-default-rust)