### PR TITLE
ci: Pin GitHub Actions runners to versioned OS labels

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-15, windows-2025]
         rust: [stable, 1.88.0]
 
     name: Check compile errors using Rust ${{ matrix.rust }} on ${{ matrix.os }}
@@ -57,7 +57,7 @@ jobs:
   embedded-esp-idf-check:
     # This checks the `sentry-core` and `sentry` crates on ESP-IDF.
     name: Check ESP-IDF compile errors
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
   codecov:
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -53,7 +53,7 @@ jobs:
 
   required:
     name: Check required jobs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ always() }}
     # Keep this list in sync with all CI jobs that should be required.
     # `codecov` is intentionally excluded from this aggregator.

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   danger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: getsentry/github-workflows/danger@26f565c05d0dd49f703d238706b775883037d76b # v3

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   doc:
     name: Build documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       RUSTDOCFLAGS: -Dwarnings
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   lint:
     name: Run lint checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: "Release a new version"
     steps:
       - name: Get auth token

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-15, windows-2025]
         rust: [stable, 1.88.0]
 
     name: Run tests using Rust ${{ matrix.rust }} on ${{ matrix.os }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         rust: [nightly, beta]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'getsentry'
 
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   weekly-audit:
     name: Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'getsentry'
 
     steps:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Pin GitHub-hosted runners away from floating `-latest` labels so CI does not silently move to a new OS when GitHub updates those aliases.

Pinned to the current GA equivalents from [actions/runner-images](https://github.com/actions/runner-images):

- `ubuntu-latest` → `ubuntu-24.04`
- `macos-latest` → `macos-15`
- `windows-latest` → `windows-2025`

`validate-pr.yml` was already on `ubuntu-24.04`.

#### Issues
* resolves: [#936](https://github.com/getsentry/sentry-rust/issues/936)
* resolves: [RUST-125](https://linear.app/getsentry/issue/RUST-125/pin-github-runners)

<div><a href="https://cursor.com/agents/bc-07e48da2-7c80-48b0-a791-4436ba84bf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07e48da2-7c80-48b0-a791-4436ba84bf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

