### PR TITLE
fix(tracing): Preserve floating-point log attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Preserve floating-point fields in tracing logs as numeric attributes ([#1278](https://github.com/getsentry/sentry-rust/pull/1278)).
+
 ## 0.49.0
 
 ### Breaking Changes

--- a/sentry-tracing/src/converters.rs
+++ b/sentry-tracing/src/converters.rs
@@ -168,6 +168,10 @@ impl Visit for FieldVisitor {
         self.record(field, value);
     }
 
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record(field, value);
+    }
+
     fn record_str(&mut self, field: &Field, value: &str) {
         self.record(field, value);
     }

--- a/sentry-tracing/src/layer/mod.rs
+++ b/sentry-tracing/src/layer/mod.rs
@@ -554,6 +554,10 @@ impl Visit for SpanFieldVisitor<'_> {
         self.record(field, value);
     }
 
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record(field, value);
+    }
+
     fn record_str(&mut self, field: &Field, value: &str) {
         self.record(field, value);
     }

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -269,6 +269,38 @@ fn test_tracing_logs() {
     }
 }
 
+#[cfg(feature = "logs")]
+#[test]
+fn test_tracing_log_floating_point_field() {
+    let sentry_layer = sentry_tracing::layer().event_filter(|_| sentry_tracing::EventFilter::Log);
+
+    let _dispatcher = tracing_subscriber::registry()
+        .with(sentry_layer)
+        .set_default();
+
+    let options = sentry::ClientOptions::new().enable_logs(true);
+    let envelopes = sentry::test::with_captured_envelopes_options(
+        || tracing::error!(floating_point = 1.0_f64),
+        options,
+    );
+
+    assert_eq!(envelopes.len(), 1);
+    let item = envelopes[0].items().next().expect("expected envelope item");
+
+    match item {
+        sentry::protocol::EnvelopeItem::ItemContainer(sentry::protocol::ItemContainer::Logs(
+            logs,
+        )) => {
+            assert_eq!(logs.len(), 1);
+            assert_eq!(
+                logs[0].attributes.get("floating_point").unwrap().clone(),
+                sentry::protocol::LogAttribute::from(1.0_f64)
+            );
+        }
+        _ => panic!("expected logs container"),
+    }
+}
+
 #[test]
 fn test_combined_event_filters() {
     let sentry_layer = sentry_tracing::layer().event_filter(|md| match *md.level() {


### PR DESCRIPTION
Forward floating-point tracing fields through the event and span visitors so Sentry preserves their numeric type instead of stringifying them. Add a focused log regression test for the user-visible attribute type.

Fixes [#1231](https://github.com/getsentry/sentry-rust/issues/1231)
Fixes [RUST-262](https://linear.app/getsentry/issue/RUST-262)
