### PR TITLE
feat(tower): Record http.response.status_code on HTTP transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### New Features
+### Features
 
 - `SentryHttpLayer` now records the [`http.response.status_code`](https://getsentry.github.io/sentry-conventions/attributes/http/) attribute on transactions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- `SentryHttpLayer` now records the [`http.response.status_code`](https://getsentry.github.io/sentry-conventions/attributes/http/) attribute on transactions.
+
 ## 0.48.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- `SentryHttpLayer` now records the [`http.response.status_code`](https://getsentry.github.io/sentry-conventions/attributes/http/) attribute on transactions.
+- `SentryHttpLayer` now records the [`http.response.status_code`](https://getsentry.github.io/sentry-conventions/attributes/http/) attribute on transactions ([#1253](https://github.com/getsentry/sentry-rust/pull/1253)).
 
 ## 0.48.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,6 @@
 - Restored the reqwest transport's pre-0.13 protocol features by disabling HTTP/2 and native-TLS ALPN ([#1258](https://github.com/getsentry/sentry-rust/pull/1258)).
 - [`EnvelopeError`](https://docs.rs/sentry-types/0.49.0/sentry_types/protocol/envelope/enum.EnvelopeError.html) is now `#[non_exhaustive]` to allow adding new error variants without a breaking change ([#1254](https://github.com/getsentry/sentry-rust/pull/1254)).
 
-
-
 ## 0.48.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- The Tower integration's [`SentryHttpLayer`](https://docs.rs/sentry-tower/0.49.3/sentry_tower/struct.SentryHttpLayer.html) now records the [`http.response.status_code`](https://getsentry.github.io/sentry-conventions/attributes/http/) attribute on transactions ([#1253](https://github.com/getsentry/sentry-rust/pull/1253)).
+
 ## 0.49.2
 
 ### Fixes
@@ -63,9 +69,7 @@
 - Restored the reqwest transport's pre-0.13 protocol features by disabling HTTP/2 and native-TLS ALPN ([#1258](https://github.com/getsentry/sentry-rust/pull/1258)).
 - [`EnvelopeError`](https://docs.rs/sentry-types/0.49.0/sentry_types/protocol/envelope/enum.EnvelopeError.html) is now `#[non_exhaustive]` to allow adding new error variants without a breaking change ([#1254](https://github.com/getsentry/sentry-rust/pull/1254)).
 
-### Features
 
-- `SentryHttpLayer` now records the [`http.response.status_code`](https://getsentry.github.io/sentry-conventions/attributes/http/) attribute on transactions ([#1253](https://github.com/getsentry/sentry-rust/pull/1253)).
 
 ## 0.48.5
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,6 +3560,7 @@ dependencies = [
  "curl",
  "embedded-svc",
  "esp-idf-svc",
+ "http 1.4.0",
  "httpdate",
  "log",
  "native-tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ dependencies = [
  "curl",
  "embedded-svc",
  "esp-idf-svc",
- "http 1.4.0",
+ "http 1.5.0",
  "httpdate",
  "log",
  "native-tls",

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -140,10 +140,16 @@ where
                 if let Some((transaction, parent_span)) = slf.transaction.take() {
                     match &res {
                         Ok(res) => {
-                            transaction.set_data(
-                                "http.response.status_code",
-                                res.status().as_u16().into(),
-                            );
+                            if !transaction
+                                .get_trace_context()
+                                .data
+                                .contains_key("http.response.status_code")
+                            {
+                                transaction.set_data(
+                                    "http.response.status_code",
+                                    res.status().as_u16().into(),
+                                );
+                            }
                             if transaction.get_status().is_none() {
                                 transaction.set_status(map_status(res.status()));
                             }

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -138,12 +138,21 @@ where
         match slf.future.poll(cx) {
             Poll::Ready(res) => {
                 if let Some((transaction, parent_span)) = slf.transaction.take() {
-                    if transaction.get_status().is_none() {
-                        let status = match &res {
-                            Ok(res) => map_status(res.status()),
-                            Err(_) => protocol::SpanStatus::UnknownError,
-                        };
-                        transaction.set_status(status);
+                    match &res {
+                        Ok(res) => {
+                            transaction.set_data(
+                                "http.response.status_code",
+                                res.status().as_u16().into(),
+                            );
+                            if transaction.get_status().is_none() {
+                                transaction.set_status(map_status(res.status()));
+                            }
+                        }
+                        Err(_) => {
+                            if transaction.get_status().is_none() {
+                                transaction.set_status(protocol::SpanStatus::UnknownError);
+                            }
+                        }
                     }
                     transaction.finish();
                     sentry_core::configure_scope(|scope| scope.set_span(parent_span));

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -96,10 +96,11 @@ esp-idf-svc = { version = "0.51.0", optional = true }
 sentry-anyhow = { path = "../sentry-anyhow" }
 sentry-log = { path = "../sentry-log" }
 sentry-slog = { path = "../sentry-slog" }
-sentry-tower = { path = "../sentry-tower" }
+sentry-tower = { path = "../sentry-tower", features = ["http"] }
 sentry-tracing = { path = "../sentry-tracing" }
 actix-web = { version = "4", default-features = false }
 anyhow = { version = "1.0.30" }
+http = "1.0.0"
 log = { version = "0.4.8", features = ["std"] }
 pretty_env_logger = "0.5.0"
 slog = { version = "2.5.2" }

--- a/sentry/tests/test_tower.rs
+++ b/sentry/tests/test_tower.rs
@@ -62,6 +62,60 @@ fn test_tower_http_records_response_status_code() {
 }
 
 #[test]
+fn test_tower_http_preserves_existing_response_status_code() {
+    let options = ClientOptions::new().traces_sample_rate(1.0);
+
+    let envelopes = sentry::test::with_captured_envelopes_options(
+        || {
+            let service = ServiceBuilder::new()
+                .layer(SentryHttpLayer::new().enable_transaction())
+                .service_fn(|_req: http::Request<()>| async move {
+                    sentry::configure_scope(|scope| {
+                        if let Some(span) = scope.get_span() {
+                            span.set_data("http.response.status_code", 418.into());
+                            span.set_status(SpanStatus::InvalidArgument);
+                        }
+                    });
+                    Ok::<_, std::convert::Infallible>(
+                        http::Response::builder()
+                            .status(http::StatusCode::NOT_FOUND)
+                            .body(())
+                            .unwrap(),
+                    )
+                });
+
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let request = http::Request::builder()
+                .method(http::Method::GET)
+                .uri("http://example.com/tea")
+                .body(())
+                .unwrap();
+            let response = rt.block_on(service.oneshot(request)).unwrap();
+            assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+        },
+        options,
+    );
+
+    assert_eq!(envelopes.len(), 1);
+    let transaction = match envelopes[0].items().next().unwrap() {
+        EnvelopeItem::Transaction(transaction) => transaction,
+        _ => panic!("expected a transaction item"),
+    };
+
+    let Context::Trace(trace) = transaction.contexts.get("trace").unwrap() else {
+        panic!("expected a trace context");
+    };
+    assert_eq!(trace.status, Some(SpanStatus::InvalidArgument));
+    assert_eq!(
+        trace.data.get("http.response.status_code"),
+        Some(&418.into())
+    );
+}
+
+#[test]
 fn test_tower_hub() {
     // Create a fake transport for new hubs
     let transport = TestTransport::new();

--- a/sentry/tests/test_tower.rs
+++ b/sentry/tests/test_tower.rs
@@ -62,60 +62,6 @@ fn test_tower_http_records_response_status_code() {
 }
 
 #[test]
-fn test_tower_http_preserves_existing_response_status_code() {
-    let options = ClientOptions::new().traces_sample_rate(1.0);
-
-    let envelopes = sentry::test::with_captured_envelopes_options(
-        || {
-            let service = ServiceBuilder::new()
-                .layer(SentryHttpLayer::new().enable_transaction())
-                .service_fn(|_req: http::Request<()>| async move {
-                    sentry::configure_scope(|scope| {
-                        if let Some(span) = scope.get_span() {
-                            span.set_data("http.response.status_code", 418.into());
-                            span.set_status(SpanStatus::InvalidArgument);
-                        }
-                    });
-                    Ok::<_, std::convert::Infallible>(
-                        http::Response::builder()
-                            .status(http::StatusCode::NOT_FOUND)
-                            .body(())
-                            .unwrap(),
-                    )
-                });
-
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-            let request = http::Request::builder()
-                .method(http::Method::GET)
-                .uri("http://example.com/tea")
-                .body(())
-                .unwrap();
-            let response = rt.block_on(service.oneshot(request)).unwrap();
-            assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
-        },
-        options,
-    );
-
-    assert_eq!(envelopes.len(), 1);
-    let transaction = match envelopes[0].items().next().unwrap() {
-        EnvelopeItem::Transaction(transaction) => transaction,
-        _ => panic!("expected a transaction item"),
-    };
-
-    let Context::Trace(trace) = transaction.contexts.get("trace").unwrap() else {
-        panic!("expected a trace context");
-    };
-    assert_eq!(trace.status, Some(SpanStatus::InvalidArgument));
-    assert_eq!(
-        trace.data.get("http.response.status_code"),
-        Some(&418.into())
-    );
-}
-
-#[test]
 fn test_tower_hub() {
     // Create a fake transport for new hubs
     let transport = TestTransport::new();

--- a/sentry/tests/test_tower.rs
+++ b/sentry/tests/test_tower.rs
@@ -3,12 +3,63 @@
 use std::sync::Arc;
 
 use sentry::{
-    protocol::{Breadcrumb, Level},
+    protocol::{Breadcrumb, Context, EnvelopeItem, Level, SpanStatus},
     test::TestTransport,
     ClientOptions, Hub,
 };
-use sentry_tower::SentryLayer;
+use sentry_tower::{SentryHttpLayer, SentryLayer};
 use tower::{ServiceBuilder, ServiceExt};
+
+#[test]
+fn test_tower_http_records_response_status_code() {
+    let options = ClientOptions::new().traces_sample_rate(1.0);
+
+    let envelopes = sentry::test::with_captured_envelopes_options(
+        || {
+            let service = ServiceBuilder::new()
+                .layer(SentryHttpLayer::new().enable_transaction())
+                .service_fn(|_req: http::Request<()>| async move {
+                    Ok::<_, std::convert::Infallible>(
+                        http::Response::builder()
+                            .status(http::StatusCode::NOT_FOUND)
+                            .body(())
+                            .unwrap(),
+                    )
+                });
+
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let request = http::Request::builder()
+                .method(http::Method::GET)
+                .uri("http://example.com/missing")
+                .body(())
+                .unwrap();
+            let response = rt.block_on(service.oneshot(request)).unwrap();
+            assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+        },
+        options,
+    );
+
+    assert_eq!(envelopes.len(), 1);
+    let transaction = match envelopes[0].items().next().unwrap() {
+        EnvelopeItem::Transaction(transaction) => transaction,
+        _ => panic!("expected a transaction item"),
+    };
+
+    assert_eq!(transaction.name.as_deref(), Some("GET /missing"));
+    let Context::Trace(trace) = transaction.contexts.get("trace").unwrap() else {
+        panic!("expected a trace context");
+    };
+    assert_eq!(trace.op.as_deref(), Some("http.server"));
+    assert_eq!(trace.origin.as_deref(), Some("auto.http.tower"));
+    assert_eq!(trace.status, Some(SpanStatus::NotFound));
+    assert_eq!(
+        trace.data.get("http.response.status_code"),
+        Some(&404.into())
+    );
+}
 
 #[test]
 fn test_tower_hub() {


### PR DESCRIPTION
When `SentryHttpLayer` starts a transaction for an incoming request, successful responses now also set the canonical [`http.response.status_code`](https://getsentry.github.io/sentry-conventions/attributes/http/) attribute on transaction data. The existing `SpanStatus` mapping is unchanged; this adds the numeric status so Sentry can surface HTTP response codes the same way other SDKs do.

Only the tower HTTP integration is affected, and only when transactions are enabled.

Context: I was trying to debug something and find traces with a particular status code.
