### PR TITLE
feat: Allow overriding the sampling rate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.49.2
+- Added `override_sampling_rate` to `ClientOptions` to allow user defined function to override sampling rate when capturing an event. ([#1128](https://github.com/getsentry/sentry-rust/pull/1128)).
+
 ## 0.49.1
 
 ### Fixes

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -397,8 +397,15 @@ impl Client {
             scope.update_session_from_event(&event);
         }
 
-        let sample_rate = event_sample_rate(&self.options.event_sampling_strategy);
-        if !self.sample_should_send(sample_rate) {
+        let sampling_rate = self
+            .options()
+            .override_sampling_rate
+            .as_ref()
+            .and_then(|f| f(&event))
+            .filter(|sampling_rate| !sampling_rate.is_nan())
+            .unwrap_or_else(|| event_sample_rate(&self.options.event_sampling_strategy));
+
+        if !self.sample_should_send(sampling_rate) {
             self.record_lost_event(ClientReportReason::SampleRate);
             None
         } else {

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -12,6 +12,9 @@ use crate::{Integration, IntoDsn, TransportFactory};
 /// Type alias for before event/breadcrumb handlers.
 pub type BeforeCallback<T> = Arc<dyn Fn(T) -> Option<T> + Send + Sync>;
 
+/// Type alias for override sample rate callback.
+pub type OverrideSamplingRateCallback = Arc<dyn Fn(&Event<'static>) -> Option<f32> + Send + Sync>;
+
 /// The Session Mode of the SDK.
 ///
 /// Depending on the use-case, the SDK can be set to two different session modes:
@@ -220,6 +223,8 @@ pub struct ClientOptions {
     ///
     /// See [`before_breadcrumb`](method@ClientOptions::before_breadcrumb) for details.
     pub before_breadcrumb: Option<BeforeCallback<Breadcrumb>>,
+    /// Callback allowing for setting sampling rate based on user defined function.
+    pub override_sampling_rate: Option<OverrideSamplingRateCallback>,
     /// Callback that is executed for each Log being added.
     ///
     /// See [`before_send_log`](method@ClientOptions::before_send_log) for details.
@@ -580,6 +585,24 @@ impl ClientOptions {
         }
     }
 
+    /// Sets the [callback](field@ClientOptions::override_sampling_rate) that is used to override the
+    /// sampling rate.
+    ///
+    /// The callback receives the event and returns the sampling rate to use for it, in the
+    /// range `[0.0, 1.0]`. Returning `None` or `NaN` falls back to the rate from
+    /// [`event_sampling_strategy`](field@ClientOptions::event_sampling_strategy). Values
+    /// outside the range are treated as `0.0` (never send) or `1.0` (always send).
+    #[inline]
+    pub fn override_sampling_rate(
+        self,
+        override_func: impl Fn(&Event<'static>) -> Option<f32> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            override_sampling_rate: Some(Arc::new(override_func)),
+            ..self
+        }
+    }
+
     /// Sets the [callback](field@ClientOptions::before_send_log) that is executed before sending
     /// each log.
     #[cfg(feature = "logs")]
@@ -773,6 +796,12 @@ impl fmt::Debug for ClientOptions {
         struct BeforeSend;
         let before_send = self.before_send.as_ref().map(|_| BeforeSend);
         #[derive(Debug)]
+        struct OverrideSamplingRate;
+        let override_sampling_rate = self
+            .override_sampling_rate
+            .as_ref()
+            .map(|_| OverrideSamplingRate);
+        #[derive(Debug)]
         struct BeforeBreadcrumb;
         let before_breadcrumb = self.before_breadcrumb.as_ref().map(|_| BeforeBreadcrumb);
         let before_send_log = {
@@ -807,6 +836,7 @@ impl fmt::Debug for ClientOptions {
             .field("integrations", &integrations)
             .field("default_integrations", &self.default_integrations)
             .field("before_send", &before_send)
+            .field("override_sampling_rate", &override_sampling_rate)
             .field("before_breadcrumb", &before_breadcrumb)
             .field("transport", &TransportFactory)
             .field("http_proxy", &self.http_proxy)
@@ -860,6 +890,7 @@ impl Default for ClientOptions {
             before_send_log: None,
             enable_metrics: true,
             before_send_metric: None,
+            override_sampling_rate: None,
         }
     }
 }

--- a/sentry-core/tests/override_sampling_rate.rs
+++ b/sentry-core/tests/override_sampling_rate.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "test")]
+
+use sentry_core::protocol::{EnvelopeItem, Event};
+use sentry_core::test::TestTransport;
+use sentry_core::{Client, ClientOptions};
+
+fn captured_event_count(options: ClientOptions) -> usize {
+    let transport = TestTransport::new();
+    let client = Client::with_options(
+        options
+            .dsn("https://public@sentry.invalid/1")
+            .transport(transport.clone()),
+    );
+
+    client.capture_event(Event::default(), None);
+
+    transport
+        .fetch_and_clear_envelopes()
+        .iter()
+        .flat_map(|envelope| envelope.items())
+        .filter(|item| matches!(item, EnvelopeItem::Event(_)))
+        .count()
+}
+
+#[test]
+fn override_zero_drops_event() {
+    let options = ClientOptions::new().override_sampling_rate(|_| Some(0.0));
+    assert_eq!(captured_event_count(options), 0);
+}
+
+#[test]
+fn override_takes_precedence_over_sample_rate() {
+    let options = ClientOptions::new()
+        .sample_rate(0.0)
+        .override_sampling_rate(|_| Some(1.0));
+    assert_eq!(captured_event_count(options), 1);
+}
+
+#[test]
+fn override_none_falls_back_to_sample_rate() {
+    let options = ClientOptions::new()
+        .sample_rate(0.0)
+        .override_sampling_rate(|_| None);
+    assert_eq!(captured_event_count(options), 0);
+}
+
+#[test]
+fn override_nan_falls_back_to_sample_rate() {
+    // NaN would fail every sampling comparison and silently drop the event,
+    // so it must be ignored in favor of the configured strategy (1.0 here).
+    let options = ClientOptions::new().override_sampling_rate(|_| Some(f32::NAN));
+    assert_eq!(captured_event_count(options), 1);
+}


### PR DESCRIPTION
Allow for a user defined function for setting the sampling rate. Similar to Python SDK https://docs.sentry.io/platforms/python/sampling/#dynamically-sampling-error-events

### Description
Allow defining a function that overrides the sampling rate. For example you have a sampling rate set below 100% but you have certain events that should always be 100%. This allows for a user defined function to provide a sample rate override otherwise falls back to the defined sampling rate.

#### Issues
<!--
* resolves: #1127 
-->
https://github.com/getsentry/sentry-rust/issues/1127

