### PR TITLE
feat!(opentelemetry): Bump opentelemetry support to 0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
       .debug(true)
       .release("my-app@1.0.0");
   ```
+- Updated the `sentry-opentelemetry` integration to support OpenTelemetry 0.32. Users of the integration must update their OpenTelemetry dependencies from 0.29 to 0.32 ([#1262](https://github.com/getsentry/sentry-rust/pull/1262)).
 - The `logs` and `metrics` features are now enabled by default in the `sentry` crate. This does not break the API, but may cause new telemetry to be sent to Sentry: log and tracing integrations can send structured logs, and applications can send metrics without adding the feature flags. Disable these features explicitly if this additional telemetry is not desired ([#1251](https://github.com/getsentry/sentry-rust/pull/1251)).
 - Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling.
 - Removed the public `ClientOptions::sample_rate` field. Use `ClientOptions::event_sampling_strategy` to inspect the configured event sampling strategy, and use the existing `ClientOptions::sample_rate(...)` builder setter to configure fixed-rate sampling ([#1228](https://github.com/getsentry/sentry-rust/pull/1228)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,35 +2578,32 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.29.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.3",
- "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -2734,6 +2731,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ httpdate = "1.0.0"
 libc = "0.2.66"
 log = "0.4.8"
 native-tls = "0.2.8"
-opentelemetry = { version = "0.29.0", default-features = false }
-opentelemetry_sdk = { version = "0.29.0", default-features = false }
+opentelemetry = { version = "0.32.0", default-features = false }
+opentelemetry_sdk = { version = "0.32.1", default-features = false }
 pin-project = "1.0.10"
 pretty_env_logger = "0.5.0"
 prost = "0.13.3"

--- a/sentry-opentelemetry/README.md
+++ b/sentry-opentelemetry/README.md
@@ -21,14 +21,12 @@ trace and span association.
 
 ## Configuration
 
-Add the necessary dependencies to your Cargo.toml:
-
-```toml
-[dependencies]
-opentelemetry = { version = "0.29.1", features = ["trace"] }
-opentelemetry_sdk = { version = "0.29.0", features = ["trace"] }
-sentry = { version = "0.38.0", features = ["opentelemetry"] }
-```
+Use the `opentelemetry` feature of the [`sentry`](https://crates.io/crates/sentry) crate to
+enable this integration. Your application must also depend directly on
+[`opentelemetry` 0.32](https://crates.io/crates/opentelemetry) and
+[`opentelemetry_sdk` 0.32](https://crates.io/crates/opentelemetry_sdk), with the `trace` feature
+enabled for both. The integration is available as
+`sentry::integrations::opentelemetry`.
 
 Initialize Sentry with a `traces_sample_rate`, then register the [`SentryPropagator`] and the
 [`SentrySpanProcessor`]:

--- a/sentry-opentelemetry/src/lib.rs
+++ b/sentry-opentelemetry/src/lib.rs
@@ -13,14 +13,12 @@
 //!
 //! # Configuration
 //!
-//! Add the necessary dependencies to your Cargo.toml:
-//!
-//! ```toml
-//! [dependencies]
-//! opentelemetry = { version = "0.29.1", features = ["trace"] }
-//! opentelemetry_sdk = { version = "0.29.0", features = ["trace"] }
-//! sentry = { version = "0.38.0", features = ["opentelemetry"] }
-//! ```
+//! Use the `opentelemetry` feature of the [`sentry`](https://crates.io/crates/sentry) crate to
+//! enable this integration. Your application must also depend directly on
+//! [`opentelemetry` 0.32](https://crates.io/crates/opentelemetry) and
+//! [`opentelemetry_sdk` 0.32](https://crates.io/crates/opentelemetry_sdk), with the `trace` feature
+//! enabled for both. The integration is available as
+//! `sentry::integrations::opentelemetry`.
 //!
 //! Initialize Sentry with a `traces_sample_rate`, then register the [`SentryPropagator`] and the
 //! [`SentrySpanProcessor`]:

--- a/sentry-opentelemetry/src/processor.rs
+++ b/sentry-opentelemetry/src/processor.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use opentelemetry::global::ObjectSafeSpan;
 use opentelemetry::trace::{get_active_span, SpanId};
@@ -186,6 +186,10 @@ impl SpanProcessor for SentrySpanProcessor {
     }
 
     fn shutdown(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
         Ok(())
     }
 


### PR DESCRIPTION
Increase our opentelemetry support to the latest 0.32.x line.

BREAKING CHANGE: The opentelemetry integration is no longer compatible with 0.29.x versions of opentelemetry.

Resolves [#1261](https://github.com/getsentry/sentry-rust/issues/1261)
Resolves [RUST-269](https://linear.app/getsentry/issue/RUST-269)
