### PR TITLE
perf!(types): Reduce the size of `EnvelopeItem`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling.
 - Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling ([#1228](https://github.com/getsentry/sentry-rust/pull/1228)).
 - Removed the public `ClientOptions::traces_sample_rate` and `ClientOptions::traces_sampler` fields. Use `ClientOptions::traces_sampling_strategy` to inspect the configured traces sampling strategy, and use the existing `ClientOptions::traces_sample_rate(...)` and `ClientOptions::traces_sampler(...)` builder setters to configure fixed-rate and callback-based sampling ([#1227](https://github.com/getsentry/sentry-rust/pull/1227)).
+- [`EnvelopeItem`](https://docs.rs/sentry-types/0.49.0/sentry_types/protocol/envelope/enum.EnvelopeItem.html) now stores `Event` and `Transaction` payloads in `Box` values. Code that constructs or pattern-matches these variants must account for the additional indirection ([#1255](https://github.com/getsentry/sentry-rust/pull/1255)).
 
 ## 0.48.5
 

--- a/sentry-opentelemetry/tests/associates_event_with_span.rs
+++ b/sentry-opentelemetry/tests/associates_event_with_span.rs
@@ -52,7 +52,7 @@ fn test_associates_event_with_span() {
                     });
                 }
                 sentry::protocol::EnvelopeItem::Transaction(tx) => {
-                    transaction = Some(tx.clone());
+                    transaction = Some(*tx.clone());
                     tx.spans.iter().for_each(|span| {
                         span_id = Some(span.span_id.to_string());
                     });

--- a/sentry-tracing/tests/transaction_assertions/mod.rs
+++ b/sentry-tracing/tests/transaction_assertions/mod.rs
@@ -1,4 +1,4 @@
-use sentry::protocol::{EnvelopeItem, Transaction};
+use sentry::protocol::EnvelopeItem;
 use sentry::Envelope;
 
 /// Assert that the given envelopes contain exactly one `Envelope`, containing
@@ -7,15 +7,14 @@ pub fn assert_transaction(envelopes: Vec<Envelope>, name: &str) {
     let envelope = get_and_assert_only_item(envelopes, "expected exactly one envelope");
     let item = get_and_assert_only_item(envelope.into_items(), "expected exactly one item");
 
-    assert!(
-        matches!(
-            item,
-            EnvelopeItem::Transaction(Transaction {
-                name: Some(expected_name),
-                ..
-            }) if expected_name == name
-        ),
-        "expected a Transaction item with name {name:?}"
+    let EnvelopeItem::Transaction(transaction) = item else {
+        panic!("expected a Transaction item, got {item:?}");
+    };
+
+    assert_eq!(
+        transaction.name.as_deref(),
+        Some(name),
+        "did not get expected transaction name"
     );
 }
 

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -155,13 +155,12 @@ struct EnvelopeItemHeader {
 /// for more details.
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
-#[allow(clippy::large_enum_variant)]
 pub enum EnvelopeItem {
     /// An Event Item.
     ///
     /// See the [Event Item documentation](https://develop.sentry.dev/sdk/envelopes/#event)
     /// for more details.
-    Event(Event<'static>),
+    Event(Box<Event<'static>>),
     /// A Session Item.
     ///
     /// See the [Session Item documentation](https://develop.sentry.dev/sdk/envelopes/#session)
@@ -176,7 +175,7 @@ pub enum EnvelopeItem {
     ///
     /// See the [Transaction Item documentation](https://develop.sentry.dev/sdk/envelopes/#transaction)
     /// for more details.
-    Transaction(Transaction<'static>),
+    Transaction(Box<Transaction<'static>>),
     /// An Attachment Item.
     ///
     /// See the [Attachment Item documentation](https://develop.sentry.dev/sdk/envelopes/#attachment)
@@ -283,7 +282,7 @@ impl EnvelopeItem {
 
 impl From<Event<'static>> for EnvelopeItem {
     fn from(event: Event<'static>) -> Self {
-        EnvelopeItem::Event(event)
+        EnvelopeItem::Event(event.into())
     }
 }
 
@@ -301,7 +300,7 @@ impl From<SessionAggregates<'static>> for EnvelopeItem {
 
 impl From<Transaction<'static>> for EnvelopeItem {
     fn from(transaction: Transaction<'static>) -> Self {
-        EnvelopeItem::Transaction(transaction)
+        EnvelopeItem::Transaction(transaction.into())
     }
 }
 
@@ -513,7 +512,7 @@ impl Envelope {
         };
 
         items.iter().find_map(|item| match item {
-            EnvelopeItem::Event(event) => Some(event),
+            EnvelopeItem::Event(event) => Some(&**event),
             _ => None,
         })
     }


### PR DESCRIPTION
Box the large event and transaction variants to reduce the size of `EnvelopeItem`. This removes the suppressed `large_enum_variant` lint.

BREAKING CHANGE: `EnvelopeItem::Event` and `EnvelopeItem::Transaction` now hold boxed payloads.

Fixes [#1129](https://github.com/getsentry/sentry-rust/issues/1129)
Fixes [RUST-217](https://linear.app/getsentry/issue/RUST-217)
