### PR TITLE
meta: set up Cursor Cloud dev environment

### DIFF
--- a/.cursor/rules/cloud-environment.mdc
+++ b/.cursor/rules/cloud-environment.mdc
@@ -1,12 +1,15 @@
-# AGENTS.md
+---
+description: Cursor Cloud dev environment, build/test commands, and commit/PR workflow for the sentry-rust workspace
+alwaysApply: true
+---
 
-## Cursor Cloud specific instructions
+# Cursor Cloud environment & workflow
 
 This repo is the **Sentry SDK for Rust** — a Cargo workspace of library crates (`sentry`,
 `sentry-core`, `sentry-types`, and integration crates). There is no long-running server or
 GUI; the "applications" are the examples under `sentry/examples/` and `sentry-actix/examples/`.
 
-### Toolchain / environment (already provisioned by the update script + snapshot)
+## Toolchain / environment (already provisioned by the update script + snapshot)
 - MSRV is **1.88** (`Cargo.toml` `rust-version`), so the default toolchain is Rust **stable**
   (>= 1.88). The base image's older 1.83 toolchain is not sufficient — stable is installed and
   set as default in the snapshot, with `rustfmt` and `clippy` components.
@@ -15,7 +18,7 @@ GUI; the "applications" are the examples under `sentry/examples/` and `sentry-ac
   "system library `openssl` was not found", reinstall with
   `sudo apt-get install -y libssl-dev pkg-config`.
 
-### Standard commands (mirror CI in `.github/workflows/`)
+## Standard commands (mirror CI in `.github/workflows/`)
 - Lint: `cargo fmt --all -- --check` and
   `cargo clippy --all-features --workspace --tests --examples --locked -- -D clippy::all`
 - Build/check: `cargo check --all-features --locked`
@@ -23,7 +26,7 @@ GUI; the "applications" are the examples under `sentry/examples/` and `sentry-ac
   `cargo test --workspace --all-features --doc --locked`
 - CI sets `RUSTFLAGS: -Dwarnings`; export it when reproducing CI locally.
 
-### Running an example (the "app")
+## Running an example (the "app")
 - `cargo run --example message-demo` runs, but with **no DSN the client is disabled** and no
   event is transmitted (it just logs "initialized disabled sentry client").
 - To exercise the full capture → serialize → transport path, provide a DSN via the
@@ -31,7 +34,7 @@ GUI; the "applications" are the examples under `sentry/examples/` and `sentry-ac
   ingest server: `SENTRY_DSN="http://key@127.0.0.1:9999/42" cargo run --example message-demo`.
   A real event envelope is then POSTed to `/api/<project_id>/envelope/`.
 
-### Pre-commit hooks
+## Pre-commit hooks
 - Always commit with pre-commit hooks enabled. `pre-commit` (the tool) is installed in the
   snapshot and the repo's `commit-msg` hook is installed at `.git/hooks/commit-msg`.
 - Cursor sets `core.hooksPath` to its own dispatcher, which chains to the repo hooks in
@@ -43,7 +46,7 @@ GUI; the "applications" are the examples under `sentry/examples/` and `sentry-ac
   like `Closes #123` into Markdown links (and Linear links) via `gh`. It is a no-op when the
   message has no issue footer. Do NOT manually add Linear links — let the hook do it.
 
