### PR TITLE
chore: Deprecate the `enable_metrics` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Deprecations
+
+- Deprecated `ClientOptions::enable_metrics`. The option is now a no-op; metrics are always enabled. To stop sending metrics, stop calling the metrics APIs ([#1300](https://github.com/getsentry/sentry-rust/pull/1300)).
+
 ## 0.49.1
 
 ### Fixes

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -172,15 +172,6 @@ impl Client {
     /// If the DSN on the options is set to `None` the client will be entirely
     /// disabled.
     pub fn with_options(mut options: ClientOptions) -> Client {
-        #[expect(deprecated, reason = "need to check deprecated fields")]
-        {
-            debug_assert!(
-                options.enable_metrics,
-                "invalid initialization options: the Sentry SDK no longer supports disabling \
-                 metrics via the `enable_metrics` field: {options:?}"
-            )
-        }
-
         // Create the main hub eagerly to avoid problems with the background thread
         // See https://github.com/getsentry/sentry-rust/issues/237
         Hub::with_current(|_| {});

--- a/sentry-core/src/client/mod.rs
+++ b/sentry-core/src/client/mod.rs
@@ -121,11 +121,7 @@ impl Clone for Client {
         });
 
         #[cfg(feature = "metrics")]
-        let metrics_batcher = RwLock::new(
-            self.options
-                .enable_metrics
-                .then(|| Batcher::new(envelope_sender.clone())),
-        );
+        let metrics_batcher = RwLock::new(Some(Batcher::new(envelope_sender.clone())));
 
         Client {
             options: self.options.clone(),
@@ -176,6 +172,15 @@ impl Client {
     /// If the DSN on the options is set to `None` the client will be entirely
     /// disabled.
     pub fn with_options(mut options: ClientOptions) -> Client {
+        #[expect(deprecated, reason = "need to check deprecated fields")]
+        {
+            debug_assert!(
+                options.enable_metrics,
+                "invalid initialization options: the Sentry SDK no longer supports disabling \
+                 metrics via the `enable_metrics` field: {options:?}"
+            )
+        }
+
         // Create the main hub eagerly to avoid problems with the background thread
         // See https://github.com/getsentry/sentry-rust/issues/237
         Hub::with_current(|_| {});
@@ -210,11 +215,7 @@ impl Client {
         });
 
         #[cfg(feature = "metrics")]
-        let metrics_batcher = RwLock::new(
-            options
-                .enable_metrics
-                .then(|| Batcher::new(envelope_sender.clone())),
-        );
+        let metrics_batcher = RwLock::new(Some(Batcher::new(envelope_sender.clone())));
 
         let client = Client {
             options,
@@ -599,11 +600,6 @@ impl Client {
     /// Captures a metric and sends it to Sentry.
     #[cfg(feature = "metrics")]
     pub fn capture_metric<M: IntoProtocolMetric>(&self, metric: M, scope: &Scope) {
-        if !self.options.enable_metrics {
-            // Skip preparing the metric if we don't send it anyways.
-            return;
-        }
-
         if let Some(metric) = self.prepare_metric(metric, scope) {
             if let Some(batcher) = self
                 .metrics_batcher

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -249,10 +249,7 @@ pub struct ClientOptions {
     ///
     /// See [`enable_logs`](method@ClientOptions::enable_logs) for details.
     pub enable_logs: bool,
-    /// Deprecated no-op.
-    ///
-    /// In debug builds, we panic if the Sentry client is initialized with this option set to
-    /// `false`. The panic occurs at initialization-time.
+    /// Deprecated no-op. Metrics are always enabled, regardless of this option's value.
     #[deprecated = "this option is a deprecated no-op"]
     pub enable_metrics: bool,
     /// Callback that is executed for each [`Metric`] before sending.
@@ -689,14 +686,10 @@ impl ClientOptions {
         }
     }
 
-    /// This function is effectively a no-op, as it sets the deprecated, no-op field
-    /// [`enable_metrics`](field@ClientOptions::enable_metrics).
+    /// This function is a no-op, as it sets the deprecated field
+    /// [`enable_metrics`](field@ClientOptions::enable_metrics). Metrics are always enabled.
     ///
-    /// To stop sending metrics, simply remove any calls to our metrics APIs. We only capture
-    /// logs if you explicitly call the relevant APIs.
-    ///
-    /// In debug builds, we panic if the Sentry client is initialized with this option set to
-    /// `false`. The panic occurs at initialization-time.
+    /// To stop sending metrics, simply remove any calls to our metrics APIs.
     #[deprecated = "this function sets a no-op option"]
     #[inline]
     pub fn enable_metrics(self, enable_metrics: bool) -> Self {

--- a/sentry-core/src/clientoptions.rs
+++ b/sentry-core/src/clientoptions.rs
@@ -249,9 +249,11 @@ pub struct ClientOptions {
     ///
     /// See [`enable_logs`](method@ClientOptions::enable_logs) for details.
     pub enable_logs: bool,
-    /// Whether metric capture APIs should capture metrics.
+    /// Deprecated no-op.
     ///
-    /// See [`enable_metrics`](method@ClientOptions::enable_metrics) for details.
+    /// In debug builds, we panic if the Sentry client is initialized with this option set to
+    /// `false`. The panic occurs at initialization-time.
+    #[deprecated = "this option is a deprecated no-op"]
     pub enable_metrics: bool,
     /// Callback that is executed for each [`Metric`] before sending.
     ///
@@ -687,12 +689,19 @@ impl ClientOptions {
         }
     }
 
-    /// Enables or disables [metric capture APIs](field@ClientOptions::enable_metrics).
+    /// This function is effectively a no-op, as it sets the deprecated, no-op field
+    /// [`enable_metrics`](field@ClientOptions::enable_metrics).
     ///
-    /// The `metrics` feature is required to capture metrics. Defaults to `true`.
+    /// To stop sending metrics, simply remove any calls to our metrics APIs. We only capture
+    /// logs if you explicitly call the relevant APIs.
+    ///
+    /// In debug builds, we panic if the Sentry client is initialized with this option set to
+    /// `false`. The panic occurs at initialization-time.
+    #[deprecated = "this function sets a no-op option"]
     #[inline]
     pub fn enable_metrics(self, enable_metrics: bool) -> Self {
         Self {
+            #[expect(deprecated, reason = "need to set deprecated field")]
             enable_metrics,
             ..self
         }
@@ -817,7 +826,11 @@ impl fmt::Debug for ClientOptions {
             .field("session_mode", &self.session_mode)
             .field("enable_logs", &self.enable_logs)
             .field("before_send_log", &before_send_log)
-            .field("enable_metrics", &self.enable_metrics)
+            .field(
+                "enable_metrics",
+                #[expect(deprecated, reason = "still need to debug-log this field")]
+                &self.enable_metrics,
+            )
             .field("before_send_metric", &before_send_metric)
             .field("org_id", &self.org_id)
             .field("strict_trace_continuation", &self.strict_trace_continuation)
@@ -858,6 +871,7 @@ impl Default for ClientOptions {
             max_request_body_size: MaxRequestBodySize::Medium,
             enable_logs: true,
             before_send_log: None,
+            #[expect(deprecated, reason = "still need to set deprecated fields")]
             enable_metrics: true,
             before_send_metric: None,
         }

--- a/sentry-core/tests/metrics.rs
+++ b/sentry-core/tests/metrics.rs
@@ -10,68 +10,6 @@ use sentry_core::{metrics, test};
 use sentry_core::{ClientOptions, TransactionContext};
 use sentry_types::protocol::v7::{Envelope, LogAttribute, Metric, User};
 
-/// Test that metrics are sent when metrics are enabled.
-#[test]
-fn sent_when_enabled() {
-    let options = ClientOptions::new().enable_metrics(true);
-
-    let mut envelopes =
-        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
-
-    assert_eq!(envelopes.len(), 1, "expected exactly one envelope");
-
-    let envelope = envelopes.pop().unwrap();
-
-    let mut items = envelope.into_items();
-    let Some(item) = items.next() else {
-        panic!("Expected at least one item");
-    };
-
-    assert!(items.next().is_none(), "Expected only one item");
-
-    let EnvelopeItem::ItemContainer(ItemContainer::Metrics(mut metrics)) = item else {
-        panic!("Envelope item has unexpected structure");
-    };
-
-    assert_eq!(metrics.len(), 1, "Expected exactly one metric");
-
-    let metric = metrics.pop().unwrap();
-    assert!(matches!(metric, Metric {
-        r#type: MetricType::Counter,
-        name,
-        value: 1.0,
-        ..
-    } if name == "test"));
-}
-
-/// Test that metrics are sent by default.
-#[test]
-fn metrics_enabled_by_default() {
-    let options = ClientOptions::default();
-
-    let envelopes =
-        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
-    assert_eq!(
-        envelopes.len(),
-        1,
-        "expected exactly one envelope when metrics are enabled by default"
-    )
-}
-
-/// Test that metrics are disabled (not sent) when disabled in the
-/// [`ClientOptions`].
-#[test]
-fn metrics_disabled_when_configured() {
-    let options = ClientOptions::new().enable_metrics(false);
-
-    let envelopes =
-        test::with_captured_envelopes_options(|| metrics::counter("test", 1).capture(), options);
-    assert!(
-        envelopes.is_empty(),
-        "no envelopes should be captured when metrics disabled"
-    )
-}
-
 /// Test that no metrics are captured by a no-op call with
 /// metrics enabled
 #[test]


### PR DESCRIPTION
Providing the ability to disable sending metrics is somewhat of a footgun, as this flag can prevent all Sentry metrics from being sent, so this change turns that option into a no-op, ensuring metrics are always enabled.

Metrics are only sent when users explicitly record them with the metrics APIs we provide. Users who do not want metrics can stop using those APIs.

Resolves [#1298](https://github.com/getsentry/sentry-rust/issues/1298)
Resolves [RUST-275](https://linear.app/getsentry/issue/RUST-275)