### PR TITLE
perf!(tracing): Fix `large_enum_variant` lint on `EventMapping`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [`EnvelopeItem`](https://docs.rs/sentry-types/0.49.0/sentry_types/protocol/envelope/enum.EnvelopeItem.html) now stores `Event` and `Transaction` payloads in `Box` values. Code that constructs or pattern-matches these variants must account for the additional indirection ([#1255](https://github.com/getsentry/sentry-rust/pull/1255)).
 - The `sentry_log::RecordMapping` enum's `Event` now stores the event in a `Box` ([#1269](https://github.com/getsentry/sentry-rust/pull/1269)).
 - `sentry_slog::RecordMapping` is now `#[non_exhaustive]` and the `Event` variant now stores a boxed `Event<'static>` ([#1270](https://github.com/getsentry/sentry-rust/pull/1270))
+- The `sentry_tracing::EventMapping` enum's `Event` variant is now stored in a `Box` ([#1271](https://github.com/getsentry/sentry-rust/pull/1271))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - [`EnvelopeItem`](https://docs.rs/sentry-types/0.49.0/sentry_types/protocol/envelope/enum.EnvelopeItem.html) now stores `Event` and `Transaction` payloads in `Box` values. Code that constructs or pattern-matches these variants must account for the additional indirection ([#1255](https://github.com/getsentry/sentry-rust/pull/1255)).
 - The `sentry_log::RecordMapping` enum's `Event` now stores the event in a `Box` ([#1269](https://github.com/getsentry/sentry-rust/pull/1269)).
 - `sentry_slog::RecordMapping` is now `#[non_exhaustive]` and the `Event` variant now stores a boxed `Event<'static>` ([#1270](https://github.com/getsentry/sentry-rust/pull/1270))
-- The `sentry_tracing::EventMapping` enum's `Event` variant is now stored in a `Box` ([#1271](https://github.com/getsentry/sentry-rust/pull/1271))
+- The `sentry_tracing::EventMapping` enum's `Event` variant is now stored in a `Box` ([#1272](https://github.com/getsentry/sentry-rust/pull/1272))
 
 ### Fixes
 

--- a/sentry-tracing/src/layer/mod.rs
+++ b/sentry-tracing/src/layer/mod.rs
@@ -38,14 +38,13 @@ bitflags! {
 /// The type of data Sentry should ingest for an [`Event`].
 #[derive(Debug)]
 #[non_exhaustive]
-#[expect(clippy::large_enum_variant)]
 pub enum EventMapping {
     /// Ignore the [`Event`]
     Ignore,
     /// Adds the [`Breadcrumb`] to the Sentry scope.
     Breadcrumb(Breadcrumb),
     /// Captures the [`sentry_core::protocol::Event`] to Sentry.
-    Event(sentry_core::protocol::Event<'static>),
+    Event(Box<sentry_core::protocol::Event<'static>>),
     /// Captures the [`sentry_core::protocol::Log`] to Sentry.
     #[cfg(feature = "logs")]
     Log(sentry_core::protocol::Log),
@@ -259,10 +258,9 @@ where
                     )));
                 }
                 if filter.contains(EventFilter::Event) {
-                    items.push(EventMapping::Event(event_from_event(
-                        event,
-                        span_ctx.as_ref(),
-                    )));
+                    items.push(EventMapping::Event(
+                        event_from_event(event, span_ctx.as_ref()).into(),
+                    ));
                 }
                 #[cfg(feature = "logs")]
                 if filter.contains(EventFilter::Log) {
@@ -278,7 +276,7 @@ where
                 EventMapping::Ignore => (),
                 EventMapping::Breadcrumb(breadcrumb) => sentry_core::add_breadcrumb(breadcrumb),
                 EventMapping::Event(event) => {
-                    sentry_core::capture_event(event);
+                    sentry_core::capture_event(*event);
                 }
                 #[cfg(feature = "logs")]
                 EventMapping::Log(log) => sentry_core::Hub::with_active(|hub| hub.capture_log(log)),

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -314,14 +314,14 @@ fn test_combined_event_mapper() {
                 sentry_tracing::EventMapping::Combined(
                     vec![
                         sentry_tracing::EventMapping::Breadcrumb(breadcrumb),
-                        sentry_tracing::EventMapping::Event(sentry_event),
+                        sentry_tracing::EventMapping::Event(sentry_event.into()),
                     ]
                     .into(),
                 )
             }
             tracing::Level::WARN => {
                 let sentry_event = sentry_tracing::event_from_event(event, Some(&ctx));
-                sentry_tracing::EventMapping::Event(sentry_event)
+                sentry_tracing::EventMapping::Event(sentry_event.into())
             }
             _ => sentry_tracing::EventMapping::Ignore,
         });


### PR DESCRIPTION
Box `Event` variant to address the `large_enum_variant` lint that was previously ignored here