### PR TITLE
chore(craft): Publish without development dependencies

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -4,6 +4,7 @@ artifactProvider:
   name: none
 targets:
   - name: crates
+    noDevDeps: true
   - name: github
   - name: registry
     sdks:


### PR DESCRIPTION
Publish the crates workspace with `cargo hack --no-dev-deps` because the
workspace dependency inheritance from PR #1243 gives internal dev-dependencies
version requirements. During a coordinated release, those versions are not yet
available on crates.io when their dependent crate is prepared.

This keeps test-only dependencies out of the publication step while preserving
the workspace dependency configuration used for development.
