### PR TITLE
fix(transport): Restore reqwest protocol features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling ([#1228](https://github.com/getsentry/sentry-rust/pull/1228)).
 - Removed the public `ClientOptions::traces_sample_rate` and `ClientOptions::traces_sampler` fields. Use `ClientOptions::traces_sampling_strategy` to inspect the configured traces sampling strategy, and use the existing `ClientOptions::traces_sample_rate(...)` and `ClientOptions::traces_sampler(...)` builder setters to configure fixed-rate and callback-based sampling ([#1227](https://github.com/getsentry/sentry-rust/pull/1227)).
 
+### Fixes
+
+- Restored the reqwest transport's pre-0.13 protocol features by disabling HTTP/2 and native-TLS ALPN ([#1258](https://github.com/getsentry/sentry-rust/pull/1258)).
+
 ## 0.48.5
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,7 +3281,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
  "http 1.4.0",
  "http-body",
  "http-body-util",

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -58,7 +58,11 @@ reqwest = ["dep:reqwest", "httpdate", "tokio"]
 curl = ["dep:curl", "httpdate"]
 ureq = ["dep:ureq", "httpdate"]
 # transport settings
-native-tls = ["dep:native-tls", "reqwest?/native-tls", "ureq?/native-tls"]
+native-tls = [
+    "dep:native-tls",
+    "reqwest?/native-tls-no-alpn",
+    "ureq?/native-tls",
+]
 rustls = ["dep:rustls", "reqwest?/rustls", "ureq?/rustls"]
 rustls-no-provider = ["dep:rustls", "reqwest?/rustls-no-provider", "ureq?/rustls"]
 embedded-svc-http = ["dep:embedded-svc", "dep:esp-idf-svc"]
@@ -78,8 +82,7 @@ sentry-slog = { version = "0.48.5", path = "../sentry-slog", optional = true }
 sentry-tower = { version = "0.48.5", path = "../sentry-tower", optional = true }
 sentry-tracing = { version = "0.48.5", path = "../sentry-tracing", optional = true }
 sentry-opentelemetry = { version = "0.48.5", path = "../sentry-opentelemetry", optional = true }
-reqwest = { version = "0.13.1", optional = true, features = [
-    "http2",
+reqwest = { version = "0.13.2", optional = true, features = [
     "blocking",
     "json",
 ], default-features = false }


### PR DESCRIPTION
In https://github.com/getsentry/sentry-rust/pull/998 we upgraded `reqwest` to `0.13.x`.
We moved from `reqwest/default-tls` to `reqwest/native-tls`. The two features are not exactly equivalent, as the second one additionally enables ALPN.

Along with that, we enabled its `http2` feature flag, which was not enabled by default in `0.12.x`.
The original author of that PR enabled `http2` as a doctest was failing.
Apparently it was failing due to this bug in reqwest https://github.com/seanmonstar/reqwest/pull/2927, where enabling only ALPN but not HTTP2 would cause a runtime panic, as the client still advertised HTTP 2 even though it was compiled without support for it.

Enabling HTTP2 is not a problem for `sentry` itself, but it can be if an application crate uses `reqwest` (independently) + `sentry`, as upgrading `sentry` might silently enable HTTP2 on the unified `reqwest` dependency.

This PR restores the previous protocol feature set by selecting `native-tls-no-alpn`, and removing `http2`.
It also bumps `reqwest` to `0.13.2` to get the fix for the aforementioned bug in. Otherwise, if a user has exactly version `0.13.1` as a direct dependency, and enables ALPN but not HTTP2, the reqwest transport will run exactly into that bug, and panic.

Close https://github.com/getsentry/sentry-rust/issues/1057