### PR TITLE
meta(changelog): Link docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### Deprecations
 
-- Deprecated `ClientOptions::enable_logs`. The option no longer disables manually captured logs (via the logging APIs); it now only disables automatic log capture by the log-capturing integrations (`tracing` and `log` with the `logs` feature). To stop an integration from sending logs, configure it via its own options ([#1299](https://github.com/getsentry/sentry-rust/pull/1299)).
-- Deprecated `ClientOptions::enable_metrics`. The option is now a no-op; metrics are always enabled. To stop sending metrics, stop calling the metrics APIs ([#1300](https://github.com/getsentry/sentry-rust/pull/1300)).
+- Deprecated [`ClientOptions::enable_logs`](https://docs.rs/sentry-core/0.49.2/sentry_core/struct.ClientOptions.html#method.enable_logs). The option no longer disables manually captured logs (via the logging APIs); it now only disables automatic log capture by the log-capturing integrations (`tracing` and `log` with the `logs` feature). To stop an integration from sending logs, configure it via its own options ([#1299](https://github.com/getsentry/sentry-rust/pull/1299)).
+- Deprecated [`ClientOptions::enable_metrics`](https://docs.rs/sentry-core/0.49.2/sentry_core/struct.ClientOptions.html#method.enable_metrics). The option is now a no-op; metrics are always enabled. To stop sending metrics, stop calling the metrics APIs ([#1300](https://github.com/getsentry/sentry-rust/pull/1300)).
 
 ## 0.49.1
 


### PR DESCRIPTION
Add docs.rs links for the deprecated options. These pin 0.49.2, the release which will include these options.