### PR TITLE
chore: Deprecate the `enable_logs` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecations
 
-- Deprecated `ClientOptions::enable_logs`. The option is now a no-op; logs are always enabled. To stop sending logs, stop calling the logging APIs or disable the log-capturing integrations (`tracing`, `log`, or `slog`) ([#1299](https://github.com/getsentry/sentry-rust/pull/1299)).
+- Deprecated `ClientOptions::enable_logs`. The option no longer disables manually captured logs (via the logging APIs); it now only disables automatic log capture by the log-capturing integrations (`tracing` and `log` with the `logs` feature). To stop an integration from sending logs, configure it via its own options ([#1299](https://github.com/getsentry/sentry-rust/pull/1299)).
 - Deprecated `ClientOptions::enable_metrics`. The option is now a no-op; metrics are always enabled. To stop sending metrics, stop calling the metrics APIs ([#1300](https://github.com/getsentry/sentry-rust/pull/1300)).
 
 ## 0.49.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Deprecations
 
+- Deprecated `ClientOptions::enable_logs`. The option is now a no-op; logs are always enabled. To stop sending logs, stop calling the logging APIs or disable the log-capturing integrations (`tracing`, `log`, or `slog`) ([#1299](https://github.com/getsentry/sentry-rust/pull/1299)).
 - Deprecated `ClientOptions::enable_metrics`. The option is now a no-op; metrics are always enabled. To stop sending metrics, stop calling the metrics APIs ([#1300](https://github.com/getsentry/sentry-rust/pull/1300)).
 
 ## 0.49.1

--- a/sentry-core/src/client/batcher.rs
+++ b/sentry-core/src/client/batcher.rs
@@ -177,7 +177,7 @@ mod tests {
                     logger_info!("test log {}", i);
                 }
             },
-            crate::ClientOptions::new().enable_logs(true),
+            crate::ClientOptions::new(),
         );
 
         assert_eq!(2, envelopes.len());
@@ -206,7 +206,7 @@ mod tests {
                     logger_info!("test log {}", i);
                 }
             },
-            crate::ClientOptions::new().enable_logs(true),
+            crate::ClientOptions::new(),
         );
 
         assert_eq!(1, envelopes.len());

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -114,11 +114,7 @@ impl Clone for Client {
         )));
 
         #[cfg(feature = "logs")]
-        let logs_batcher = RwLock::new(if self.options.enable_logs {
-            Some(Batcher::new(envelope_sender.clone()))
-        } else {
-            None
-        });
+        let logs_batcher = RwLock::new(Some(Batcher::new(envelope_sender.clone())));
 
         #[cfg(feature = "metrics")]
         let metrics_batcher = RwLock::new(Some(Batcher::new(envelope_sender.clone())));
@@ -171,7 +167,21 @@ impl Client {
     ///
     /// If the DSN on the options is set to `None` the client will be entirely
     /// disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if the deprecated no-op field
+    /// [`enable_logs`](field@ClientOptions::enable_logs) is set to `false`.
     pub fn with_options(mut options: ClientOptions) -> Client {
+        #[expect(deprecated, reason = "need to check deprecated fields")]
+        {
+            debug_assert!(
+                options.enable_logs,
+                "invalid initialization options: the Sentry SDK no longer supports disabling logs \
+                 via the `enable_logs` field: {options:?}"
+            );
+        }
+
         // Create the main hub eagerly to avoid problems with the background thread
         // See https://github.com/getsentry/sentry-rust/issues/237
         Hub::with_current(|_| {});
@@ -199,11 +209,7 @@ impl Client {
         )));
 
         #[cfg(feature = "logs")]
-        let logs_batcher = RwLock::new(if options.enable_logs {
-            Some(Batcher::new(envelope_sender.clone()))
-        } else {
-            None
-        });
+        let logs_batcher = RwLock::new(Some(Batcher::new(envelope_sender.clone())));
 
         #[cfg(feature = "metrics")]
         let metrics_batcher = RwLock::new(Some(Batcher::new(envelope_sender.clone())));
@@ -551,10 +557,6 @@ impl Client {
     /// Captures a log and sends it to Sentry.
     #[cfg(feature = "logs")]
     pub fn capture_log(&self, log: Log, scope: &Scope) {
-        if !self.options.enable_logs {
-            sentry_debug!("[Client] called capture_log, but options.enable_logs is set to false");
-            return;
-        }
         if let Some(log) = self.prepare_log(log, scope) {
             if let Some(ref batcher) = *self.logs_batcher.read().unwrap() {
                 batcher.enqueue(log);

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -167,21 +167,7 @@ impl Client {
     ///
     /// If the DSN on the options is set to `None` the client will be entirely
     /// disabled.
-    ///
-    /// # Panics
-    ///
-    /// Panics in debug builds if the deprecated no-op field
-    /// [`enable_logs`](field@ClientOptions::enable_logs) is set to `false`.
     pub fn with_options(mut options: ClientOptions) -> Client {
-        #[expect(deprecated, reason = "need to check deprecated fields")]
-        {
-            debug_assert!(
-                options.enable_logs,
-                "invalid initialization options: the Sentry SDK no longer supports disabling logs \
-                 via the `enable_logs` field: {options:?}"
-            );
-        }
-
         // Create the main hub eagerly to avoid problems with the background thread
         // See https://github.com/getsentry/sentry-rust/issues/237
         Hub::with_current(|_| {});

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -245,9 +245,11 @@ pub struct ClientOptions {
     ///
     /// See [`max_request_body_size`](method@ClientOptions::max_request_body_size) for details.
     pub max_request_body_size: MaxRequestBodySize,
-    /// Whether captured structured logs should be sent to Sentry.
+    /// Deprecated no-op.
     ///
-    /// See [`enable_logs`](method@ClientOptions::enable_logs) for details.
+    /// In debug builds, we panic if the Sentry client is initialized with this option set to
+    /// `false`. The panic occurs at initialization-time.
+    #[deprecated = "this option is a deprecated no-op"]
     pub enable_logs: bool,
     /// Deprecated no-op. Metrics are always enabled, regardless of this option's value.
     #[deprecated = "this option is a deprecated no-op"]
@@ -675,12 +677,21 @@ impl ClientOptions {
         }
     }
 
-    /// Enables or disables sending [structured logs](field@ClientOptions::enable_logs).
+    /// This function is effectively a no-op, as it sets the deprecated, no-op field
+    /// [`enable_logs`](field@ClientOptions::enable_logs).
     ///
-    /// The `logs` feature is required to capture logs. Defaults to `true`.
+    /// To stop sending logs, simply remove any calls to our logging APIs. We only capture
+    /// logs if you explicitly call the relevant APIs or if you enable an integration that
+    /// captures logs. Alternatively, use [`Self::before_send_log`] to configure a callback that
+    /// drops all logs.
+    ///
+    /// In debug builds, we panic if the Sentry client is initialized with this option set to
+    /// `false`. The panic occurs at initialization-time.
+    #[deprecated = "this is a deprecated no-op"]
     #[inline]
     pub fn enable_logs(self, enable_logs: bool) -> Self {
         Self {
+            #[expect(deprecated, reason = "need to set deprecated field")]
             enable_logs,
             ..self
         }
@@ -817,7 +828,11 @@ impl fmt::Debug for ClientOptions {
             .field("accept_invalid_certs", &self.accept_invalid_certs)
             .field("auto_session_tracking", &self.auto_session_tracking)
             .field("session_mode", &self.session_mode)
-            .field("enable_logs", &self.enable_logs)
+            .field(
+                "enable_logs",
+                #[expect(deprecated, reason = "still need to debug-log this field")]
+                &self.enable_logs,
+            )
             .field("before_send_log", &before_send_log)
             .field(
                 "enable_metrics",
@@ -862,6 +877,7 @@ impl Default for ClientOptions {
             session_mode: SessionMode::Application,
             user_agent: Cow::Borrowed(USER_AGENT),
             max_request_body_size: MaxRequestBodySize::Medium,
+            #[expect(deprecated, reason = "still need to set deprecated fields")]
             enable_logs: true,
             before_send_log: None,
             #[expect(deprecated, reason = "still need to set deprecated fields")]

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -245,11 +245,14 @@ pub struct ClientOptions {
     ///
     /// See [`max_request_body_size`](method@ClientOptions::max_request_body_size) for details.
     pub max_request_body_size: MaxRequestBodySize,
-    /// Deprecated no-op.
+    /// Deprecated. Setting this to `false` only disables automatic log capture by the
+    /// log-capturing integrations (`log` and `tracing` with the `logs` feature); it does not
+    /// disable logs captured manually via [`Hub::capture_log`](crate::Hub::capture_log) and the
+    /// `logger_*` macros. Defaults to `true`.
     ///
-    /// In debug builds, we panic if the Sentry client is initialized with this option set to
-    /// `false`. The panic occurs at initialization-time.
-    #[deprecated = "this option is a deprecated no-op"]
+    /// To stop an integration from sending logs, use its own options to configure what it
+    /// captures.
+    #[deprecated = "logs captured manually are always sent; only automatic capture by integrations respects this option"]
     pub enable_logs: bool,
     /// Deprecated no-op. Metrics are always enabled, regardless of this option's value.
     #[deprecated = "this option is a deprecated no-op"]
@@ -677,17 +680,14 @@ impl ClientOptions {
         }
     }
 
-    /// This function is effectively a no-op, as it sets the deprecated, no-op field
-    /// [`enable_logs`](field@ClientOptions::enable_logs).
+    /// Deprecated. Setting [`enable_logs`](field@ClientOptions::enable_logs) to `false` only
+    /// disables automatic log capture by the log-capturing integrations (`log` and `tracing`
+    /// with the `logs` feature); it does not disable logs captured manually via
+    /// [`Hub::capture_log`](crate::Hub::capture_log) and the `logger_*` macros.
     ///
-    /// To stop sending logs, simply remove any calls to our logging APIs. We only capture
-    /// logs if you explicitly call the relevant APIs or if you enable an integration that
-    /// captures logs. Alternatively, use [`Self::before_send_log`] to configure a callback that
-    /// drops all logs.
-    ///
-    /// In debug builds, we panic if the Sentry client is initialized with this option set to
-    /// `false`. The panic occurs at initialization-time.
-    #[deprecated = "this is a deprecated no-op"]
+    /// To stop an integration from sending logs, use its own options to configure what it
+    /// captures. Alternatively, use [`Self::before_send_log`] to filter logs.
+    #[deprecated = "logs captured manually are always sent; only automatic capture by integrations respects this option"]
     #[inline]
     pub fn enable_logs(self, enable_logs: bool) -> Self {
         Self {

--- a/sentry-log/src/logger.rs
+++ b/sentry-log/src/logger.rs
@@ -184,9 +184,17 @@ impl<L: log::Log> log::Log for SentryLogger<L> {
                     sentry_core::capture_event(*event);
                 }
                 #[cfg(feature = "logs")]
-                RecordMapping::Log(log) => {
-                    sentry_core::Hub::with_active(|hub| hub.capture_log(log))
-                }
+                RecordMapping::Log(log) => sentry_core::Hub::with_active(|hub| {
+                    let enabled = hub.client().is_none_or(|client| {
+                        let options = client.options();
+
+                        #[expect(deprecated, reason = "checking a deprecated field")]
+                        options.enable_logs
+                    });
+                    if enabled {
+                        hub.capture_log(log);
+                    }
+                }),
             }
         }
 

--- a/sentry-tracing/README.md
+++ b/sentry-tracing/README.md
@@ -94,7 +94,7 @@ for i in 0..10 {
 
 Tracing events can be captured as traditional structured logs in Sentry.
 This is gated by the `logs` feature flag and requires setting up a custom Event filter/mapper
-to capture logs. You also need to pass `enable_logs: true` in your `sentry::init` call.
+to capture logs.
 
 ```rust
 // assuming `tracing::Level::INFO => EventFilter::Log` in your `event_filter`

--- a/sentry-tracing/src/layer/mod.rs
+++ b/sentry-tracing/src/layer/mod.rs
@@ -279,7 +279,17 @@ where
                     sentry_core::capture_event(*event);
                 }
                 #[cfg(feature = "logs")]
-                EventMapping::Log(log) => sentry_core::Hub::with_active(|hub| hub.capture_log(log)),
+                EventMapping::Log(log) => sentry_core::Hub::with_active(|hub| {
+                    let enabled = hub.client().is_none_or(|client| {
+                        let options = client.options();
+
+                        #[expect(deprecated, reason = "checking a deprecated field")]
+                        options.enable_logs
+                    });
+                    if enabled {
+                        hub.capture_log(log);
+                    }
+                }),
                 EventMapping::Combined(_) => {
                     sentry_core::sentry_debug!(
                         "[SentryLayer] found nested CombinedEventMapping, ignoring"

--- a/sentry-tracing/src/lib.rs
+++ b/sentry-tracing/src/lib.rs
@@ -86,7 +86,7 @@
 //!
 //! Tracing events can be captured as traditional structured logs in Sentry.
 //! This is gated by the `logs` feature flag and requires setting up a custom Event filter/mapper
-//! to capture logs. You also need to pass `enable_logs: true` in your `sentry::init` call.
+//! to capture logs.
 //!
 //! ```
 //! // assuming `tracing::Level::INFO => EventFilter::Log` in your `event_filter`

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -342,6 +342,35 @@ fn test_basic_capture_log_macro_message() {
 
 #[cfg(feature = "logs")]
 #[test]
+fn test_basic_capture_log_macro_message_disabled() {
+    use sentry_core::logger_info;
+
+    #[expect(deprecated, reason = "testing the deprecated option")]
+    let options = sentry::ClientOptions::new().enable_logs(false);
+    let envelopes = sentry::test::with_captured_envelopes_options(
+        || {
+            logger_info!("Hello, world!");
+        },
+        options,
+    );
+    // Manually captured logs are always sent, regardless of `enable_logs`.
+    assert_eq!(envelopes.len(), 1);
+    let envelope = envelopes.first().expect("expected envelope");
+    let item = envelope.items().next().expect("expected envelope item");
+    match item {
+        EnvelopeItem::ItemContainer(container) => match container {
+            sentry::protocol::ItemContainer::Logs(logs) => {
+                let log = logs.iter().next().expect("expected log");
+                assert_eq!("Hello, world!", log.body);
+            }
+            _ => panic!("expected logs"),
+        },
+        _ => panic!("expected item container"),
+    }
+}
+
+#[cfg(feature = "logs")]
+#[test]
 fn test_basic_capture_log_macro_message_formatted() {
     use sentry::protocol::LogAttribute;
     use sentry_core::logger_warn;

--- a/sentry/tests/test_basic.rs
+++ b/sentry/tests/test_basic.rs
@@ -269,7 +269,7 @@ fn test_basic_capture_log() {
 
     use sentry::{protocol::Log, protocol::LogAttribute, protocol::Map, Hub};
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             let mut attributes: Map<String, LogAttribute> = Map::new();
@@ -313,7 +313,7 @@ fn test_basic_capture_log() {
 fn test_basic_capture_log_macro_message() {
     use sentry_core::logger_info;
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             logger_info!("Hello, world!");
@@ -346,7 +346,7 @@ fn test_basic_capture_log_macro_message_formatted() {
     use sentry::protocol::LogAttribute;
     use sentry_core::logger_warn;
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             let failed_requests = ["request1", "request2", "request3"];
@@ -410,7 +410,7 @@ fn test_basic_capture_log_macro_message_with_attributes() {
     use sentry::protocol::LogAttribute;
     use sentry_core::logger_error;
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             logger_error!(
@@ -466,7 +466,7 @@ fn test_basic_capture_log_macro_message_formatted_with_attributes() {
     use sentry::protocol::LogAttribute;
     use sentry_core::logger_debug;
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
             logger_debug!(

--- a/sentry/tests/test_log_logs.rs
+++ b/sentry/tests/test_log_logs.rs
@@ -11,7 +11,7 @@ fn test_log_logs() {
         .map(|()| log::set_max_level(log::LevelFilter::Trace))
         .unwrap();
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
 
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {

--- a/sentry/tests/test_tracing.rs
+++ b/sentry/tests/test_tracing.rs
@@ -197,7 +197,7 @@ fn test_tracing_logs() {
         .with(sentry_layer)
         .set_default();
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
 
     let envelopes = sentry::test::with_captured_envelopes_options(
         || {
@@ -278,7 +278,7 @@ fn test_tracing_log_floating_point_field() {
         .with(sentry_layer)
         .set_default();
 
-    let options = sentry::ClientOptions::new().enable_logs(true);
+    let options = sentry::ClientOptions::new();
     let envelopes = sentry::test::with_captured_envelopes_options(
         || tracing::error!(floating_point = 1.0_f64),
         options,


### PR DESCRIPTION
Disabling log sending via `ClientOptions::enable_logs` is somewhat of a footgun, as this flag can prevent all Sentry logs from being sent. This change deprecates the option and restricts its effect: setting `enable_logs` to `false` now only disables automatic log capture by the log-capturing integrations (currently `tracing` and `log`, both with the `logs` feature). Logs captured manually via the logging APIs we provide (`Hub::capture_log` and the `logger_*` macros) are always sent, regardless of the option's value.

We also deprecate the option, as we will remove it in the next breaking release. The migration path is to configure the relevant integration via its own options to not send logs; each integration's documentation describes how to do this.

Resolves [#1297](https://github.com/getsentry/sentry-rust/issues/1297)
Resolves [RUST-274](https://linear.app/getsentry/issue/RUST-274/deprecate-and-no-op-ify-enable-logs)