-### Commit messages & pull requests
+## Commit messages & pull requests
 - Commit messages are reused as PR descriptions (see `.agents/skills/commit/SKILL.md`). Write
   each commit's subject + body for human reviewers/maintainers.
 - When opening a PR, use the commit message as the PR **title and description** verbatim. Do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **Sentry SDK for Rust** — a Cargo workspace of library crates (`sentry`,
+`sentry-core`, `sentry-types`, and integration crates). There is no long-running server or
+GUI; the "applications" are the examples under `sentry/examples/` and `sentry-actix/examples/`.
+
+### Toolchain / environment (already provisioned by the update script + snapshot)
+- MSRV is **1.88** (`Cargo.toml` `rust-version`), so the default toolchain is Rust **stable**
+  (>= 1.88). The base image's older 1.83 toolchain is not sufficient — stable is installed and
+  set as default in the snapshot, with `rustfmt` and `clippy` components.
+- System libs `libssl-dev` and `pkg-config` are required (the `native-tls`/`openssl-sys` and
+  `curl` code paths pull in OpenSSL). These are baked into the snapshot. If a build fails with
+  "system library `openssl` was not found", reinstall with
+  `sudo apt-get install -y libssl-dev pkg-config`.
+
+### Standard commands (mirror CI in `.github/workflows/`)
+- Lint: `cargo fmt --all -- --check` and
+  `cargo clippy --all-features --workspace --tests --examples --locked -- -D clippy::all`
+- Build/check: `cargo check --all-features --locked`
+- Test: `cargo test --workspace --all-features --all-targets --locked` plus
+  `cargo test --workspace --all-features --doc --locked`
+- CI sets `RUSTFLAGS: -Dwarnings`; export it when reproducing CI locally.
+
+### Running an example (the "app")
+- `cargo run --example message-demo` runs, but with **no DSN the client is disabled** and no
+  event is transmitted (it just logs "initialized disabled sentry client").
+- To exercise the full capture → serialize → transport path, provide a DSN via the
+  `SENTRY_DSN` env var (read automatically by `sentry::init`), e.g. point it at a local mock
+  ingest server: `SENTRY_DSN="http://key@127.0.0.1:9999/42" cargo run --example message-demo`.
+  A real event envelope is then POSTed to `/api/<project_id>/envelope/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,24 @@ GUI; the "applications" are the examples under `sentry/examples/` and `sentry-ac
   `SENTRY_DSN` env var (read automatically by `sentry::init`), e.g. point it at a local mock
   ingest server: `SENTRY_DSN="http://key@127.0.0.1:9999/42" cargo run --example message-demo`.
   A real event envelope is then POSTed to `/api/<project_id>/envelope/`.
+
+### Pre-commit hooks
+- Always commit with pre-commit hooks enabled. `pre-commit` (the tool) is installed in the
+  snapshot and the repo's `commit-msg` hook is installed at `.git/hooks/commit-msg`.
+- Cursor sets `core.hooksPath` to its own dispatcher, which chains to the repo hooks in
+  `/workspace/.git/hooks`, so the pre-commit `commit-msg` hook runs alongside Cursor's hooks.
+- Because `core.hooksPath` is set, `pre-commit install` refuses to run directly. If the hook is
+  ever missing, reinstall with: `HP="$(git config --get core.hooksPath)"; git config --unset-all
+  core.hooksPath; pre-commit install --install-hooks; git config core.hooksPath "$HP"`.
+- The `commit-msg` hook runs `scripts/commit-msg-expand-issues.py`, which expands issue footers
+  like `Closes #123` into Markdown links (and Linear links) via `gh`. It is a no-op when the
+  message has no issue footer. Do NOT manually add Linear links — let the hook do it.
+
+### Commit messages & pull requests
+- Commit messages are reused as PR descriptions (see `.agents/skills/commit/SKILL.md`). Write
+  each commit's subject + body for human reviewers/maintainers.
+- When opening a PR, use the commit message as the PR **title and description** verbatim. Do
+  **not** use the `.github/pull_request_template.md` template.
+- Use Conventional Commits style for the subject (`feat:`, `fix:`, `ref:`, `meta:`, etc.).
+- Reference issues only via footers in the exact `Closes #123` / `Related to owner/repo#123`
+  format so the `commit-msg` hook can expand them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Set up and document the Cursor Cloud development environment for the sentry-rust workspace.

- Rust **stable** (>= MSRV 1.88) is the default toolchain with `rustfmt` + `clippy`; system libs `libssl-dev`/`pkg-config` are provisioned. Update script is `cargo fetch --locked`.
- `pre-commit` is installed and the repo's `commit-msg` hook is wired through Cursor's `core.hooksPath` dispatcher so it runs on every commit (it expands issue footers via `scripts/commit-msg-expand-issues.py`).
- Commit messages are reused verbatim as PR title/description (no `.github/pull_request_template.md`).

These notes live in `.cursor/rules/cloud-environment.mdc` (a Cursor-only `alwaysApply` rule) rather than `AGENTS.md`, since `AGENTS.md` is shared with other agents used against this repo and this content is Cursor-Cloud specific — mirroring how the repo already keeps `CLAUDE.md` for Claude.

Verified: `cargo fmt`/`clippy` clean, `cargo check --all-features`, full `cargo test` (all-targets + doc) passing, and `message-demo` sending a real event envelope end-to-end to a local mock ingest server.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df67d978-c961-4582-8147-7bb9122172ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df67d978-c961-4582-8147-7bb9122172ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

