### PR TITLE
chore!(types): Make EnvelopeError non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Fixes
 
 - Restored the reqwest transport's pre-0.13 protocol features by disabling HTTP/2 and native-TLS ALPN ([#1258](https://github.com/getsentry/sentry-rust/pull/1258)).
+- [`EnvelopeError`](https://docs.rs/sentry-types/0.49.0/sentry_types/protocol/envelope/enum.EnvelopeError.html) is now `#[non_exhaustive]` to allow adding new error variants without a breaking change ([#1254](https://github.com/getsentry/sentry-rust/pull/1254)).
 
 ## 0.48.5
 

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -17,6 +17,7 @@ use protocol::{
 
 /// Raised if a envelope cannot be parsed from a given input.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum EnvelopeError {
     /// Unexpected end of file
     #[error("unexpected end of file")]


### PR DESCRIPTION
BREAKING CHANGE: EnvelopeError is now non-exhaustive, so external code must include a wildcard when matching its variants.

Fixes [#1130](https://github.com/getsentry/sentry-rust/issues/1130)
Fixes [RUST-216](https://linear.app/getsentry/issue/RUST-216)
