### PR TITLE
ref!(slog): Make RecordMapping non_exhaustive and smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Removed the public `ClientOptions::traces_sample_rate` and `ClientOptions::traces_sampler` fields. Use `ClientOptions::traces_sampling_strategy` to inspect the configured traces sampling strategy, and use the existing `ClientOptions::traces_sample_rate(...)` and `ClientOptions::traces_sampler(...)` builder setters to configure fixed-rate and callback-based sampling ([#1227](https://github.com/getsentry/sentry-rust/pull/1227)).
 - [`EnvelopeItem`](https://docs.rs/sentry-types/0.49.0/sentry_types/protocol/envelope/enum.EnvelopeItem.html) now stores `Event` and `Transaction` payloads in `Box` values. Code that constructs or pattern-matches these variants must account for the additional indirection ([#1255](https://github.com/getsentry/sentry-rust/pull/1255)).
 - The `sentry_log::RecordMapping` enum's `Event` now stores the event in a `Box` ([#1269](https://github.com/getsentry/sentry-rust/pull/1269)).
+- `sentry_slog::RecordMapping` is now `#[non_exhaustive]` and the `Event` variant now stores a boxed `Event<'static>` ([#1270](https://github.com/getsentry/sentry-rust/pull/1270))
 
 ### Fixes
 

--- a/sentry-slog/src/drain.rs
+++ b/sentry-slog/src/drain.rs
@@ -17,14 +17,14 @@ pub enum LevelFilter {
 }
 
 /// The type of Data Sentry should ingest for a [`slog::Record`].
-#[expect(clippy::large_enum_variant)]
+#[non_exhaustive]
 pub enum RecordMapping {
     /// Ignore the [`Record`].
     Ignore,
     /// Adds the [`Breadcrumb`] to the Sentry scope.
     Breadcrumb(Breadcrumb),
     /// Captures the [`Event`] to Sentry.
-    Event(Event<'static>),
+    Event(Box<Event<'static>>),
 }
 
 /// The default slog filter.
@@ -111,9 +111,11 @@ impl<D: Drain> slog::Drain for SentryDrain<D> {
                 LevelFilter::Breadcrumb => {
                     RecordMapping::Breadcrumb(breadcrumb_from_record(record, values))
                 }
-                LevelFilter::Event => RecordMapping::Event(event_from_record(record, values)),
+                LevelFilter::Event => {
+                    RecordMapping::Event(event_from_record(record, values).into())
+                }
                 LevelFilter::Exception => {
-                    RecordMapping::Event(exception_from_record(record, values))
+                    RecordMapping::Event(exception_from_record(record, values).into())
                 }
             },
         };
@@ -122,7 +124,7 @@ impl<D: Drain> slog::Drain for SentryDrain<D> {
             RecordMapping::Ignore => {}
             RecordMapping::Breadcrumb(b) => sentry_core::add_breadcrumb(b),
             RecordMapping::Event(e) => {
-                sentry_core::capture_event(e);
+                sentry_core::capture_event(*e);
             }
         }
 

--- a/sentry-slog/src/lib.rs
+++ b/sentry-slog/src/lib.rs
@@ -61,7 +61,7 @@
 //!     })
 //!     .mapper(|record, kv| match record.level() {
 //!         slog::Level::Critical | slog::Level::Error => {
-//!             RecordMapping::Event(exception_from_record(record, kv))
+//!             RecordMapping::Event(exception_from_record(record, kv).into())
 //!         }
 //!         _ => RecordMapping::Ignore,
 //!     });


### PR DESCRIPTION
Make RecordMapping non_exhaustive to preserve API flexibility, and correct the ignored large_enum_variant lint by boxing Event