### PR TITLE
chore(dependabot): Add basic Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+# Keep Cargo.lock current so CI runs against the latest compatible dependency
+# versions. This does not affect dependency resolution for library users and can
+# reduce stale-dependency RUSTSEC alerts. Major updates are separate PRs because
+# they may be breaking for users and are treated primarily as upgrade notices.
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Avoid changing Cargo.toml when the existing requirement allows the update.
+    versioning-strategy: increase-if-necessary
+    groups:
+      non-major:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
I think this could be nice to have, the proposed config will update our lockfile (which only affects our CI environment) every week in a single PR, then will open separate PRs for major version bumps in `Cargo.toml` when these are available. We will treat the major version bumps more like notifications that we can update, but likely will often not merge these, at least not right away.