### PR TITLE
fix(curl): Preserve Sentry rate-limit header values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Preserve floating-point fields in tracing logs as numeric attributes ([#1278](https://github.com/getsentry/sentry-rust/pull/1278)).
+- Fix a bug that prevented the Curl transport from respecting Sentry rate limits ([#1279](https://github.com/getsentry/sentry-rust/pull/1279)).
 
 ## 0.49.0
 

--- a/sentry/src/transports/curl.rs
+++ b/sentry/src/transports/curl.rs
@@ -162,13 +162,11 @@ impl CurlHttpTransport {
                 handle
                     .header_function(move |data| {
                         if let Ok(data) = std::str::from_utf8(data) {
-                            let mut iter = data.split(':');
-                            if let Some(key) = iter.next().map(str::to_lowercase) {
-                                if key == "retry-after" {
-                                    *retry_after_setter = iter.next().map(|x| x.trim().to_string());
-                                } else if key == "x-sentry-rate-limits" {
-                                    *sentry_header_setter =
-                                        iter.next().map(|x| x.trim().to_string());
+                            if let Some((key, value)) = data.split_once(':') {
+                                if key.eq_ignore_ascii_case("retry-after") {
+                                    *retry_after_setter = Some(value.trim().to_string());
+                                } else if key.eq_ignore_ascii_case("x-sentry-rate-limits") {
+                                    *sentry_header_setter = Some(value.trim().to_string());
                                 }
                             }
                         }


### PR DESCRIPTION
Preserve the complete value of X-Sentry-Rate-Limits when parsing curl response headers. Previously, splitting on every colon discarded category and scope fields, so valid headers such as `120:error:project` were not applied by RateLimiter and rate-limited error envelopes could continue to be sent.

This change also refactors to use `eq_ignore_ascii_case` rather than converting the headers to lowercase and comparing directly. `eq_ignore_ascii_case` avoids allocations and is therefore likely more performant.

Fixes [#1111](https://github.com/getsentry/sentry-rust/issues/1111)
Fixes [RUST-209](https://linear.app/getsentry/issue/RUST-209/fix-curl-transport-parsing-of-x-sentry-rate-limits-header)
