### PR TITLE
feat(slog): Support capturing records as Sentry logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add support for capturing `slog` records as Sentry structured logs behind the `logs` feature ([#1307](https://github.com/getsentry/sentry-rust/pull/1307)).
+
 ### Deprecations
 
 - Deprecated `ClientOptions::enable_metrics`. The option is now a no-op; metrics are always enabled. To stop sending metrics, stop calling the metrics APIs ([#1300](https://github.com/getsentry/sentry-rust/pull/1300)).

--- a/sentry-slog/Cargo.toml
+++ b/sentry-slog/Cargo.toml
@@ -15,6 +15,10 @@ rust-version = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+# Enables capturing slog records as Sentry structured logs.
+logs = ["sentry-core/logs"]
+
 [dependencies]
 sentry-core = { workspace = true }
 slog = { workspace = true, features = ["nested-values"] }

--- a/sentry-slog/src/converters.rs
+++ b/sentry-slog/src/converters.rs
@@ -1,6 +1,12 @@
 use sentry_core::protocol::{Breadcrumb, Event, Level, Map, Value};
+#[cfg(feature = "logs")]
+use sentry_core::protocol::{Log, LogAttribute, LogLevel};
 use slog::{Key, OwnedKVList, Record, Serializer, KV};
+#[cfg(feature = "logs")]
+use std::collections::BTreeMap;
 use std::fmt;
+#[cfg(feature = "logs")]
+use std::time::SystemTime;
 
 /// Converts a [`slog::Level`] to a Sentry [`Level`]
 pub fn convert_log_level(level: slog::Level) -> Level {
@@ -9,6 +15,19 @@ pub fn convert_log_level(level: slog::Level) -> Level {
         slog::Level::Info => Level::Info,
         slog::Level::Warning => Level::Warning,
         slog::Level::Error | slog::Level::Critical => Level::Error,
+    }
+}
+
+/// Converts a [`slog::Level`] to a Sentry [`LogLevel`], used for [`Log`].
+#[cfg(feature = "logs")]
+pub fn convert_to_sentry_log_level(level: slog::Level) -> LogLevel {
+    match level {
+        slog::Level::Trace => LogLevel::Trace,
+        slog::Level::Debug => LogLevel::Debug,
+        slog::Level::Info => LogLevel::Info,
+        slog::Level::Warning => LogLevel::Warn,
+        slog::Level::Error => LogLevel::Error,
+        slog::Level::Critical => LogLevel::Fatal,
     }
 }
 
@@ -101,6 +120,41 @@ pub fn exception_from_record(record: &Record, values: &OwnedKVList) -> Event<'st
     event_from_record(record, values)
 }
 
+/// Creates a [`Log`] from the [`Record`].
+///
+/// The record's key-value pairs are attached as log attributes, alongside the
+/// source code location the record originated from.
+#[cfg(feature = "logs")]
+pub fn log_from_record(record: &Record, values: &OwnedKVList) -> Log {
+    let mut kvs = Map::new();
+    add_kv_to_map(&mut kvs, record, values);
+
+    let mut attributes: BTreeMap<String, LogAttribute> = kvs
+        .into_iter()
+        .map(|(key, val)| (key, val.into()))
+        .collect();
+
+    attributes.insert("code.file.path".into(), record.file().into());
+    attributes.insert("code.line.number".into(), record.line().into());
+    attributes.insert("code.module.name".into(), record.module().into());
+
+    let tag = record.tag();
+    if !tag.is_empty() {
+        attributes.insert("logger.name".into(), tag.into());
+    }
+
+    attributes.insert("sentry.origin".into(), "auto.logger.slog".into());
+
+    Log {
+        level: convert_to_sentry_log_level(record.level()),
+        body: record.msg().to_string(),
+        trace_id: None,
+        timestamp: SystemTime::now(),
+        severity_number: None,
+        attributes,
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -169,5 +223,32 @@ mod test {
                 .collect()
             ))
         )
+    }
+
+    #[cfg(feature = "logs")]
+    #[test]
+    fn test_log_from_record() {
+        let kv = o!("user_id" => 42, "request_id" => "abc123");
+        let args = format_args!("Hello, world!");
+        let record = record!(Level::Info, "some_tag", &args, b!());
+
+        let log = log_from_record(&record, &kv.into());
+
+        assert_eq!(log.level, LogLevel::Info);
+        assert_eq!(log.body, "Hello, world!");
+        assert_eq!(log.attributes.get("user_id").unwrap().0, Value::from(42));
+        assert_eq!(
+            log.attributes.get("request_id").unwrap().0,
+            Value::from("abc123")
+        );
+        assert_eq!(
+            log.attributes.get("logger.name").unwrap().0,
+            Value::from("some_tag")
+        );
+        assert_eq!(
+            log.attributes.get("sentry.origin").unwrap().0,
+            Value::from("auto.logger.slog")
+        );
+        assert!(log.attributes.contains_key("code.module.name"));
     }
 }

--- a/sentry-slog/src/drain.rs
+++ b/sentry-slog/src/drain.rs
@@ -1,6 +1,8 @@
 use sentry_core::protocol::{Breadcrumb, Event};
 use slog::{Drain, OwnedKVList, Record};
 
+#[cfg(feature = "logs")]
+use crate::log_from_record;
 use crate::{breadcrumb_from_record, event_from_record, exception_from_record};
 
 /// The action that Sentry should perform for a [`slog::Level`].
@@ -14,6 +16,9 @@ pub enum LevelFilter {
     Event,
     /// Create an exception [`Event`] from this [`Record`].
     Exception,
+    /// Create a [`sentry_core::protocol::Log`] from this [`Record`].
+    #[cfg(feature = "logs")]
+    Log,
 }
 
 /// The type of Data Sentry should ingest for a [`slog::Record`].
@@ -25,6 +30,9 @@ pub enum RecordMapping {
     Breadcrumb(Breadcrumb),
     /// Captures the [`Event`] to Sentry.
     Event(Box<Event<'static>>),
+    /// Captures the [`sentry_core::protocol::Log`] to Sentry.
+    #[cfg(feature = "logs")]
+    Log(sentry_core::protocol::Log),
 }
 
 /// The default slog filter.
@@ -117,6 +125,8 @@ impl<D: Drain> slog::Drain for SentryDrain<D> {
                 LevelFilter::Exception => {
                     RecordMapping::Event(exception_from_record(record, values).into())
                 }
+                #[cfg(feature = "logs")]
+                LevelFilter::Log => RecordMapping::Log(log_from_record(record, values)),
             },
         };
 
@@ -125,6 +135,10 @@ impl<D: Drain> slog::Drain for SentryDrain<D> {
             RecordMapping::Breadcrumb(b) => sentry_core::add_breadcrumb(b),
             RecordMapping::Event(e) => {
                 sentry_core::capture_event(*e);
+            }
+            #[cfg(feature = "logs")]
+            RecordMapping::Log(log) => {
+                sentry_core::Hub::with_active(|hub| hub.capture_log(log));
             }
         }
 

--- a/sentry-slog/src/lib.rs
+++ b/sentry-slog/src/lib.rs
@@ -7,6 +7,13 @@
 //! The integration also supports [`slog::KV`] pairs. They will be added to the
 //! breadcrumb `data` or the event `extra` properties respectively.
 //!
+//! If the `logs` feature is enabled and the `sentry` crate is used with its own
+//! `logs` feature, records can also be captured as Sentry
+//! [structured logs](https://docs.sentry.io/product/explore/logs/) by mapping
+//! them to `LevelFilter::Log` in a custom `filter`, or by returning a
+//! `RecordMapping::Log` from a custom `mapper` (see `log_from_record`). The
+//! `KV` pairs are attached as log attributes.
+//!
 //! # Examples
 //!
 //! ```

--- a/sentry/Cargo.toml
+++ b/sentry/Cargo.toml
@@ -50,7 +50,7 @@ opentelemetry = ["sentry-opentelemetry"]
 # other features
 test = ["sentry-core/test"]
 release-health = ["sentry-core/release-health", "sentry-actix?/release-health"]
-logs = ["sentry-core/logs", "sentry-tracing?/logs", "sentry-log?/logs"]
+logs = ["sentry-core/logs", "sentry-tracing?/logs", "sentry-log?/logs", "sentry-slog?/logs"]
 metrics = ["sentry-core/metrics"]
 # transports
 transport = ["reqwest", "native-tls"]

--- a/sentry/tests/test_slog_logs.rs
+++ b/sentry/tests/test_slog_logs.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "test")]
+
+// Test `slog` integration <> Sentry structured logging.
+#[cfg(feature = "logs")]
+#[test]
+fn test_slog_logs() {
+    let drain =
+        sentry_slog::SentryDrain::new(slog::Discard).filter(|_| sentry_slog::LevelFilter::Log);
+    let root = slog::Logger::root(drain, slog::o!("global_kv" => 1234));
+
+    let options = sentry::ClientOptions::new().enable_logs(true);
+
+    let envelopes = sentry::test::with_captured_envelopes_options(
+        || {
+            slog::info!(root, "This is a log"; "user_id" => 42, "request_id" => "abc123");
+        },
+        options,
+    );
+
+    assert_eq!(envelopes.len(), 1);
+    let envelope = envelopes.first().expect("expected envelope");
+    let item = envelope.items().next().expect("expected envelope item");
+
+    match item {
+        sentry::protocol::EnvelopeItem::ItemContainer(container) => match container {
+            sentry::protocol::ItemContainer::Logs(logs) => {
+                assert_eq!(logs.len(), 1);
+
+                let info_log = logs
+                    .iter()
+                    .find(|log| log.level == sentry::protocol::LogLevel::Info)
+                    .expect("expected info log");
+                assert_eq!(info_log.body, "This is a log");
+                assert_eq!(
+                    info_log.attributes.get("user_id").unwrap().clone(),
+                    42.into()
+                );
+                assert_eq!(
+                    info_log.attributes.get("request_id").unwrap().clone(),
+                    "abc123".into()
+                );
+                assert_eq!(
+                    info_log.attributes.get("global_kv").unwrap().clone(),
+                    1234.into()
+                );
+                assert_eq!(
+                    info_log.attributes.get("sentry.origin").unwrap().clone(),
+                    "auto.logger.slog".into()
+                );
+                assert!(info_log.attributes.contains_key("code.module.name"));
+            }
+            _ => panic!("expected logs"),
+        },
+        _ => panic!("expected item container"),
+    }
+}


### PR DESCRIPTION
### Description

`sentry-slog` supported breadcrumbs and events but not structured logs, unlike `sentry-log` and `sentry-tracing`. This adds a `logs` feature that mirrors those crates.

With the feature enabled there's a new `LevelFilter::Log` (and matching `RecordMapping::Log`), so a `filter` or `mapper` can turn slog records into Sentry logs via `log_from_record`. The record's KV pairs are attached as log attributes along with the source location. The default filter is left unchanged, so this is opt-in and existing behavior is preserved.

#### Issues

* resolves: #1306

#### Reminders

- Added a CHANGELOG.md entry.
- Added a converter unit test plus an end-to-end test under `sentry/tests`.
