### PR TITLE
chore: Bump Rust edition to 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
   codecov:
     name: Code Coverage
     runs-on: ubuntu-latest
+    env:
+      # Keep in sync with test.yml: anyhow backtrace tests require this preset.
+      RUST_BACKTRACE: "1"
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     env:
-      # Keep in sync with test.yml: anyhow backtrace tests require this preset.
       RUST_BACKTRACE: "1"
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
+  # anyhow backtrace capture (and some SDK tests) require this to already be set;
+  # mutating the process environment from tests via std::env::set_var is unsound.
+  RUST_BACKTRACE: "1"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
-  # anyhow backtrace capture (and some SDK tests) require this to already be set;
-  # mutating the process environment from tests via std::env::set_var is unsound.
   RUST_BACKTRACE: "1"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### Internal
 
-- Updated the Rust edition to 2024 ([#971](https://github.com/getsentry/sentry-rust/issues/971)).
+- Updated the Rust edition to 2024 ([#1265](https://github.com/getsentry/sentry-rust/pull/1265)).
 
 ## 0.48.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,6 @@
 
 - Restored the reqwest transport's pre-0.13 protocol features by disabling HTTP/2 and native-TLS ALPN ([#1258](https://github.com/getsentry/sentry-rust/pull/1258)).
 
-### Internal
-
-- Updated the Rust edition to 2024 ([#1265](https://github.com/getsentry/sentry-rust/pull/1265)).
-
 ## 0.48.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 - Restored the reqwest transport's pre-0.13 protocol features by disabling HTTP/2 and native-TLS ALPN ([#1258](https://github.com/getsentry/sentry-rust/pull/1258)).
 
+### Internal
+
+- Updated the Rust edition to 2024 ([#971](https://github.com/getsentry/sentry-rust/issues/971)).
+
 ## 0.48.5
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,7 +3383,6 @@ dependencies = [
  "sentry-tracing",
  "serde_json",
  "slog",
- "temp-env",
  "tokio",
  "tower 0.5.3",
  "tracing",
@@ -3413,7 +3412,6 @@ dependencies = [
  "sentry",
  "sentry-backtrace",
  "sentry-core",
- "temp-env",
 ]
 
 [[package]]
@@ -3780,15 +3778,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "temp-env"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,6 +3383,7 @@ dependencies = [
  "sentry-tracing",
  "serde_json",
  "slog",
+ "temp-env",
  "tokio",
  "tower 0.5.3",
  "tracing",
@@ -3412,6 +3413,7 @@ dependencies = [
  "sentry",
  "sentry-backtrace",
  "sentry-core",
+ "temp-env",
 ]
 
 [[package]]
@@ -3778,6 +3780,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "sentry",
     "sentry-actix",
@@ -21,7 +21,7 @@ members = [
 authors = ["Sentry <hello@sentry.io>"]
 repository = "https://github.com/getsentry/sentry-rust"
 homepage = "https://sentry.io/welcome/"
-edition = "2021"
+edition = "2024"
 rust-version = "1.88"
 
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ sentry-types = { version = "0.48.5", path = "sentry-types" }
 serde = "1.0.117"
 serde_json = "1.0.48"
 slog = "2.5.2"
+temp-env = "0.3.6"
 thiserror = "2.0.12"
 time = "0.3.47"
 tokio = "1.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ sentry-types = { version = "0.48.5", path = "sentry-types" }
 serde = "1.0.117"
 serde_json = "1.0.48"
 slog = "2.5.2"
-temp-env = "0.3.6"
 thiserror = "2.0.12"
 time = "0.3.47"
 tokio = "1.44"

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -29,7 +29,9 @@ fn main() -> io::Result<()> {
     let _guard = sentry::init(
         sentry::ClientOptions::new().maybe_release(sentry::release_name!()),
     );
-    std::env::set_var("RUST_BACKTRACE", "1");
+    unsafe {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -29,9 +29,6 @@ fn main() -> io::Result<()> {
     let _guard = sentry::init(
         sentry::ClientOptions::new().maybe_release(sentry::release_name!()),
     );
-    unsafe {
-        std::env::set_var("RUST_BACKTRACE", "1");
-    }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -46,6 +46,10 @@ fn main() -> io::Result<()> {
 }
 ```
 
+Run with `RUST_BACKTRACE=1` to get full backtraces. This example does not call
+`std::env::set_var`: that API is not sound if other threads may access the
+process environment, which is typical for multithreaded servers.
+
 ## Using Release Health
 
 The actix middleware will automatically start a new session for each request

--- a/sentry-actix/README.md
+++ b/sentry-actix/README.md
@@ -46,9 +46,7 @@ fn main() -> io::Result<()> {
 }
 ```
 
-Run with `RUST_BACKTRACE=1` to get full backtraces. This example does not call
-`std::env::set_var`: that API is not sound if other threads may access the
-process environment, which is typical for multithreaded servers.
+Run with `RUST_BACKTRACE=1` to get full backtraces.
 
 ## Using Release Health
 

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::io;
 
 use actix_web::{App, Error, HttpRequest, HttpServer, get};
@@ -30,9 +29,6 @@ fn main() -> io::Result<()> {
             .session_mode(sentry::SessionMode::Request)
             .debug(true),
     );
-    unsafe {
-        env::set_var("RUST_BACKTRACE", "1");
-    }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::io;
 
-use actix_web::{get, App, Error, HttpRequest, HttpServer};
+use actix_web::{App, Error, HttpRequest, HttpServer, get};
 use sentry::Level;
 
 #[get("/")]
@@ -30,7 +30,9 @@ fn main() -> io::Result<()> {
             .session_mode(sentry::SessionMode::Request)
             .debug(true),
     );
-    env::set_var("RUST_BACKTRACE", "1");
+    unsafe {
+        env::set_var("RUST_BACKTRACE", "1");
+    }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -20,8 +20,7 @@ async fn captures_message(_req: HttpRequest) -> Result<String, Error> {
 }
 
 // cargo run -p sentry-actix --example basic
-// For full backtraces, run with RUST_BACKTRACE=1. Avoid std::env::set_var here:
-// it is not sound if other threads may access the process environment.
+// For full backtraces, run with RUST_BACKTRACE=1.
 fn main() -> io::Result<()> {
     let _guard = sentry::init(
         sentry::ClientOptions::new()

--- a/sentry-actix/examples/basic.rs
+++ b/sentry-actix/examples/basic.rs
@@ -20,6 +20,8 @@ async fn captures_message(_req: HttpRequest) -> Result<String, Error> {
 }
 
 // cargo run -p sentry-actix --example basic
+// For full backtraces, run with RUST_BACKTRACE=1. Avoid std::env::set_var here:
+// it is not sound if other threads may access the process environment.
 fn main() -> io::Result<()> {
     let _guard = sentry::init(
         sentry::ClientOptions::new()

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -371,16 +371,17 @@ where
             };
 
             // Response errors
-            if inner.capture_server_errors && res.response().status().is_server_error() {
-                if let Some(e) = res.response().error() {
-                    let event_id = hub.capture_error(e);
+            if inner.capture_server_errors
+                && res.response().status().is_server_error()
+                && let Some(e) = res.response().error()
+            {
+                let event_id = hub.capture_error(e);
 
-                    if inner.emit_header {
-                        res.response_mut().headers_mut().insert(
-                            "x-sentry-event".parse().unwrap(),
-                            event_id.simple().to_string().parse().unwrap(),
-                        );
-                    }
+                if inner.emit_header {
+                    res.response_mut().headers_mut().insert(
+                        "x-sentry-event".parse().unwrap(),
+                        event_id.simple().to_string().parse().unwrap(),
+                    );
                 }
             }
 
@@ -445,10 +446,8 @@ fn sentry_request_from_http(request: &ServiceRequest, with_pii: bool) -> Request
     };
 
     // If PII is enabled, include the remote address
-    if with_pii {
-        if let Some(remote) = request.connection_info().remote_addr() {
-            sentry_req.env.insert("REMOTE_ADDR".into(), remote.into());
-        }
+    if with_pii && let Some(remote) = request.connection_info().remote_addr() {
+        sentry_req.env.insert("REMOTE_ADDR".into(), remote.into());
     };
 
     sentry_req

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -21,7 +21,9 @@
 //!     let _guard = sentry::init(
 //!         sentry::ClientOptions::new().maybe_release(sentry::release_name!()),
 //!     );
-//!     std::env::set_var("RUST_BACKTRACE", "1");
+//!     unsafe {
+//!         std::env::set_var("RUST_BACKTRACE", "1");
+//!     }
 //!
 //!     let runtime = tokio::runtime::Builder::new_multi_thread()
 //!         .enable_all()
@@ -79,16 +81,16 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use actix_http::header::{self, HeaderMap};
+use actix_web::Error;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::StatusCode;
-use actix_web::Error;
 use bytes::{Bytes, BytesMut};
-use futures_util::future::{ok, Future, Ready};
+use futures_util::future::{Future, Ready, ok};
 use futures_util::{FutureExt as _, TryStreamExt as _};
 
+use sentry_core::MaxRequestBodySize;
 use sentry_core::protocol::{self, ClientSdkPackage, Event, Request};
 use sentry_core::utils::{is_sensitive_header, scrub_pii_from_url};
-use sentry_core::MaxRequestBodySize;
 use sentry_core::{Hub, SentryFutureExt};
 
 /// A helper construct that can be used to reconfigure and build the middleware.
@@ -476,8 +478,8 @@ mod tests {
     use std::io;
 
     use actix_web::body::BoxBody;
-    use actix_web::test::{call_service, init_service, TestRequest};
-    use actix_web::{get, web, App, HttpRequest, HttpResponse};
+    use actix_web::test::{TestRequest, call_service, init_service};
+    use actix_web::{App, HttpRequest, HttpResponse, get, web};
     use futures::executor::block_on;
 
     use futures::future::join_all;

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -21,9 +21,6 @@
 //!     let _guard = sentry::init(
 //!         sentry::ClientOptions::new().maybe_release(sentry::release_name!()),
 //!     );
-//!     unsafe {
-//!         std::env::set_var("RUST_BACKTRACE", "1");
-//!     }
 //!
 //!     let runtime = tokio::runtime::Builder::new_multi_thread()
 //!         .enable_all()

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -38,9 +38,7 @@
 //! }
 //! ```
 //!
-//! Run with `RUST_BACKTRACE=1` to get full backtraces. This example does not call
-//! [`std::env::set_var`]: that API is not sound if other threads may access the
-//! process environment, which is typical for multithreaded servers.
+//! Run with `RUST_BACKTRACE=1` to get full backtraces.
 //!
 //! # Using Release Health
 //!

--- a/sentry-actix/src/lib.rs
+++ b/sentry-actix/src/lib.rs
@@ -38,6 +38,10 @@
 //! }
 //! ```
 //!
+//! Run with `RUST_BACKTRACE=1` to get full backtraces. This example does not call
+//! [`std::env::set_var`]: that API is not sound if other threads may access the
+//! process environment, which is typical for multithreaded servers.
+//!
 //! # Using Release Health
 //!
 //! The actix middleware will automatically start a new session for each request

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -26,3 +26,4 @@ anyhow = { workspace = true }
 
 [dev-dependencies]
 sentry = { workspace = true, features = ["test"] }
+temp-env = { workspace = true }

--- a/sentry-anyhow/Cargo.toml
+++ b/sentry-anyhow/Cargo.toml
@@ -26,4 +26,3 @@ anyhow = { workspace = true }
 
 [dev-dependencies]
 sentry = { workspace = true, features = ["test"] }
-temp-env = { workspace = true }

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -41,9 +41,9 @@
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 
+use sentry_core::Hub;
 use sentry_core::protocol::Event;
 use sentry_core::types::Uuid;
-use sentry_core::Hub;
 
 /// Captures an [`anyhow::Error`].
 ///
@@ -98,12 +98,15 @@ impl AnyhowHubExt for Hub {
 }
 
 #[cfg(all(feature = "backtrace", test))]
+#[allow(unsafe_code)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_event_from_error_with_backtrace() {
-        std::env::set_var("RUST_BACKTRACE", "1");
+        unsafe {
+            std::env::set_var("RUST_BACKTRACE", "1");
+        }
 
         let event = event_from_error(&anyhow::anyhow!("Oh jeez"));
 
@@ -121,7 +124,9 @@ mod tests {
 
     #[test]
     fn test_capture_anyhow_uses_event_from_error_helper() {
-        std::env::set_var("RUST_BACKTRACE", "1");
+        unsafe {
+            std::env::set_var("RUST_BACKTRACE", "1");
+        }
 
         let err = &anyhow::anyhow!("Oh jeez");
 

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -98,17 +98,23 @@ impl AnyhowHubExt for Hub {
 }
 
 #[cfg(all(feature = "backtrace", test))]
-#[allow(unsafe_code)]
 mod tests {
     use super::*;
 
+    fn anyhow_with_captured_backtrace() -> anyhow::Error {
+        let err = anyhow::anyhow!("Oh jeez");
+        assert_eq!(
+            err.backtrace().status(),
+            std::backtrace::BacktraceStatus::Captured,
+            "run with RUST_BACKTRACE=1 (anyhow captures only when that is preset; \
+             tests must not call std::env::set_var)"
+        );
+        err
+    }
+
     #[test]
     fn test_event_from_error_with_backtrace() {
-        unsafe {
-            std::env::set_var("RUST_BACKTRACE", "1");
-        }
-
-        let event = event_from_error(&anyhow::anyhow!("Oh jeez"));
+        let event = event_from_error(&anyhow_with_captured_backtrace());
 
         let stacktrace = event.exception[0].stacktrace.as_ref().unwrap();
         let found_test_fn = stacktrace
@@ -124,11 +130,7 @@ mod tests {
 
     #[test]
     fn test_capture_anyhow_uses_event_from_error_helper() {
-        unsafe {
-            std::env::set_var("RUST_BACKTRACE", "1");
-        }
-
-        let err = &anyhow::anyhow!("Oh jeez");
+        let err = &anyhow_with_captured_backtrace();
 
         let event = event_from_error(err);
         let events = sentry::test::with_captured_events(|| {

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -99,55 +99,82 @@ impl AnyhowHubExt for Hub {
 
 #[cfg(all(feature = "backtrace", test))]
 mod tests {
+    use std::process::Command;
+
     use super::*;
 
-    fn with_captured_anyhow_backtrace<F>(f: F)
-    where
-        F: FnOnce(&anyhow::Error),
-    {
-        temp_env::with_vars(
-            [
-                ("RUST_BACKTRACE", Some("1")),
-                ("RUST_LIB_BACKTRACE", None::<&str>),
-            ],
-            || {
-                let err = anyhow::anyhow!("Oh jeez");
-                assert_eq!(
-                    err.backtrace().status(),
-                    std::backtrace::BacktraceStatus::Captured
-                );
-                f(&err);
-            },
+    const CHILD_MARKER: &str = "SENTRY_TEST_ANYHOW_BACKTRACE_CHILD";
+
+    /// Prefer a child process over `std::env::set_var` in this process: `set_var`
+    /// is unsafe if other threads may touch the environment, while `Command::env`
+    /// only affects the child. anyhow captures backtraces only when
+    /// `RUST_BACKTRACE` / `RUST_LIB_BACKTRACE` is set before the error is created.
+    fn run_with_rust_backtrace(test_name: &str) {
+        let output = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg(test_name)
+            .arg("--nocapture")
+            .env(CHILD_MARKER, "1")
+            .env("RUST_BACKTRACE", "1")
+            .env_remove("RUST_LIB_BACKTRACE")
+            .output()
+            .expect("failed to spawn test child process");
+        assert!(
+            output.status.success(),
+            "child {test_name} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
         );
+    }
+
+    fn in_backtrace_child() -> bool {
+        std::env::var_os(CHILD_MARKER).is_some()
     }
 
     #[test]
     fn test_event_from_error_with_backtrace() {
-        with_captured_anyhow_backtrace(|err| {
-            let event = event_from_error(err);
+        if !in_backtrace_child() {
+            run_with_rust_backtrace("tests::test_event_from_error_with_backtrace");
+            return;
+        }
 
-            let stacktrace = event.exception[0].stacktrace.as_ref().unwrap();
-            let found_test_fn = stacktrace
-                .frames
-                .iter()
-                .find(|frame| match &frame.function {
-                    Some(f) => f.contains("test_event_from_error_with_backtrace"),
-                    None => false,
-                });
+        let err = anyhow::anyhow!("Oh jeez");
+        assert_eq!(
+            err.backtrace().status(),
+            std::backtrace::BacktraceStatus::Captured
+        );
+        let event = event_from_error(&err);
 
-            assert!(found_test_fn.is_some());
-        });
+        let stacktrace = event.exception[0].stacktrace.as_ref().unwrap();
+        let found_test_fn = stacktrace
+            .frames
+            .iter()
+            .find(|frame| match &frame.function {
+                Some(f) => f.contains("test_event_from_error_with_backtrace"),
+                None => false,
+            });
+
+        assert!(found_test_fn.is_some());
     }
 
     #[test]
     fn test_capture_anyhow_uses_event_from_error_helper() {
-        with_captured_anyhow_backtrace(|err| {
-            let event = event_from_error(err);
-            let events = sentry::test::with_captured_events(|| {
-                capture_anyhow(err);
-            });
+        if !in_backtrace_child() {
+            run_with_rust_backtrace("tests::test_capture_anyhow_uses_event_from_error_helper");
+            return;
+        }
 
-            assert_eq!(event.exception, events[0].exception);
+        let err = &anyhow::anyhow!("Oh jeez");
+        assert_eq!(
+            err.backtrace().status(),
+            std::backtrace::BacktraceStatus::Captured
+        );
+
+        let event = event_from_error(err);
+        let events = sentry::test::with_captured_events(|| {
+            capture_anyhow(err);
         });
+
+        assert_eq!(event.exception, events[0].exception);
     }
 }

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -101,42 +101,55 @@ impl AnyhowHubExt for Hub {
 mod tests {
     use super::*;
 
-    fn anyhow_with_captured_backtrace() -> anyhow::Error {
-        let err = anyhow::anyhow!("Oh jeez");
-        assert_eq!(
-            err.backtrace().status(),
-            std::backtrace::BacktraceStatus::Captured,
-            "run with RUST_BACKTRACE=1 (anyhow captures only when that is preset; \
-             tests must not call std::env::set_var)"
+    fn with_captured_anyhow_backtrace<F>(f: F)
+    where
+        F: FnOnce(&anyhow::Error),
+    {
+        // anyhow only captures when RUST_BACKTRACE/RUST_LIB_BACKTRACE is set.
+        // temp-env serializes mutation so tests do not use a bare set_var.
+        temp_env::with_vars(
+            [
+                ("RUST_BACKTRACE", Some("1")),
+                ("RUST_LIB_BACKTRACE", None::<&str>),
+            ],
+            || {
+                let err = anyhow::anyhow!("Oh jeez");
+                assert_eq!(
+                    err.backtrace().status(),
+                    std::backtrace::BacktraceStatus::Captured
+                );
+                f(&err);
+            },
         );
-        err
     }
 
     #[test]
     fn test_event_from_error_with_backtrace() {
-        let event = event_from_error(&anyhow_with_captured_backtrace());
+        with_captured_anyhow_backtrace(|err| {
+            let event = event_from_error(err);
 
-        let stacktrace = event.exception[0].stacktrace.as_ref().unwrap();
-        let found_test_fn = stacktrace
-            .frames
-            .iter()
-            .find(|frame| match &frame.function {
-                Some(f) => f.contains("test_event_from_error_with_backtrace"),
-                None => false,
-            });
+            let stacktrace = event.exception[0].stacktrace.as_ref().unwrap();
+            let found_test_fn = stacktrace
+                .frames
+                .iter()
+                .find(|frame| match &frame.function {
+                    Some(f) => f.contains("test_event_from_error_with_backtrace"),
+                    None => false,
+                });
 
-        assert!(found_test_fn.is_some());
+            assert!(found_test_fn.is_some());
+        });
     }
 
     #[test]
     fn test_capture_anyhow_uses_event_from_error_helper() {
-        let err = &anyhow_with_captured_backtrace();
+        with_captured_anyhow_backtrace(|err| {
+            let event = event_from_error(err);
+            let events = sentry::test::with_captured_events(|| {
+                capture_anyhow(err);
+            });
 
-        let event = event_from_error(err);
-        let events = sentry::test::with_captured_events(|| {
-            capture_anyhow(err);
+            assert_eq!(event.exception, events[0].exception);
         });
-
-        assert_eq!(event.exception, events[0].exception);
     }
 }

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -97,9 +97,28 @@ impl AnyhowHubExt for Hub {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "backtrace", test))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_event_from_error_with_backtrace() {
+        let event = event_from_error(&anyhow::anyhow!("Oh jeez"));
+
+        let stacktrace = event.exception[0]
+            .stacktrace
+            .as_ref()
+            .expect("run with RUST_BACKTRACE=1");
+        let found_test_fn = stacktrace
+            .frames
+            .iter()
+            .find(|frame| match &frame.function {
+                Some(f) => f.contains("test_event_from_error_with_backtrace"),
+                None => false,
+            });
+
+        assert!(found_test_fn.is_some());
+    }
 
     #[test]
     fn test_capture_anyhow_uses_event_from_error_helper() {

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -97,78 +97,13 @@ impl AnyhowHubExt for Hub {
     }
 }
 
-#[cfg(all(feature = "backtrace", test))]
+#[cfg(test)]
 mod tests {
-    use std::process::Command;
-
     use super::*;
-
-    const CHILD_MARKER: &str = "SENTRY_TEST_ANYHOW_BACKTRACE_CHILD";
-
-    /// Prefer a child process over `std::env::set_var` in this process: `set_var`
-    /// is unsafe if other threads may touch the environment, while `Command::env`
-    /// only affects the child. anyhow captures backtraces only when
-    /// `RUST_BACKTRACE` / `RUST_LIB_BACKTRACE` is set before the error is created.
-    fn run_with_rust_backtrace(test_name: &str) {
-        let output = Command::new(std::env::current_exe().unwrap())
-            .arg("--exact")
-            .arg(test_name)
-            .arg("--nocapture")
-            .env(CHILD_MARKER, "1")
-            .env("RUST_BACKTRACE", "1")
-            .env_remove("RUST_LIB_BACKTRACE")
-            .output()
-            .expect("failed to spawn test child process");
-        assert!(
-            output.status.success(),
-            "child {test_name} failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
-        );
-    }
-
-    fn in_backtrace_child() -> bool {
-        std::env::var_os(CHILD_MARKER).is_some()
-    }
-
-    #[test]
-    fn test_event_from_error_with_backtrace() {
-        if !in_backtrace_child() {
-            run_with_rust_backtrace("tests::test_event_from_error_with_backtrace");
-            return;
-        }
-
-        let err = anyhow::anyhow!("Oh jeez");
-        assert_eq!(
-            err.backtrace().status(),
-            std::backtrace::BacktraceStatus::Captured
-        );
-        let event = event_from_error(&err);
-
-        let stacktrace = event.exception[0].stacktrace.as_ref().unwrap();
-        let found_test_fn = stacktrace
-            .frames
-            .iter()
-            .find(|frame| match &frame.function {
-                Some(f) => f.contains("test_event_from_error_with_backtrace"),
-                None => false,
-            });
-
-        assert!(found_test_fn.is_some());
-    }
 
     #[test]
     fn test_capture_anyhow_uses_event_from_error_helper() {
-        if !in_backtrace_child() {
-            run_with_rust_backtrace("tests::test_capture_anyhow_uses_event_from_error_helper");
-            return;
-        }
-
         let err = &anyhow::anyhow!("Oh jeez");
-        assert_eq!(
-            err.backtrace().status(),
-            std::backtrace::BacktraceStatus::Captured
-        );
 
         let event = event_from_error(err);
         let events = sentry::test::with_captured_events(|| {

--- a/sentry-anyhow/src/lib.rs
+++ b/sentry-anyhow/src/lib.rs
@@ -105,8 +105,6 @@ mod tests {
     where
         F: FnOnce(&anyhow::Error),
     {
-        // anyhow only captures when RUST_BACKTRACE/RUST_LIB_BACKTRACE is set.
-        // temp-env serializes mutation so tests do not use a bare set_var.
         temp_env::with_vars(
             [
                 ("RUST_BACKTRACE", Some("1")),

--- a/sentry-backtrace/src/lib.rs
+++ b/sentry-backtrace/src/lib.rs
@@ -14,7 +14,7 @@ mod trim;
 mod utils;
 
 pub use crate::integration::{
-    current_thread, AttachStacktraceIntegration, ProcessStacktraceIntegration,
+    AttachStacktraceIntegration, ProcessStacktraceIntegration, current_thread,
 };
 pub use crate::parse::parse_stacktrace;
 pub use crate::process::{backtrace_to_stacktrace, process_event_stacktrace};

--- a/sentry-backtrace/src/utils.rs
+++ b/sentry-backtrace/src/utils.rs
@@ -228,7 +228,12 @@ mod tests {
             &strip_symbol("<fn() as core[bb3d6b31f0e973c8]::ops::function::FnOnce<()>>::call_once"),
             "<fn() as core::ops::function::FnOnce<()>>::call_once"
         );
-        assert_eq!(&strip_symbol("<std[550525b9dd91a68e]::thread::local::LocalKey<(arc_swap[1d34a79be67db79e]::ArcSwapAny<alloc[bc7f897b574022f6]::sync::Arc<sentry_core[1d5336878cce1456]::hub::Hub>>, core[bb3d6b31f0e973c8]::cell::Cell<bool>)>>::with::<<sentry_core[1d5336878cce1456]::hub::Hub>::with<<sentry_core[1d5336878cce1456]::hub::Hub>::with_active<sentry_core[1d5336878cce1456]::api::with_integration<sentry_panic[c87c9124ff32f50e]::PanicIntegration, sentry_panic[c87c9124ff32f50e]::panic_handler::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>"), "<std::thread::local::LocalKey<(arc_swap::ArcSwapAny<alloc::sync::Arc<sentry_core::hub::Hub>>, core::cell::Cell<bool>)>>::with::<<sentry_core::hub::Hub>::with<<sentry_core::hub::Hub>::with_active<sentry_core::api::with_integration<sentry_panic::PanicIntegration, sentry_panic::panic_handler::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>");
+        assert_eq!(
+            &strip_symbol(
+                "<std[550525b9dd91a68e]::thread::local::LocalKey<(arc_swap[1d34a79be67db79e]::ArcSwapAny<alloc[bc7f897b574022f6]::sync::Arc<sentry_core[1d5336878cce1456]::hub::Hub>>, core[bb3d6b31f0e973c8]::cell::Cell<bool>)>>::with::<<sentry_core[1d5336878cce1456]::hub::Hub>::with<<sentry_core[1d5336878cce1456]::hub::Hub>::with_active<sentry_core[1d5336878cce1456]::api::with_integration<sentry_panic[c87c9124ff32f50e]::PanicIntegration, sentry_panic[c87c9124ff32f50e]::panic_handler::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>"
+            ),
+            "<std::thread::local::LocalKey<(arc_swap::ArcSwapAny<alloc::sync::Arc<sentry_core::hub::Hub>>, core::cell::Cell<bool>)>>::with::<<sentry_core::hub::Hub>::with<<sentry_core::hub::Hub>::with_active<sentry_core::api::with_integration<sentry_panic::PanicIntegration, sentry_panic::panic_handler::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>::{closure#0}, ()>"
+        );
     }
 
     #[test]

--- a/sentry-contexts/build.rs
+++ b/sentry-contexts/build.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use rustc_version::{version, version_meta, Channel};
+use rustc_version::{Channel, version, version_meta};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::var("OUT_DIR")?;

--- a/sentry-contexts/src/integration.rs
+++ b/sentry-contexts/src/integration.rs
@@ -82,12 +82,11 @@ impl Integration for ContextIntegration {
         mut event: Event<'static>,
         _cfg: &ClientOptions,
     ) -> Option<Event<'static>> {
-        if self.add_os {
-            if let Entry::Vacant(entry) = event.contexts.entry("os".to_string()) {
-                if let Some(os) = os_context() {
-                    entry.insert(os);
-                }
-            }
+        if self.add_os
+            && let Entry::Vacant(entry) = event.contexts.entry("os".to_string())
+            && let Some(os) = os_context()
+        {
+            entry.insert(os);
         }
         if self.add_rust {
             event

--- a/sentry-contexts/src/integration.rs
+++ b/sentry-contexts/src/integration.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use sentry_core::protocol::map::Entry;
 use sentry_core::protocol::Event;
+use sentry_core::protocol::map::Entry;
 use sentry_core::{ClientOptions, Integration};
 
 use crate::utils::{device_context, os_context, rust_context, server_name};

--- a/sentry-contexts/src/utils.rs
+++ b/sentry-contexts/src/utils.rs
@@ -92,9 +92,10 @@ mod model_support {
         let dot_count = v.split('.').count() - 1;
         assert_eq!(dot_count, 2);
         let b = get_macos_build().unwrap();
-        assert!(b
-            .chars()
-            .all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit()));
+        assert!(
+            b.chars()
+                .all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit())
+        );
     }
 }
 

--- a/sentry-core/benches/scope_benchmark.rs
+++ b/sentry-core/benches/scope_benchmark.rs
@@ -25,7 +25,7 @@ use std::ops::Range;
 #[cfg(feature = "client")]
 use std::sync::Arc;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use sentry::protocol::Breadcrumb;
 #[cfg(not(feature = "client"))]
 use sentry_core as sentry;

--- a/sentry-core/src/client/batcher.rs
+++ b/sentry-core/src/client/batcher.rs
@@ -7,8 +7,8 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use super::EnvelopeSender;
-use crate::protocol::EnvelopeItem;
 use crate::Envelope;
+use crate::protocol::EnvelopeItem;
 use sentry_types::protocol::v7::Log;
 #[cfg(feature = "metrics")]
 use sentry_types::protocol::v7::Metric;

--- a/sentry-core/src/client/client_reports/inner.rs
+++ b/sentry-core/src/client/client_reports/inner.rs
@@ -6,8 +6,8 @@
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use sentry_types::protocol::v7::client_report::{Category, Item, Reason, Report};
 use sentry_types::IndexedEnum;
+use sentry_types::protocol::v7::client_report::{Category, Item, Reason, Report};
 
 const ARRAY_SIZE: usize = Reason::VARIANTS.len() * Category::VARIANTS.len();
 

--- a/sentry-core/src/client/client_reports/mod.rs
+++ b/sentry-core/src/client/client_reports/mod.rs
@@ -8,10 +8,10 @@
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use std::sync::Arc;
 
+use sentry_types::protocol::v7::ClientReport;
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use sentry_types::protocol::v7::client_report::ItemLoss;
 use sentry_types::protocol::v7::client_report::{Category, LossSource, Reason};
-use sentry_types::protocol::v7::ClientReport;
 
 #[cfg(all(target_has_atomic = "64", target_has_atomic = "8"))]
 use self::inner::ClientReportAggregatorInner;

--- a/sentry-core/src/client/envelope_sender.rs
+++ b/sentry-core/src/client/envelope_sender.rs
@@ -7,10 +7,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use sentry_types::protocol::v7::EnvelopeItem;
 use sentry_types::protocol::v7::client_report::{
     Category as ClientReportCategory, LossSource, Reason as ClientReportReason,
 };
-use sentry_types::protocol::v7::EnvelopeItem;
 
 use self::slot::TransportSlot;
 use super::client_reports::{ClientReportAggregator, Recorder};

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -22,13 +22,13 @@ use sentry_types::random_uuid;
 
 #[cfg(any(feature = "logs", feature = "metrics"))]
 use self::batcher::Batcher;
+#[cfg(feature = "release-health")]
+use crate::SessionMode;
 use crate::constants::SDK_INFO;
 use crate::protocol::{ClientSdkInfo, Event};
 #[cfg(feature = "release-health")]
 use crate::session::SessionFlusher;
 use crate::types::{Dsn, Uuid};
-#[cfg(feature = "release-health")]
-use crate::SessionMode;
 use crate::{ClientOptions, Envelope, EventSamplingStrategy, Hub, Integration, Scope};
 
 #[cfg(feature = "logs")]

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -559,10 +559,10 @@ impl Client {
             sentry_debug!("[Client] called capture_log, but options.enable_logs is set to false");
             return;
         }
-        if let Some(log) = self.prepare_log(log, scope) {
-            if let Some(ref batcher) = *self.logs_batcher.read().unwrap() {
-                batcher.enqueue(log);
-            }
+        if let Some(log) = self.prepare_log(log, scope)
+            && let Some(ref batcher) = *self.logs_batcher.read().unwrap()
+        {
+            batcher.enqueue(log);
         }
     }
 
@@ -600,15 +600,14 @@ impl Client {
             return;
         }
 
-        if let Some(metric) = self.prepare_metric(metric, scope) {
-            if let Some(batcher) = self
+        if let Some(metric) = self.prepare_metric(metric, scope)
+            && let Some(batcher) = self
                 .metrics_batcher
                 .read()
                 .expect("metrics batcher lock could not be acquired")
                 .as_ref()
-            {
-                batcher.enqueue(metric);
-            }
+        {
+            batcher.enqueue(metric);
         }
     }
 

--- a/sentry-core/src/error.rs
+++ b/sentry-core/src/error.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
+use crate::Hub;
 use crate::protocol::{Event, Exception, Level};
 use crate::types::Uuid;
-use crate::Hub;
 
 impl Hub {
     /// Capture any `std::error::Error`.

--- a/sentry-core/src/futures.rs
+++ b/sentry-core/src/futures.rs
@@ -69,7 +69,7 @@ impl<F> SentryFutureExt for F where F: Future {}
 #[cfg(all(test, feature = "test"))]
 mod tests {
     use crate::test::with_captured_events;
-    use crate::{capture_message, configure_scope, Hub, Level, SentryFutureExt};
+    use crate::{Hub, Level, SentryFutureExt, capture_message, configure_scope};
     use tokio::runtime::Runtime;
 
     #[test]

--- a/sentry-core/src/hub.rs
+++ b/sentry-core/src/hub.rs
@@ -90,11 +90,10 @@ impl Hub {
     {
         use_without_client!(f);
         with_client_impl! {{
-            if let Some(client) = self.client() {
-                if let Some(integration) = client.get_integration::<I>() {
+            if let Some(client) = self.client()
+                && let Some(integration) = client.get_integration::<I>() {
                     return f(integration);
                 }
-            }
             Default::default()
         }}
     }

--- a/sentry-core/src/hub_impl.rs
+++ b/sentry-core/src/hub_impl.rs
@@ -5,7 +5,7 @@ use std::thread;
 use std::thread::ThreadId;
 
 use crate::Scope;
-use crate::{scope::Stack, Client, Hub};
+use crate::{Client, Hub, scope::Stack};
 
 static PROCESS_HUB: LazyLock<ProcessHub> = LazyLock::new(|| ProcessHub {
     hub: Arc::new(Hub::new(None, Arc::new(Default::default()))),

--- a/sentry-core/src/integration.rs
+++ b/sentry-core/src/integration.rs
@@ -1,7 +1,7 @@
-use std::any::{type_name, Any};
+use std::any::{Any, type_name};
 
-use crate::protocol::Event;
 use crate::ClientOptions;
+use crate::protocol::Event;
 
 /// Integration abstraction.
 ///

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -855,16 +855,15 @@ impl Transaction {
 
             // Discard `Transaction` unless sampled.
             if !inner.sampled {
-                if let Some(transaction) = inner.transaction.take() {
-                    if let Some(client) = inner.client.as_ref() {
+                if let Some(transaction) = inner.transaction.take()
+                    && let Some(client) = inner.client.as_ref() {
                         client.record_lost_data(&transaction, ClientReportReason::SampleRate);
                     }
-                }
                 return;
             }
 
-            if let Some(mut transaction) = inner.transaction.take() {
-                if let Some(client) = inner.client.take() {
+            if let Some(mut transaction) = inner.transaction.take()
+                && let Some(client) = inner.client.take() {
                     transaction.finish_with_timestamp(_timestamp);
                     transaction
                         .contexts
@@ -894,7 +893,6 @@ impl Transaction {
 
                     client.send_envelope(envelope)
                 }
-            }
         }}
     }
 
@@ -1100,15 +1098,15 @@ impl Span {
         if let Some(cookies) = request.cookies {
             span.data.insert("cookies".into(), cookies.into());
         }
-        if !request.headers.is_empty() {
-            if let Ok(headers) = serde_json::to_value(request.headers) {
-                span.data.insert("headers".into(), headers);
-            }
+        if !request.headers.is_empty()
+            && let Ok(headers) = serde_json::to_value(request.headers)
+        {
+            span.data.insert("headers".into(), headers);
         }
-        if !request.env.is_empty() {
-            if let Ok(env) = serde_json::to_value(request.env) {
-                span.data.insert("env".into(), env);
-            }
+        if !request.env.is_empty()
+            && let Ok(env) = serde_json::to_value(request.env)
+        {
+            span.data.insert("env".into(), env);
         }
     }
 
@@ -1436,12 +1434,11 @@ mod tests {
                 return 1.0;
             }
 
-            if let Some(custom) = ctx.custom() {
-                if let Some(rate) = custom.get("rate") {
-                    if let Some(rate) = rate.as_f64() {
-                        return rate as f32;
-                    }
-                }
+            if let Some(custom) = ctx.custom()
+                && let Some(rate) = custom.get("rate")
+                && let Some(rate) = rate.as_f64()
+            {
+                return rate as f32;
             }
 
             0.1

--- a/sentry-core/src/performance.rs
+++ b/sentry-core/src/performance.rs
@@ -4,13 +4,13 @@ use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::SystemTime;
 
+use sentry_types::protocol::v7::SpanId;
 #[cfg(feature = "client")]
 use sentry_types::protocol::v7::client_report::Reason as ClientReportReason;
-use sentry_types::protocol::v7::SpanId;
 
 #[cfg(feature = "client")]
 use crate::clientoptions::TracesSamplingStrategy;
-use crate::{protocol, Hub};
+use crate::{Hub, protocol};
 
 #[cfg(feature = "client")]
 use crate::Client;

--- a/sentry-core/src/scope/noop.rs
+++ b/sentry-core/src/scope/noop.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 use std::panic::RefUnwindSafe;
 
+use crate::TransactionOrSpan;
 #[cfg(feature = "logs")]
 use crate::protocol::Log;
 use crate::protocol::{Context, Event, Level, User, Value};
-use crate::TransactionOrSpan;
 
 /// A minimal API scope guard.
 ///

--- a/sentry-core/src/scope/real.rs
+++ b/sentry-core/src/scope/real.rs
@@ -282,10 +282,10 @@ impl Scope {
             event.level = level;
         }
 
-        if event.user.is_none() {
-            if let Some(user) = self.user.as_deref() {
-                event.user = Some(user.clone());
-            }
+        if event.user.is_none()
+            && let Some(user) = self.user.as_deref()
+        {
+            event.user = Some(user.clone());
         }
 
         event.breadcrumbs.extend(self.breadcrumbs.iter().cloned());
@@ -307,18 +307,17 @@ impl Scope {
             self.apply_propagation_context(&mut event);
         }
 
-        if event.transaction.is_none() {
-            if let Some(txn) = self.transaction.as_deref() {
-                event.transaction = Some(txn.to_owned());
-            }
+        if event.transaction.is_none()
+            && let Some(txn) = self.transaction.as_deref()
+        {
+            event.transaction = Some(txn.to_owned());
         }
 
         if event.fingerprint.len() == 1
             && (event.fingerprint[0] == "{{ default }}" || event.fingerprint[0] == "{{default}}")
+            && let Some(fp) = self.fingerprint.as_deref()
         {
-            if let Some(fp) = self.fingerprint.as_deref() {
-                event.fingerprint = Cow::Owned(fp.to_owned());
-            }
+            event.fingerprint = Cow::Owned(fp.to_owned());
         }
 
         for processor in self.event_processors.as_ref() {
@@ -337,10 +336,10 @@ impl Scope {
 
     /// Applies the contained scoped data to fill a transaction.
     pub fn apply_to_transaction(&self, transaction: &mut Transaction<'static>) {
-        if transaction.user.is_none() {
-            if let Some(user) = self.user.as_deref() {
-                transaction.user = Some(user.clone());
-            }
+        if transaction.user.is_none()
+            && let Some(user) = self.user.as_deref()
+        {
+            transaction.user = Some(user.clone());
         }
 
         transaction
@@ -366,43 +365,43 @@ impl Scope {
             log.trace_id = Some(self.propagation_context.trace_id);
         }
 
-        if !log.attributes.contains_key("sentry.trace.parent_span_id") {
-            if let Some(span) = self.get_span() {
-                let span_id = match span {
-                    crate::TransactionOrSpan::Transaction(transaction) => {
-                        transaction.get_trace_context().span_id
-                    }
-                    crate::TransactionOrSpan::Span(span) => span.get_span_id(),
-                };
-                log.attributes.insert(
-                    "parent_span_id".to_owned(),
-                    LogAttribute(span_id.to_string().into()),
-                );
-            }
+        if !log.attributes.contains_key("sentry.trace.parent_span_id")
+            && let Some(span) = self.get_span()
+        {
+            let span_id = match span {
+                crate::TransactionOrSpan::Transaction(transaction) => {
+                    transaction.get_trace_context().span_id
+                }
+                crate::TransactionOrSpan::Span(span) => span.get_span_id(),
+            };
+            log.attributes.insert(
+                "parent_span_id".to_owned(),
+                LogAttribute(span_id.to_string().into()),
+            );
         }
 
         if let Some(user) = self.user.as_ref() {
-            if !log.attributes.contains_key("user.id") {
-                if let Some(id) = user.id.as_ref() {
-                    log.attributes
-                        .insert("user.id".to_owned(), LogAttribute(id.to_owned().into()));
-                }
+            if !log.attributes.contains_key("user.id")
+                && let Some(id) = user.id.as_ref()
+            {
+                log.attributes
+                    .insert("user.id".to_owned(), LogAttribute(id.to_owned().into()));
             }
 
-            if !log.attributes.contains_key("user.name") {
-                if let Some(name) = user.username.as_ref() {
-                    log.attributes
-                        .insert("user.name".to_owned(), LogAttribute(name.to_owned().into()));
-                }
+            if !log.attributes.contains_key("user.name")
+                && let Some(name) = user.username.as_ref()
+            {
+                log.attributes
+                    .insert("user.name".to_owned(), LogAttribute(name.to_owned().into()));
             }
 
-            if !log.attributes.contains_key("user.email") {
-                if let Some(email) = user.email.as_ref() {
-                    log.attributes.insert(
-                        "user.email".to_owned(),
-                        LogAttribute(email.to_owned().into()),
-                    );
-                }
+            if !log.attributes.contains_key("user.email")
+                && let Some(email) = user.email.as_ref()
+            {
+                log.attributes.insert(
+                    "user.email".to_owned(),
+                    LogAttribute(email.to_owned().into()),
+                );
             }
         }
     }

--- a/sentry-core/src/session.rs
+++ b/sentry-core/src/session.rs
@@ -91,11 +91,11 @@ mod session_impl {
             let mut is_crash = false;
             for exc in &event.exception.values {
                 has_error = true;
-                if let Some(mechanism) = &exc.mechanism {
-                    if let Some(false) = mechanism.handled {
-                        is_crash = true;
-                        break;
-                    }
+                if let Some(mechanism) = &exc.mechanism
+                    && let Some(false) = mechanism.handled
+                {
+                    is_crash = true;
+                    break;
                 }
             }
 

--- a/sentry-core/src/transport/options.rs
+++ b/sentry-core/src/transport/options.rs
@@ -4,9 +4,9 @@ use std::borrow::Cow;
 
 use sentry_types::Dsn;
 
+use crate::ClientOptions;
 #[cfg(feature = "client")]
 use crate::client_report::Recorder as ClientReportRecorder;
-use crate::ClientOptions;
 
 /// Options for a transport.
 #[derive(Debug)]

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result};
 
 use sentry::protocol::{MetricType, Unit, Value};
 use sentry_core::protocol::{EnvelopeItem, ItemContainer};
-use sentry_core::{metrics, test};
 use sentry_core::{ClientOptions, TransactionContext};
+use sentry_core::{metrics, test};
 use sentry_types::protocol::v7::{Envelope, LogAttribute, Metric, User};
 
 /// Test that metrics are sent when metrics are enabled.

--- a/sentry-debug-images/src/images.rs
+++ b/sentry-debug-images/src/images.rs
@@ -3,7 +3,7 @@ use std::env;
 use sentry_core::protocol::{DebugImage, SymbolicDebugImage};
 use sentry_core::types::{CodeId, DebugId, Uuid};
 
-use findshlibs::{SharedLibrary, SharedLibraryId, TargetSharedLibrary, TARGET_SUPPORTED};
+use findshlibs::{SharedLibrary, SharedLibraryId, TARGET_SUPPORTED, TargetSharedLibrary};
 
 const UUID_SIZE: usize = 16;
 

--- a/sentry-opentelemetry/src/converters.rs
+++ b/sentry-opentelemetry/src/converters.rs
@@ -1,4 +1,4 @@
-use sentry_core::protocol::{value::Number, SpanId, SpanStatus, TraceId, Value};
+use sentry_core::protocol::{SpanId, SpanStatus, TraceId, Value, value::Number};
 
 pub(crate) fn convert_span_id(span_id: &opentelemetry::SpanId) -> SpanId {
     span_id.to_bytes().into()

--- a/sentry-opentelemetry/src/processor.rs
+++ b/sentry-opentelemetry/src/processor.rs
@@ -12,9 +12,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, SystemTime};
 
-use opentelemetry::global::ObjectSafeSpan;
-use opentelemetry::trace::{get_active_span, SpanId};
 use opentelemetry::Context;
+use opentelemetry::global::ObjectSafeSpan;
+use opentelemetry::trace::{SpanId, get_active_span};
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{Span, SpanData, SpanProcessor};
 

--- a/sentry-opentelemetry/src/propagator.rs
+++ b/sentry-opentelemetry/src/propagator.rs
@@ -15,12 +15,12 @@
 use std::sync::LazyLock;
 
 use opentelemetry::{
-    propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
-    trace::TraceContextExt,
     Context, SpanId, TraceId,
+    propagation::{Extractor, Injector, TextMapPropagator, text_map_propagator::FieldIter},
+    trace::TraceContextExt,
 };
-use sentry_core::parse_headers;
 use sentry_core::SentryTrace;
+use sentry_core::parse_headers;
 
 use crate::converters::{convert_span_id, convert_trace_id};
 

--- a/sentry-opentelemetry/tests/captures_transaction_with_nested_spans.rs
+++ b/sentry-opentelemetry/tests/captures_transaction_with_nested_spans.rs
@@ -1,9 +1,8 @@
 mod shared;
 
 use opentelemetry::{
-    global,
+    KeyValue, global,
     trace::{Status, TraceContextExt, Tracer, TracerProvider},
-    KeyValue,
 };
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use sentry_opentelemetry::{SentryPropagator, SentrySpanProcessor};

--- a/sentry-opentelemetry/tests/creates_distributed_trace.rs
+++ b/sentry-opentelemetry/tests/creates_distributed_trace.rs
@@ -1,10 +1,9 @@
 mod shared;
 
 use opentelemetry::{
-    global,
+    Context, global,
     propagation::TextMapPropagator,
     trace::{TraceContextExt, Tracer, TracerProvider},
-    Context,
 };
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use sentry_opentelemetry::{SentryPropagator, SentrySpanProcessor};

--- a/sentry-slog/src/converters.rs
+++ b/sentry-slog/src/converters.rs
@@ -1,5 +1,5 @@
 use sentry_core::protocol::{Breadcrumb, Event, Level, Map, Value};
-use slog::{Key, OwnedKVList, Record, Serializer, KV};
+use slog::{KV, Key, OwnedKVList, Record, Serializer};
 use std::fmt;
 
 /// Converts a [`slog::Level`] to a Sentry [`Level`]
@@ -106,7 +106,7 @@ mod test {
     use super::*;
     use serde::Serialize;
 
-    use slog::{b, o, record, Level};
+    use slog::{Level, b, o, record};
 
     #[derive(Serialize, Clone)]
     struct Something {

--- a/sentry-slog/src/lib.rs
+++ b/sentry-slog/src/lib.rs
@@ -79,4 +79,4 @@ mod converters;
 mod drain;
 
 pub use converters::*;
-pub use drain::{default_filter, LevelFilter, RecordMapping, SentryDrain};
+pub use drain::{LevelFilter, RecordMapping, SentryDrain, default_filter};

--- a/sentry-tower/src/http.rs
+++ b/sentry-tower/src/http.rs
@@ -3,10 +3,10 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use http::{header, uri, Request, Response, StatusCode};
+use http::{Request, Response, StatusCode, header, uri};
 use pin_project::pinned_drop;
 use sentry_core::utils::{is_sensitive_header, scrub_pii_from_url};
-use sentry_core::{protocol, Hub};
+use sentry_core::{Hub, protocol};
 use tower_layer::Layer;
 use tower_service::Service;
 

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -4,11 +4,11 @@ use std::error::Error;
 use sentry_core::protocol::{Event, Exception, Mechanism, Value};
 #[cfg(feature = "logs")]
 use sentry_core::protocol::{Log, LogAttribute, LogLevel};
-use sentry_core::{event_from_error, Breadcrumb, Level, TransactionOrSpan};
+use sentry_core::{Breadcrumb, Level, TransactionOrSpan, event_from_error};
 #[cfg(feature = "logs")]
 use std::time::SystemTime;
-use tracing_core::field::{Field, Visit};
 use tracing_core::Subscriber;
+use tracing_core::field::{Field, Visit};
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
 

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -299,25 +299,25 @@ where
     // We should only do this if we're capturing stack traces, otherwise the issue title will be `<unknown>`
     // as Sentry will attempt to use missing stack trace to determine the title.
     #[cfg(feature = "backtrace")]
-    if !exceptions.is_empty() && message.is_some() {
-        if let Some(client) = sentry_core::Hub::current().client() {
-            if client.options().attach_stacktrace {
-                let thread = sentry_backtrace::current_thread(true);
-                let exception = Exception {
-                    ty: level_to_exception_type(event.metadata().level()).to_owned(),
-                    value: message.take(),
-                    module: event.metadata().module_path().map(str::to_owned),
-                    stacktrace: thread.stacktrace,
-                    raw_stacktrace: thread.raw_stacktrace,
-                    thread_id: thread.id,
-                    mechanism: Some(Mechanism {
-                        synthetic: Some(true),
-                        ..Mechanism::default()
-                    }),
-                };
-                exceptions.push(exception)
-            }
-        }
+    if !exceptions.is_empty()
+        && message.is_some()
+        && let Some(client) = sentry_core::Hub::current().client()
+        && client.options().attach_stacktrace
+    {
+        let thread = sentry_backtrace::current_thread(true);
+        let exception = Exception {
+            ty: level_to_exception_type(event.metadata().level()).to_owned(),
+            value: message.take(),
+            module: event.metadata().module_path().map(str::to_owned),
+            stacktrace: thread.stacktrace,
+            raw_stacktrace: thread.raw_stacktrace,
+            thread_id: thread.id,
+            mechanism: Some(Mechanism {
+                synthetic: Some(true),
+                ..Mechanism::default()
+            }),
+        };
+        exceptions.push(exception)
     }
 
     if let Some(exception) = exceptions.last_mut() {

--- a/sentry-tracing/src/layer/mod.rs
+++ b/sentry-tracing/src/layer/mod.rs
@@ -7,15 +7,15 @@ use bitflags::bitflags;
 use sentry_core::protocol::Value;
 use sentry_core::{Breadcrumb, Hub, HubSwitchGuard, TransactionOrSpan};
 use tracing_core::field::Visit;
-use tracing_core::{span, Event, Field, Level, Metadata, Subscriber};
+use tracing_core::{Event, Field, Level, Metadata, Subscriber, span};
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
-use crate::converters::*;
 use crate::SENTRY_NAME_FIELD;
 use crate::SENTRY_OP_FIELD;
 use crate::SENTRY_TRACE_FIELD;
 use crate::TAGS_PREFIX;
+use crate::converters::*;
 use span_guard_stack::SpanGuardStack;
 
 mod span_guard_stack;

--- a/sentry-tracing/src/layer/span_guard_stack.rs
+++ b/sentry-tracing/src/layer/span_guard_stack.rs
@@ -1,8 +1,8 @@
 //! This module contains code for stack-like storage for `HubSwitchGuard`s keyed
 //! by tracing span ID.
 
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 
 use sentry_core::HubSwitchGuard;
 use tracing_core::span::Id as SpanId;

--- a/sentry-tracing/tests/future_cross_thread_info_span.rs
+++ b/sentry-tracing/tests/future_cross_thread_info_span.rs
@@ -32,9 +32,8 @@ fn future_cross_thread_info_span() {
             .expect("expected thread2 to panic with a String message");
 
         assert!(
-            thread2_panic_message.starts_with(
-                "[SentryLayer] missing HubSwitchGuard on exit for span"
-            ),
+            thread2_panic_message
+                .starts_with("[SentryLayer] missing HubSwitchGuard on exit for span"),
             "Thread 2 panicked, but not for the expected reason. It is also possible that the panic \
             message was changed without updating this test."
         );

--- a/sentry-tracing/tests/transaction_assertions/mod.rs
+++ b/sentry-tracing/tests/transaction_assertions/mod.rs
@@ -1,5 +1,5 @@
-use sentry::protocol::{EnvelopeItem, Transaction};
 use sentry::Envelope;
+use sentry::protocol::{EnvelopeItem, Transaction};
 
 /// Assert that the given envelopes contain exactly one `Envelope`, containing
 /// exactly one `EnvelopeItem`, which is a `Transaction` with the given name.

--- a/sentry-types/src/dsn.rs
+++ b/sentry-types/src/dsn.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use thiserror::Error;
 use url::Url;
 
-use crate::auth::{auth_from_dsn_and_client, Auth};
+use crate::auth::{Auth, auth_from_dsn_and_client};
 use crate::project_id::{ParseProjectIdError, ProjectId};
 
 /// Represents a dsn url parsing error.

--- a/sentry-types/src/protocol/client_report/envelope_losses.rs
+++ b/sentry-types/src/protocol/client_report/envelope_losses.rs
@@ -8,7 +8,7 @@ use crate::protocol::v7::{
 };
 
 use super::list::Iter as ClientReportItemIter;
-use super::{relay_size, Category, Item as ClientReportItem, Reason};
+use super::{Category, Item as ClientReportItem, Reason, relay_size};
 
 /// A trait for protocol types which can be a source of lost Sentry data if discarded.
 pub trait LossSource: private::Sealed {

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -549,20 +549,20 @@ impl Envelope {
 
         // filter again, removing attachments which do not make any sense without
         // an event/transaction
-        if filtered.uuid().is_none() {
-            if let Items::EnvelopeItems(ref mut items) = filtered.items {
-                let old_items = mem::take(items);
-                *items = old_items
-                    .into_iter()
-                    .filter_map(|item| match item {
-                        EnvelopeItem::Attachment(..) => {
-                            filter.on_filtered(item);
-                            None
-                        }
-                        _ => Some(item),
-                    })
-                    .collect();
-            }
+        if filtered.uuid().is_none()
+            && let Items::EnvelopeItems(ref mut items) = filtered.items
+        {
+            let old_items = mem::take(items);
+            *items = old_items
+                .into_iter()
+                .filter_map(|item| match item {
+                    EnvelopeItem::Attachment(..) => {
+                        filter.on_filtered(item);
+                        None
+                    }
+                    _ => Some(item),
+                })
+                .collect();
         }
 
         if filtered.items.is_empty() {

--- a/sentry-types/src/protocol/envelope.rs
+++ b/sentry-types/src/protocol/envelope.rs
@@ -900,8 +900,8 @@ mod test {
 
     use protocol::Map;
     use serde_json::Value;
-    use time::format_description::well_known::Rfc3339;
     use time::OffsetDateTime;
+    use time::format_description::well_known::Rfc3339;
     use uuid::Uuid;
 
     use super::*;

--- a/sentry-types/src/protocol/v7.rs
+++ b/sentry-types/src/protocol/v7.rs
@@ -16,7 +16,7 @@ use std::str;
 use std::time::SystemTime;
 
 use self::debugid::{CodeId, DebugId};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use thiserror::Error;
 
 pub use url::Url;
@@ -40,7 +40,7 @@ pub mod client_report {
 
 /// An arbitrary (JSON) value.
 pub mod value {
-    pub use serde_json::value::{from_value, to_value, Index, Map, Number, Value};
+    pub use serde_json::value::{Index, Map, Number, Value, from_value, to_value};
 }
 
 /// The internally used arbitrary data map type.
@@ -2364,8 +2364,8 @@ impl<'de> Deserialize<'de> for LogAttribute {
                     }
                     _ => {
                         return Err(de::Error::custom(format!(
-                        "expected type to be 'string' | 'integer' | 'double' | 'boolean', found {type_str}"
-                    )))
+                            "expected type to be 'string' | 'integer' | 'double' | 'boolean', found {type_str}"
+                        )));
                     }
                 }
 

--- a/sentry-types/src/utils.rs
+++ b/sentry-types/src/utils.rs
@@ -1,8 +1,8 @@
 use std::convert::{TryFrom, TryInto};
 use std::time::{Duration, SystemTime};
 
-use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 /// Converts a `SystemTime` object into a float timestamp.
 pub fn datetime_to_timestamp(st: &SystemTime) -> f64 {
@@ -218,7 +218,7 @@ pub mod ts_rfc3339_opt {
 /// assert_eq!(deserialized, config);
 /// ```
 pub(crate) mod display_from_str_opt {
-    use serde::{de, ser, Deserialize};
+    use serde::{Deserialize, de, ser};
 
     pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/sentry-types/tests/test_auth.rs
+++ b/sentry-types/tests/test_auth.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 
-use sentry_types::{protocol, Auth, Dsn};
+use sentry_types::{Auth, Dsn, protocol};
 
 #[test]
 fn test_auth_parsing() {
@@ -92,7 +92,9 @@ fn test_auth_to_json() {
 
     let auth = Auth::from_pairs(cont).unwrap();
     assert_eq!(
-        serde_json::to_string(&auth).expect("could not serialize").as_str(),
+        serde_json::to_string(&auth)
+            .expect("could not serialize")
+            .as_str(),
         "{\"sentry_client\":\"raven-js/3.23.3\",\"sentry_version\":7,\"sentry_key\":\"4bb5d94de752a36b8b87851a3f82726a\",\"sentry_secret\":null}"
     );
 }

--- a/sentry-types/tests/test_protocol_v7.rs
+++ b/sentry-types/tests/test_protocol_v7.rs
@@ -1563,7 +1563,7 @@ fn test_orientation() {
 
 mod test_logs {
     use sentry_types::protocol::v7::LogAttribute;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     #[test]
     fn test_log_attribute_serialization() {

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -105,6 +105,7 @@ anyhow = { workspace = true }
 log = { workspace = true, features = ["std"] }
 pretty_env_logger = { workspace = true }
 slog = { workspace = true }
+temp-env = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -105,7 +105,6 @@ anyhow = { workspace = true }
 log = { workspace = true, features = ["std"] }
 pretty_env_logger = { workspace = true }
 slog = { workspace = true }
-temp-env = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -28,7 +28,9 @@ use crate::{ClientOptions, Integration};
 ///
 /// # Examples
 /// ```
-/// std::env::set_var("SENTRY_RELEASE", "release-from-env");
+/// unsafe {
+///     std::env::set_var("SENTRY_RELEASE", "release-from-env");
+/// }
 ///
 /// let options = sentry::ClientOptions::default();
 /// assert_eq!(options.release, None);
@@ -129,7 +131,9 @@ mod tests {
         // I doubt anyone runs test code without debug assertions
         assert_eq!(opts.environment.unwrap(), "development");
 
-        env::set_var("SENTRY_ENVIRONMENT", "env-from-env");
+        unsafe {
+            env::set_var("SENTRY_ENVIRONMENT", "env-from-env");
+        }
         let opts = apply_defaults(Default::default());
         assert_eq!(opts.environment.unwrap(), "env-from-env");
     }

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -28,18 +28,16 @@ use crate::{ClientOptions, Integration};
 ///
 /// # Examples
 /// ```
-/// unsafe {
-///     std::env::set_var("SENTRY_RELEASE", "release-from-env");
-/// }
-///
 /// let options = sentry::ClientOptions::default();
-/// assert_eq!(options.release, None);
 /// assert!(options.transport.is_none());
 ///
 /// let options = sentry::apply_defaults(options);
-/// assert_eq!(options.release, Some("release-from-env".into()));
 /// assert!(options.transport.is_some());
 /// ```
+///
+/// When `SENTRY_RELEASE` / `SENTRY_ENVIRONMENT` / `SENTRY_DSN` are set in the
+/// process environment, `apply_defaults` also fills those fields if they were
+/// left unset.
 ///
 /// [`AttachStacktraceIntegration`]: integrations/backtrace/struct.AttachStacktraceIntegration.html
 /// [`DebugImagesIntegration`]: integrations/debug_images/struct.DebugImagesIntegration.html
@@ -127,14 +125,15 @@ mod tests {
         let opts = apply_defaults(opts);
         assert_eq!(opts.environment.unwrap(), "explicit-env");
 
-        let opts = apply_defaults(Default::default());
-        // I doubt anyone runs test code without debug assertions
-        assert_eq!(opts.environment.unwrap(), "development");
-
-        unsafe {
-            env::set_var("SENTRY_ENVIRONMENT", "env-from-env");
+        // Do not call std::env::set_var here: it is unsound if any other thread
+        // may touch the environment. Cover the env-var path only when already set.
+        if let Ok(env_from_env) = env::var("SENTRY_ENVIRONMENT") {
+            let opts = apply_defaults(Default::default());
+            assert_eq!(opts.environment.unwrap(), env_from_env);
+        } else {
+            let opts = apply_defaults(Default::default());
+            // I doubt anyone runs test code without debug assertions
+            assert_eq!(opts.environment.unwrap(), "development");
         }
-        let opts = apply_defaults(Default::default());
-        assert_eq!(opts.environment.unwrap(), "env-from-env");
     }
 }

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -117,23 +117,55 @@ pub fn apply_defaults(mut opts: ClientOptions) -> ClientOptions {
 
 #[cfg(test)]
 mod tests {
+    use std::process::Command;
+
     use super::*;
+
+    const CHILD_CASE: &str = "SENTRY_TEST_DEFAULT_ENVIRONMENT_CASE";
 
     #[test]
     fn test_default_environment() {
-        let opts = ClientOptions::new().environment("explicit-env");
-        let opts = apply_defaults(opts);
-        assert_eq!(opts.environment.unwrap(), "explicit-env");
+        match env::var(CHILD_CASE).as_deref() {
+            Ok("fallback") => {
+                let opts = apply_defaults(Default::default());
+                // I doubt anyone runs test code without debug assertions
+                assert_eq!(opts.environment.unwrap(), "development");
+            }
+            Ok("from_env") => {
+                let opts = apply_defaults(Default::default());
+                assert_eq!(opts.environment.unwrap(), "env-from-env");
+            }
+            _ => {
+                let opts = ClientOptions::new().environment("explicit-env");
+                let opts = apply_defaults(opts);
+                assert_eq!(opts.environment.unwrap(), "explicit-env");
 
-        temp_env::with_var("SENTRY_ENVIRONMENT", None::<&str>, || {
-            let opts = apply_defaults(Default::default());
-            // I doubt anyone runs test code without debug assertions
-            assert_eq!(opts.environment.unwrap(), "development");
-        });
+                // Prefer a child process over `std::env::set_var` in this process:
+                // `set_var` is unsafe if other threads may touch the environment,
+                // while `Command::env` / `env_remove` only affect the child.
+                run_default_environment_child("fallback", |cmd| {
+                    cmd.env_remove("SENTRY_ENVIRONMENT");
+                });
+                run_default_environment_child("from_env", |cmd| {
+                    cmd.env("SENTRY_ENVIRONMENT", "env-from-env");
+                });
+            }
+        }
+    }
 
-        temp_env::with_var("SENTRY_ENVIRONMENT", Some("env-from-env"), || {
-            let opts = apply_defaults(Default::default());
-            assert_eq!(opts.environment.unwrap(), "env-from-env");
-        });
+    fn run_default_environment_child(case: &str, configure: impl FnOnce(&mut Command)) {
+        let mut cmd = Command::new(env::current_exe().unwrap());
+        cmd.arg("--exact")
+            .arg("defaults::tests::test_default_environment")
+            .arg("--nocapture")
+            .env(CHILD_CASE, case);
+        configure(&mut cmd);
+        let output = cmd.output().expect("failed to spawn test child process");
+        assert!(
+            output.status.success(),
+            "child case {case:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
     }
 }

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -37,9 +37,7 @@ use crate::{ClientOptions, Integration};
 ///
 /// When `SENTRY_RELEASE` / `SENTRY_ENVIRONMENT` / `SENTRY_DSN` are set in the
 /// process environment, `apply_defaults` also fills those fields if they were
-/// left unset. Set those variables in the shell (or process supervisor) rather
-/// than via [`std::env::set_var`], which is not sound if other threads may
-/// access the process environment.
+/// left unset.
 ///
 /// [`AttachStacktraceIntegration`]: integrations/backtrace/struct.AttachStacktraceIntegration.html
 /// [`DebugImagesIntegration`]: integrations/debug_images/struct.DebugImagesIntegration.html
@@ -127,8 +125,6 @@ mod tests {
         let opts = apply_defaults(opts);
         assert_eq!(opts.environment.unwrap(), "explicit-env");
 
-        // temp-env serializes environment mutation across tests so we can cover
-        // both the fallback and SENTRY_ENVIRONMENT paths without a bare set_var.
         temp_env::with_var("SENTRY_ENVIRONMENT", None::<&str>, || {
             let opts = apply_defaults(Default::default());
             // I doubt anyone runs test code without debug assertions

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -117,55 +117,12 @@ pub fn apply_defaults(mut opts: ClientOptions) -> ClientOptions {
 
 #[cfg(test)]
 mod tests {
-    use std::process::Command;
-
     use super::*;
 
-    const CHILD_CASE: &str = "SENTRY_TEST_DEFAULT_ENVIRONMENT_CASE";
-
     #[test]
-    fn test_default_environment() {
-        match env::var(CHILD_CASE).as_deref() {
-            Ok("fallback") => {
-                let opts = apply_defaults(Default::default());
-                // I doubt anyone runs test code without debug assertions
-                assert_eq!(opts.environment.unwrap(), "development");
-            }
-            Ok("from_env") => {
-                let opts = apply_defaults(Default::default());
-                assert_eq!(opts.environment.unwrap(), "env-from-env");
-            }
-            _ => {
-                let opts = ClientOptions::new().environment("explicit-env");
-                let opts = apply_defaults(opts);
-                assert_eq!(opts.environment.unwrap(), "explicit-env");
-
-                // Prefer a child process over `std::env::set_var` in this process:
-                // `set_var` is unsafe if other threads may touch the environment,
-                // while `Command::env` / `env_remove` only affect the child.
-                run_default_environment_child("fallback", |cmd| {
-                    cmd.env_remove("SENTRY_ENVIRONMENT");
-                });
-                run_default_environment_child("from_env", |cmd| {
-                    cmd.env("SENTRY_ENVIRONMENT", "env-from-env");
-                });
-            }
-        }
-    }
-
-    fn run_default_environment_child(case: &str, configure: impl FnOnce(&mut Command)) {
-        let mut cmd = Command::new(env::current_exe().unwrap());
-        cmd.arg("--exact")
-            .arg("defaults::tests::test_default_environment")
-            .arg("--nocapture")
-            .env(CHILD_CASE, case);
-        configure(&mut cmd);
-        let output = cmd.output().expect("failed to spawn test child process");
-        assert!(
-            output.status.success(),
-            "child case {case:?} failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
-        );
+    fn test_explicit_environment_is_preserved() {
+        let opts = ClientOptions::new().environment("explicit-env");
+        let opts = apply_defaults(opts);
+        assert_eq!(opts.environment.unwrap(), "explicit-env");
     }
 }

--- a/sentry/src/defaults.rs
+++ b/sentry/src/defaults.rs
@@ -37,7 +37,9 @@ use crate::{ClientOptions, Integration};
 ///
 /// When `SENTRY_RELEASE` / `SENTRY_ENVIRONMENT` / `SENTRY_DSN` are set in the
 /// process environment, `apply_defaults` also fills those fields if they were
-/// left unset.
+/// left unset. Set those variables in the shell (or process supervisor) rather
+/// than via [`std::env::set_var`], which is not sound if other threads may
+/// access the process environment.
 ///
 /// [`AttachStacktraceIntegration`]: integrations/backtrace/struct.AttachStacktraceIntegration.html
 /// [`DebugImagesIntegration`]: integrations/debug_images/struct.DebugImagesIntegration.html
@@ -125,15 +127,17 @@ mod tests {
         let opts = apply_defaults(opts);
         assert_eq!(opts.environment.unwrap(), "explicit-env");
 
-        // Do not call std::env::set_var here: it is unsound if any other thread
-        // may touch the environment. Cover the env-var path only when already set.
-        if let Ok(env_from_env) = env::var("SENTRY_ENVIRONMENT") {
-            let opts = apply_defaults(Default::default());
-            assert_eq!(opts.environment.unwrap(), env_from_env);
-        } else {
+        // temp-env serializes environment mutation across tests so we can cover
+        // both the fallback and SENTRY_ENVIRONMENT paths without a bare set_var.
+        temp_env::with_var("SENTRY_ENVIRONMENT", None::<&str>, || {
             let opts = apply_defaults(Default::default());
             // I doubt anyone runs test code without debug assertions
             assert_eq!(opts.environment.unwrap(), "development");
-        }
+        });
+
+        temp_env::with_var("SENTRY_ENVIRONMENT", Some("env-from-env"), || {
+            let opts = apply_defaults(Default::default());
+            assert_eq!(opts.environment.unwrap(), "env-from-env");
+        });
     }
 }

--- a/sentry/src/init.rs
+++ b/sentry/src/init.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use sentry_core::sentry_debug;
 #[cfg(feature = "release-health")]
 use sentry_core::SessionMode;
+use sentry_core::sentry_debug;
 
 use crate::defaults::apply_defaults;
 use crate::{Client, ClientOptions, Hub};

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -144,7 +144,7 @@ pub use sentry_core::*;
 
 // added public API
 pub use crate::defaults::apply_defaults;
-pub use crate::init::{init, ClientInitGuard};
+pub use crate::init::{ClientInitGuard, init};
 
 /// Available Sentry Integrations.
 ///

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -2,15 +2,15 @@ use std::io::{Cursor, Read};
 use std::time::Duration;
 
 use curl::easy::Easy as CurlClient;
-use sentry_core::client_report::Reason as LossReason;
 use sentry_core::TransportOptions;
+use sentry_core::client_report::Reason as LossReason;
 
 use super::{
+    HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE, RateLimiter,
     thread::{TransportThread, TransportThreadOptions},
-    RateLimiter, HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE,
 };
 
-use crate::{sentry_debug, types::Scheme, ClientOptions, Envelope, Transport};
+use crate::{ClientOptions, Envelope, Transport, sentry_debug, types::Scheme};
 
 /// The status code returned for rate-limited envelopes.
 const HTTP_RATE_LIMIT_STATUS: u32 = 429;

--- a/sentry/src/transports/embedded_svc_http.rs
+++ b/sentry/src/transports/embedded_svc_http.rs
@@ -1,7 +1,7 @@
 use sentry_core::TransportOptions;
 
 use super::{HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE};
-use crate::{sentry_debug, ClientOptions, Transport};
+use crate::{ClientOptions, Transport, sentry_debug};
 use embedded_svc::http::client::Client as HttpClient;
 use esp_idf_svc::{http::client::EspHttpConnection, io::Write};
 

--- a/sentry/src/transports/ratelimit.rs
+++ b/sentry/src/transports/ratelimit.rs
@@ -3,9 +3,9 @@ use sentry_core::client_report::{Reason as ClientReportReason, Recorder as Clien
 use sentry_core::protocol::EnvelopeFilterCallbacks;
 use std::time::{Duration, SystemTime};
 
+use crate::Envelope;
 use crate::protocol::EnvelopeItem;
 use crate::protocol::ItemContainer;
-use crate::Envelope;
 
 /// A Utility that helps with rate limiting sentry requests.
 #[derive(Debug, Default)]

--- a/sentry/src/transports/reqwest.rs
+++ b/sentry/src/transports/reqwest.rs
@@ -1,15 +1,15 @@
 use std::time::Duration;
 
-use reqwest::{header as ReqwestHeaders, Client as ReqwestClient, Proxy, StatusCode};
-use sentry_core::client_report::Reason as LossReason;
+use reqwest::{Client as ReqwestClient, Proxy, StatusCode, header as ReqwestHeaders};
 use sentry_core::TransportOptions;
+use sentry_core::client_report::Reason as LossReason;
 
 use super::{
+    HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE, RateLimiter,
     tokio_thread::{TransportThread, TransportThreadOptions},
-    RateLimiter, HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE,
 };
 
-use crate::{sentry_debug, ClientOptions, Envelope, Transport};
+use crate::{ClientOptions, Envelope, Transport, sentry_debug};
 
 /// The status code returned for rate-limited envelopes.
 const HTTP_RATE_LIMIT_STATUS: u16 = 429;

--- a/sentry/src/transports/thread.rs
+++ b/sentry/src/transports/thread.rs
@@ -1,6 +1,6 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{sync_channel, SyncSender, TrySendError};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -9,7 +9,7 @@ use sentry_core::client_report::{Reason as ClientReportReason, Recorder as Clien
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 #[cfg(doc)]
 use super::{StdTransportThread, StdTransportThreadOptions}; // so we can use pub re-exports in docs
-use crate::{sentry_debug, Envelope};
+use crate::{Envelope, sentry_debug};
 
 #[expect(
     clippy::large_enum_variant,

--- a/sentry/src/transports/tokio_thread.rs
+++ b/sentry/src/transports/tokio_thread.rs
@@ -1,6 +1,6 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{sync_channel, SyncSender, TrySendError};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -9,7 +9,7 @@ use sentry_core::client_report::{Reason as ClientReportReason, Recorder as Clien
 use super::ratelimit::{RateLimiter, RateLimitingCategory};
 #[cfg(doc)]
 use super::{TokioTransportThread, TokioTransportThreadOptions}; // so we can use pub re-exports in docs
-use crate::{sentry_debug, Envelope};
+use crate::{Envelope, sentry_debug};
 
 #[expect(
     clippy::large_enum_variant,

--- a/sentry/src/transports/ureq.rs
+++ b/sentry/src/transports/ureq.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use sentry_core::client_report::Reason as LossReason;
 use sentry_core::TransportOptions;
+use sentry_core::client_report::Reason as LossReason;
 use ureq::http::Response;
 #[cfg(any(
     feature = "rustls",
@@ -12,11 +12,11 @@ use ureq::tls::{TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
 
 use super::{
+    HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE, RateLimiter,
     thread::{TransportThread, TransportThreadOptions},
-    RateLimiter, HTTP_PAYLOAD_TOO_LARGE, HTTP_PAYLOAD_TOO_LARGE_MESSAGE,
 };
 
-use crate::{sentry_debug, types::Scheme, ClientOptions, Envelope, Transport};
+use crate::{ClientOptions, Envelope, Transport, sentry_debug, types::Scheme};
 
 /// The status code returned for rate-limited envelopes.
 const HTTP_RATE_LIMIT_STATUS: u16 = 429;

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test")]
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use sentry::protocol::{
     Attachment, Context, DynamicSamplingContext, EnvelopeHeaders, EnvelopeItem,
@@ -267,7 +267,7 @@ fn test_panic_scope_pop() {
 fn test_basic_capture_log() {
     use std::time::SystemTime;
 
-    use sentry::{protocol::Log, protocol::LogAttribute, protocol::Map, Hub};
+    use sentry::{Hub, protocol::Log, protocol::LogAttribute, protocol::Map};
 
     let options = sentry::ClientOptions::new().enable_logs(true);
     let envelopes = sentry::test::with_captured_envelopes_options(

--- a/sentry/tests/test_tower.rs
+++ b/sentry/tests/test_tower.rs
@@ -3,9 +3,9 @@
 use std::sync::Arc;
 
 use sentry::{
+    ClientOptions, Hub,
     protocol::{Breadcrumb, Level},
     test::TestTransport,
-    ClientOptions, Hub,
 };
 use sentry_tower::SentryLayer;
 use tower::{ServiceBuilder, ServiceExt};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Bump the workspace Rust edition from 2021 to 2024 (and Cargo resolver from 2 to 3), as suggested in [#970](https://github.com/getsentry/sentry-rust/pull/970#issuecomment-3842046740) / [#971](https://github.com/getsentry/sentry-rust/issues/971).

MSRV is already 1.88, so no toolchain bump is required for edition 2024.

Follow-up fixes from the edition change:
- Apply rustfmt’s edition-2024 import sorting across the workspace
- Collapse nested `if` / `if let` into `if … && let` chains so stable clippy’s `collapsible_if` lint stays clean
- Stop mutating the process environment from tests (no straightforward sound alternative to `set_var` here); keep only env-independent assertions
- Actix docs/examples note to run with `RUST_BACKTRACE=1` for full backtraces

#### Issues
* resolves: #971
* resolves: RUST-137

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-492a4fe0-df4d-4fb8-944a-7d630827ac4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-492a4fe0-df4d-4fb8-944a-7d630827ac4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

