### PR TITLE
docs(readme): Only claim "recent" self-hosted compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ best API and adding new features.
 
 ## Requirements
 
-We currently only verify this crate against a recent version of Sentry hosted on [sentry.io](https://sentry.io/) but it
-should work with on-prem Sentry versions 20.6 and later.
+We currently only verify this crate against a recent version of Sentry hosted on [sentry.io](https://sentry.io/), but it
+should also work with recent self-hosted Sentry versions.
 
 The **Minimum Supported Rust Version** is currently at _1.88.0_.
 The Sentry crates tries to support a _6 months_ old Rust version at time of release,


### PR DESCRIPTION
Since the addition of client reports, the statement here has been incorrect, as client reports require at least Sentry version 21.9.0, as older versions will reject envelopes containing client reports. 

Rather than claiming we support a specific self-hosted version range, we should just state that we aim to support "recent" self-hosted versions.